### PR TITLE
Support Parquet files in package push

### DIFF
--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -658,7 +658,7 @@ def _build_schema_from_yaml(ds: DatasetMetadata) -> Optional[dict[str, Any]]:
 
 def _build_non_frictionless_resource_dict(
     ds: DatasetMetadata,
-    manager: DatasetsManager,
+    _manager: DatasetsManager,
     publish_config: Optional[PublishConfig],
     data_path: Path,
     mediatype: str,

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -733,7 +733,7 @@ def build_resource_dict(
     # --- Non-frictionless path (e.g. Parquet) ---
     if suffix in _NON_FRICTIONLESS_SUFFIXES:
         try:
-            mediatype = _PARQUET_MEDIATYPE if suffix in {".parquet", ".parq"} else "application/octet-stream"
+            mediatype = _PARQUET_MEDIATYPE
             return _build_non_frictionless_resource_dict(ds, manager, publish_config, data_path, mediatype)
         except Exception as e:
             click.echo(f"Warning: Failed to describe '{ds.slug}': {e}", err=True)

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -627,22 +627,116 @@ def package() -> None:
     pass
 
 
+# File suffixes that frictionless cannot describe — use schema-from-yaml path instead.
+_NON_FRICTIONLESS_SUFFIXES: frozenset[str] = frozenset({".parquet", ".parq"})
+
+# IANA media type for Apache Parquet
+_PARQUET_MEDIATYPE = "application/vnd.apache.parquet"
+
+
+def _build_schema_from_yaml(ds: DatasetMetadata) -> Optional[dict[str, Any]]:
+    """Build a Frictionless-compatible schema dict from datasets.yaml field declarations.
+
+    Returns None if no fields are declared.
+    """
+    if not ds.fields:
+        return None
+    field_dicts = []
+    for f in ds.fields:
+        field_dict: dict[str, Any] = {"name": f.name, "type": f.type}
+        if f.description:
+            field_dict["description"] = f.description
+        if f.unit:
+            field_dict["unit"] = f.unit
+        if f.source:
+            field_dict["source"] = f.source
+        if f.constraints:
+            field_dict["constraints"] = f.constraints
+        field_dicts.append(field_dict)
+    return {"fields": field_dicts}
+
+
+def _build_non_frictionless_resource_dict(
+    ds: DatasetMetadata,
+    manager: DatasetsManager,
+    publish_config: Optional[PublishConfig],
+    data_path: Path,
+    mediatype: str,
+) -> dict[str, Any]:
+    """Build a resource dict for file types that frictionless cannot describe.
+
+    Uses field declarations from datasets.yaml as the schema rather than
+    inferring from the file content.
+    """
+    if publish_config and publish_config.flatten:
+        resource_path = data_path.name
+    else:
+        resource_path = ds.location
+
+    if publish_config and publish_config.as_url:
+        public_base = publish_config.as_url.rstrip("/") + "/"
+        path = public_base + resource_path
+    else:
+        path = resource_path
+
+    resource_dict: dict[str, Any] = {
+        "name": ds.slug,
+        "title": ds.name,
+        "path": path,
+        "mediatype": mediatype,
+        f"{STANDARD_RDF_PREFIXES['rdf']}type": f"{STANDARD_RDF_PREFIXES['dcat']}Distribution",
+    }
+
+    if ds.description:
+        resource_dict["description"] = ds.description
+
+    schema = _build_schema_from_yaml(ds)
+    if schema:
+        resource_dict["schema"] = schema
+
+    as_url = publish_config.as_url if publish_config else None
+    should_flatten = publish_config.flatten if publish_config else False
+    if ds.custom_properties:
+        prefixes = {**STANDARD_RDF_PREFIXES, **(ds.rdf_prefixes or {})}
+        resource_dict.update(
+            expand_custom_properties(ds.custom_properties, prefixes, ds.location, as_url, flatten=should_flatten)
+        )
+
+    return resource_dict
+
+
 def build_resource_dict(
     ds: DatasetMetadata,
     manager: DatasetsManager,
     publish_config: Optional[PublishConfig],
 ) -> Optional[dict[str, Any]]:
     """
-    Build a Frictionless resource dict for a dataset.
+    Build a resource dict for a dataset.
+
+    For file types supported by frictionless (CSV, Excel, JSON, …), the schema
+    is inferred from the file content and augmented with metadata from datasets.yaml.
+
+    For file types NOT supported by frictionless (Parquet, …), the schema is
+    built entirely from the ``fields`` declared in datasets.yaml, and the file
+    content is not read.  This avoids silent failures where frictionless raises
+    an exception and the dataset is quietly dropped from the package.
 
     Returns None if the data file doesn't exist or description fails.
     """
-    from frictionless import Resource, describe  # noqa: F401
-
     data_path = manager.get_absolute_path(ds.location)
     if not data_path.exists():
         click.echo(f"Warning: Data file not found for '{ds.slug}': {data_path}", err=True)
         return None
+
+    suffix = data_path.suffix.lower()
+
+    # --- Non-frictionless path (e.g. Parquet) ---
+    if suffix in _NON_FRICTIONLESS_SUFFIXES:
+        mediatype = _PARQUET_MEDIATYPE if suffix in {".parquet", ".parq"} else "application/octet-stream"
+        return _build_non_frictionless_resource_dict(ds, manager, publish_config, data_path, mediatype)
+
+    # --- Frictionless path (CSV, Excel, JSON, …) ---
+    from frictionless import Resource, describe  # noqa: F401
 
     try:
         # Determine resource path based on flatten and as_url settings

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -732,8 +732,12 @@ def build_resource_dict(
 
     # --- Non-frictionless path (e.g. Parquet) ---
     if suffix in _NON_FRICTIONLESS_SUFFIXES:
-        mediatype = _PARQUET_MEDIATYPE if suffix in {".parquet", ".parq"} else "application/octet-stream"
-        return _build_non_frictionless_resource_dict(ds, manager, publish_config, data_path, mediatype)
+        try:
+            mediatype = _PARQUET_MEDIATYPE if suffix in {".parquet", ".parq"} else "application/octet-stream"
+            return _build_non_frictionless_resource_dict(ds, manager, publish_config, data_path, mediatype)
+        except Exception as e:
+            click.echo(f"Warning: Failed to describe '{ds.slug}': {e}", err=True)
+            return None
 
     # --- Frictionless path (CSV, Excel, JSON, …) ---
     from frictionless import Resource, describe  # noqa: F401

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1577,3 +1577,195 @@ class TestLineageCLI:
         assert result.exit_code == 0
         assert "derived-data" in result.output
         assert "source-data" in result.output
+
+
+class TestParquetResourceSupport:
+    """Tests for Parquet file support in build_resource_dict and package push."""
+
+    @pytest.fixture
+    def parquet_project(self, tmp_path: Path) -> Path:
+        """Create a temporary project with a Parquet output file and datasets.yaml."""
+        project = tmp_path / "project"
+        project.mkdir()
+        data_dir = project / "data" / "output"
+        data_dir.mkdir(parents=True)
+
+        # Create a minimal valid Parquet file
+        try:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+
+            table = pa.table(
+                {
+                    "geo_path": pa.array(["no.mun_3303"], type=pa.string()),
+                    "area_name": pa.array(["Kongsberg"], type=pa.string()),
+                    "year": pa.array([2024], type=pa.int16()),
+                    "value": pa.array([28848.0], type=pa.float64()),
+                }
+            )
+            pq.write_table(table, data_dir / "population.parquet")
+        except ImportError:
+            # Fallback: write a minimal Parquet magic-byte file for path-detection tests
+            parquet_magic = b"PAR1" + b"\x00" * 8 + b"PAR1"
+            (data_dir / "population.parquet").write_bytes(parquet_magic)
+
+        datasets_yaml = project / "datasets.yaml"
+        datasets_yaml.write_text(
+            "publish:\n"
+            "  enabled: true\n"
+            "  to: gs://test-bucket/test-project/\n"
+            "\n"
+            "outputs:\n"
+            "  - name: Population Statistics\n"
+            "    slug: population-oslo\n"
+            "    location: data/output/population.parquet\n"
+            "    type: table\n"
+            "    fields:\n"
+            "      - name: geo_path\n"
+            "        type: string\n"
+            "        description: ltree geographic path\n"
+            "      - name: area_name\n"
+            "        type: string\n"
+            "      - name: year\n"
+            "        type: integer\n"
+            "        unit: year\n"
+            "      - name: value\n"
+            "        type: number\n"
+        )
+        return project
+
+    def test_build_resource_dict_parquet_returns_dict(self, parquet_project: Path) -> None:
+        """build_resource_dict returns a dict for Parquet files (not None)."""
+        from sunstone.cli import build_resource_dict
+        from sunstone.datasets import DatasetsManager
+        from sunstone.lineage import PublishConfig
+
+        manager = DatasetsManager(parquet_project)
+        outputs = manager.get_all_outputs()
+        assert len(outputs) == 1, "Expected one output dataset"
+
+        publish_config = PublishConfig(enabled=True, to="gs://test-bucket/test-project/")
+        result = build_resource_dict(outputs[0], manager, publish_config)
+
+        assert result is not None, "build_resource_dict returned None for a Parquet file"
+
+    def test_build_resource_dict_parquet_has_correct_mediatype(self, parquet_project: Path) -> None:
+        """Parquet resource dict has application/vnd.apache.parquet mediatype."""
+        from sunstone.cli import _PARQUET_MEDIATYPE, build_resource_dict
+        from sunstone.datasets import DatasetsManager
+        from sunstone.lineage import PublishConfig
+
+        manager = DatasetsManager(parquet_project)
+        outputs = manager.get_all_outputs()
+        publish_config = PublishConfig(enabled=True, to="gs://test-bucket/test-project/")
+        result = build_resource_dict(outputs[0], manager, publish_config)
+
+        assert result is not None
+        assert result["mediatype"] == _PARQUET_MEDIATYPE
+
+    def test_build_resource_dict_parquet_schema_from_yaml(self, parquet_project: Path) -> None:
+        """Parquet resource dict schema comes from datasets.yaml fields, not frictionless."""
+        from sunstone.cli import build_resource_dict
+        from sunstone.datasets import DatasetsManager
+        from sunstone.lineage import PublishConfig
+
+        manager = DatasetsManager(parquet_project)
+        outputs = manager.get_all_outputs()
+        publish_config = PublishConfig(enabled=True, to="gs://test-bucket/test-project/")
+        result = build_resource_dict(outputs[0], manager, publish_config)
+
+        assert result is not None
+        schema = result.get("schema", {})
+        fields = schema.get("fields", [])
+        field_names = [f["name"] for f in fields]
+
+        assert "geo_path" in field_names
+        assert "year" in field_names
+        assert "value" in field_names
+
+        # Check unit is preserved from datasets.yaml
+        year_field = next(f for f in fields if f["name"] == "year")
+        assert year_field.get("unit") == "year"
+
+        # Check description is preserved
+        geo_field = next(f for f in fields if f["name"] == "geo_path")
+        assert geo_field.get("description") == "ltree geographic path"
+
+    def test_build_resource_dict_parquet_no_frictionless_call(self, parquet_project: Path) -> None:
+        """frictionless Resource.infer() is NOT called for Parquet files."""
+        from unittest.mock import patch
+
+        from sunstone.cli import build_resource_dict
+        from sunstone.datasets import DatasetsManager
+        from sunstone.lineage import PublishConfig
+
+        manager = DatasetsManager(parquet_project)
+        outputs = manager.get_all_outputs()
+        publish_config = PublishConfig(enabled=True, to="gs://test-bucket/test-project/")
+
+        with patch("frictionless.Resource.infer") as mock_infer:
+            result = build_resource_dict(outputs[0], manager, publish_config)
+
+        assert result is not None
+        mock_infer.assert_not_called()
+
+    def test_package_push_parquet_uploads_file(self, runner: CliRunner, parquet_project: Path) -> None:
+        """package push uploads Parquet files when publish is configured."""
+        from unittest.mock import MagicMock, patch
+
+        mock_bucket = MagicMock()
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        with patch("google.cloud.storage.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            mock_client.bucket.return_value = mock_bucket
+
+            result = runner.invoke(
+                main,
+                ["package", "push", "-f", str(parquet_project / "datasets.yaml")],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        # Verify upload_from_filename was called for the Parquet file
+        upload_calls = mock_blob.upload_from_filename.call_args_list
+        parquet_calls = [c for c in upload_calls if str(c.args[0]).endswith(".parquet")]
+        assert len(parquet_calls) >= 1, (
+            f"Expected at least one Parquet upload, got: {upload_calls}"
+        )
+
+    def test_parquet_resource_has_rdf_type(self, parquet_project: Path) -> None:
+        """Parquet resource dict includes the DCAT Distribution RDF type."""
+        from sunstone.cli import STANDARD_RDF_PREFIXES, build_resource_dict
+        from sunstone.datasets import DatasetsManager
+        from sunstone.lineage import PublishConfig
+
+        manager = DatasetsManager(parquet_project)
+        outputs = manager.get_all_outputs()
+        publish_config = PublishConfig(enabled=True, to="gs://test-bucket/test-project/")
+        result = build_resource_dict(outputs[0], manager, publish_config)
+
+        assert result is not None
+        rdf_type_key = f"{STANDARD_RDF_PREFIXES['rdf']}type"
+        assert rdf_type_key in result
+        assert "Distribution" in result[rdf_type_key]
+
+    def test_parquet_resource_path_with_as_url(self, parquet_project: Path) -> None:
+        """Parquet resource path uses as_url when configured."""
+        from sunstone.cli import build_resource_dict
+        from sunstone.datasets import DatasetsManager
+        from sunstone.lineage import PublishConfig
+
+        manager = DatasetsManager(parquet_project)
+        outputs = manager.get_all_outputs()
+        publish_config = PublishConfig(
+            enabled=True,
+            to="gs://test-bucket/test-project/",
+            as_url="https://cdn.example.com/test-project",
+        )
+        result = build_resource_dict(outputs[0], manager, publish_config)
+
+        assert result is not None
+        assert result["path"].startswith("https://cdn.example.com/test-project/")
+        assert result["path"].endswith("population.parquet")


### PR DESCRIPTION
## Summary

Fixes #28.

`sunstone package push` silently skipped Parquet files because frictionless does not support Parquet — `Resource.infer()` raised an exception caught by the bare `except`, causing `build_resource_dict` to return `None` and the dataset to be dropped.

## Changes

**`src/sunstone/cli.py`**

- `_NON_FRICTIONLESS_SUFFIXES = frozenset({".parquet", ".parq"})` — sentinel set for file types frictionless cannot handle
- `_PARQUET_MEDIATYPE = "application/vnd.apache.parquet"` — IANA media type constant
- `_build_schema_from_yaml(ds)` — builds a Frictionless-compatible schema dict from the `fields:` declared in `datasets.yaml`, without reading the file
- `_build_non_frictionless_resource_dict(...)` — builds a full resource dict (name, title, path, mediatype, schema, RDF type, custom properties) without calling `Resource.infer()`
- `build_resource_dict()` — dispatches on file suffix: Parquet → new path, everything else → existing frictionless path (unchanged behaviour)

## Design decisions

- **Schema from `datasets.yaml`** — for Parquet, the field schema is taken from the `fields:` declarations in `datasets.yaml` rather than inferred from the file. This is intentional: Parquet files often have rich PyArrow metadata that frictionless would not capture anyway, and `datasets.yaml` is the authoritative schema source.
- **Explicit suffix list** — `_NON_FRICTIONLESS_SUFFIXES` makes it easy to extend support to other binary formats (Arrow IPC, Avro, ORC) in future PRs.
- **Existing frictionless path unchanged** — CSV, Excel, JSON files continue to use frictionless inference exactly as before.

## Tests

7 new tests in `TestParquetResourceSupport`:

| Test | What it verifies |
|---|---|
| `test_build_resource_dict_parquet_returns_dict` | Returns a dict, not None |
| `test_build_resource_dict_parquet_has_correct_mediatype` | `application/vnd.apache.parquet` mediatype |
| `test_build_resource_dict_parquet_schema_from_yaml` | Schema comes from `datasets.yaml` fields, not frictionless |
| `test_build_resource_dict_parquet_no_frictionless_call` | `Resource.infer()` is never called for Parquet |
| `test_package_push_parquet_uploads_file` | `package push` uploads Parquet to GCS |
| `test_parquet_resource_has_rdf_type` | DCAT Distribution RDF type is included |
| `test_parquet_resource_path_with_as_url` | `as_url` config generates correct public URL |

All 87 existing tests pass. No regressions.
