### PR TITLE
Add sunstone.errors module re-exporting pandas.errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 - Added: package metadata support to datasets.yaml schema
+- Added: `sunstone.errors` module re-exporting all of `pandas.errors`
 
 ## [1.0.1] - 2026-02-04
 - Fixed: to_csv passing Sunstone-specific kwargs to pandas

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -50,6 +50,9 @@ from .lineage import (
 # Import pandas module for pd-like interface
 from . import pandas
 
+# Import errors module (re-exports pandas.errors)
+from . import errors
+
 # Import validation utilities
 from .validation import (
     ImportCheckResult,
@@ -66,6 +69,8 @@ __all__ = [
     "DatasetsManager",
     # Pandas-like interface
     "pandas",
+    # Errors (re-exported from pandas.errors)
+    "errors",
     # Validation utilities
     "ImportCheckResult",
     "check_notebook_imports",

--- a/src/sunstone/errors.py
+++ b/src/sunstone/errors.py
@@ -1,0 +1,14 @@
+"""
+Re-export pandas.errors for use as sunstone.errors.
+
+This module allows users who do ``from sunstone import pandas as pd``
+to also access ``from sunstone import errors`` (or ``from sunstone.errors
+import ParserError``, etc.) without importing pandas directly.
+
+All public names from ``pandas.errors`` are re-exported here.
+"""
+
+from pandas.errors import *  # noqa: F401,F403
+from pandas.errors import __all__ as _pd_errors_all
+
+__all__ = list(_pd_errors_all)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,42 @@
+"""Tests for the sunstone.errors module."""
+
+import pandas.errors as pd_errors
+
+import sunstone.errors as ss_errors
+
+
+class TestErrorsReExport:
+    """Verify sunstone.errors re-exports everything from pandas.errors."""
+
+    def test_all_pandas_errors_names_available(self):
+        """Every name in pandas.errors.__all__ should be in sunstone.errors."""
+        for name in pd_errors.__all__:
+            assert hasattr(ss_errors, name), (
+                f"sunstone.errors is missing pandas.errors.{name}"
+            )
+
+    def test_objects_are_identical(self):
+        """Re-exported objects should be the exact same objects, not copies."""
+        for name in pd_errors.__all__:
+            assert getattr(ss_errors, name) is getattr(pd_errors, name), (
+                f"sunstone.errors.{name} is not identical to pandas.errors.{name}"
+            )
+
+    def test_dunder_all_matches_pandas(self):
+        """sunstone.errors.__all__ should contain all pandas.errors.__all__ entries."""
+        assert set(pd_errors.__all__) == set(ss_errors.__all__)
+
+    def test_import_specific_error(self):
+        """Commonly used errors should be directly importable."""
+        from sunstone.errors import EmptyDataError, MergeError, ParserError
+
+        assert ParserError is pd_errors.ParserError
+        assert EmptyDataError is pd_errors.EmptyDataError
+        assert MergeError is pd_errors.MergeError
+
+    def test_accessible_via_sunstone_package(self):
+        """sunstone.errors should be importable via the top-level package."""
+        import sunstone
+
+        assert hasattr(sunstone, "errors")
+        assert sunstone.errors.ParserError is pd_errors.ParserError


### PR DESCRIPTION
This allows users who use `from sunstone import pandas as pd` to also
access pandas error classes via `from sunstone.errors import ParserError`
(or `from sunstone import errors`) without importing pandas directly.

The module re-exports all public names from pandas.errors.

https://claude.ai/code/session_012zPwLRxtJByWPhpw5ozF6e