### PR TITLE
Stream-based plugin IO with cloud storage support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ data science workflow.
 The `sunstone-py` package provides:
 - **DataFrame wrapper**: Pandas-compatible DataFrame with automatic lineage tracking
 - **Dataset management**: Integration with `datasets.yaml` for all I/O operations
+- **Plugin system**: Extensible auth, URL handling, and format support via entry points
 - **Validation tools**: Check notebooks and scripts for correct import usage
 - **Pandas-like API**: Familiar interface for data scientists via `from sunstone import pandas as pd`
 
@@ -18,35 +19,61 @@ The `sunstone-py` package provides:
 ├── pyproject.toml
 ├── README.md
 ├── src
-│   └── sunstone
-│       ├── __init__.py
-│       ├── _release.py
-│       ├── dataframe.py
-│       ├── datasets.py
-│       ├── exceptions.py
-│       ├── lineage.py
-│       ├── pandas.py
-│       ├── py.typed
-│       └── validation.py
+│   └── sunstone
+│       ├── __init__.py
+│       ├── _release.py
+│       ├── cli.py
+│       ├── context.py
+│       ├── dataframe.py
+│       ├── datasets.py
+│       ├── errors.py
+│       ├── exceptions.py
+│       ├── handlers.py
+│       ├── handlers_gcs.py
+│       ├── handlers_s3.py
+│       ├── lineage.py
+│       ├── packaging.py
+│       ├── pandas.py
+│       ├── plugins.py
+│       ├── py.typed
+│       ├── queries.py
+│       ├── session.py
+│       └── validation.py
 ├── templates
-│   ├── analysis_notebook.ipynb
-│   ├── analysis_notebook.py
-│   └── README.md
+│   ├── analysis_notebook.ipynb
+│   ├── analysis_notebook.py
+│   └── README.md
 └── tests
-    ├── conftest.py
-    ├── test_dataframe.py
-    ├── test_datasets.py
-    ├── test_lineage_persistence.py
-    ├── test_pandas_compatibility.py
-    └── testdata
-        └── UNMembersProject
-            ├── create_un_members_dataset.py
-            ├── datasets.yaml
-            ├── inputs
-            │   └── official_un_member_states_raw.csv
-            ├── outputs
-            ├── pyproject.toml
-            └── uv.lock
+    ├── conftest.py
+    ├── test_cli.py
+    ├── test_context.py
+    ├── test_dataframe.py
+    ├── test_dataframe_coverage.py
+    ├── test_datasets.py
+    ├── test_datasets_coverage.py
+    ├── test_errors.py
+    ├── test_handlers.py
+    ├── test_handlers_gcs.py
+    ├── test_handlers_s3.py
+    ├── test_lineage_flow.py
+    ├── test_lineage_persistence.py
+    ├── test_packaging.py
+    ├── test_pandas_compatibility.py
+    ├── test_plugins.py
+    ├── test_queries.py
+    ├── test_rdf.py
+    ├── test_remaining_coverage.py
+    ├── test_session.py
+    ├── test_validation.py
+    └── testdata
+        └── UNMembersProject
+            ├── create_un_members_dataset.py
+            ├── datasets.yaml
+            ├── inputs
+            │   └── official_un_member_states_raw.csv
+            ├── outputs
+            ├── pyproject.toml
+            └── uv.lock
 ```
 
 ## Usage for Data Scientists
@@ -80,6 +107,23 @@ result.to_csv(
 2. **Dataset registration**: All reads/writes must be in `datasets.yaml`
 3. **Access underlying data**: Use `.data` to access the pandas DataFrame directly
 4. **Save with metadata**: `to_csv()` requires `slug` and `name` for new outputs
+
+## Plugin System
+
+Reading, writing, and URL fetching are handled by a plugin registry. Built-in handlers
+cover CSV, JSON, Excel, Parquet, TSV formats and HTTP/HTTPS, local file, GCS, and S3/R2 URLs.
+External plugins are discovered via the `sunstone.plugins` entry point group and take priority
+over built-ins.
+
+Key modules:
+- `plugins.py` — Protocol definitions (`AuthProvider`, `URLHandler`, `FormatHandler`) and `PluginRegistry`
+- `handlers.py` — Built-in `BuiltinFormatHandler`, `HttpURLHandler`, and `LocalFileHandler`
+- `handlers_gcs.py` — `GcsURLHandler` for `gs://` URLs (requires `sunstone-py[gcs]`)
+- `handlers_s3.py` — `S3URLHandler` for `s3://` and `r2://` URLs (requires `sunstone-py[s3]`)
+- `packaging.py` — Library functions for building and pushing data packages via URLHandler
+
+URLHandler uses stream-based `open(url, mode) -> BinaryIO | TextIO` matching Python's built-in `open()`.
+Plugin config uses cascading precedence: `datasets.yaml` → `pyproject.toml` → environment variables (`SUNSTONE_PLUGIN_<NAME>_<KEY>`).
 
 ## Cross-Platform (Windows CI)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added: Plugin system with AuthProvider, URLHandler, and FormatHandler protocols
+- Added: Plugin discovery via Python entry points (`sunstone.plugins` group)
+- Added: Cascading plugin config from pyproject.toml, datasets.yaml, and environment variables
+- Added: Auth header injection in dataset URL fetching
+- Added: Format handler integration in read and write pipelines
 
 ## [1.3.1] - 2026-03-26
 - Fixed: Use `as_posix()` for `script_path` in datasets.yaml to avoid backslashes on Windows CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added: Cascading plugin config from pyproject.toml, datasets.yaml, and environment variables
 - Added: Auth header injection in dataset URL fetching
 - Added: Format handler integration in read and write pipelines
+- Changed: Built-in format handlers (CSV, JSON, Excel, Parquet, TSV) now registered as internal plugins
+- Changed: HTTP URL fetching now handled by internal HttpURLHandler plugin
 
 ## [1.3.1] - 2026-03-26
 - Fixed: Use `as_posix()` for `script_path` in datasets.yaml to avoid backslashes on Windows CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Changed: HTTP URL fetching now handled by internal HttpURLHandler plugin
 - Added: LocalFileHandler plugin for local filesystem paths and file:// URLs, registered as last fallback in URL handler chain
 - Changed: HttpURLHandler now uses stdlib urllib.request instead of requests library, with stream-based open() interface
+- Changed: Read pipeline in dataframe.py now routes through URLHandler.open() → stream → FormatHandler.read() instead of passing Path directly
+- Changed: LocalFileHandler is always registered in PluginRegistry (not only during plugin discovery)
 
 ## [1.3.1] - 2026-03-26
 - Fixed: Use `as_posix()` for `script_path` in datasets.yaml to avoid backslashes on Windows CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added: LocalFileHandler plugin for local filesystem paths and file:// URLs, registered as last fallback in URL handler chain
 - Changed: HttpURLHandler now uses stdlib urllib.request instead of requests library, with stream-based open() interface
 - Changed: Read pipeline in dataframe.py now routes through URLHandler.open() → stream → FormatHandler.read() instead of passing Path directly
+- Changed: Write pipeline in dataframe.py now routes through URLHandler.open() → stream → FormatHandler.write() for both tracked and untracked writes
 - Changed: LocalFileHandler is always registered in PluginRegistry (not only during plugin discovery)
 
 ## [1.3.1] - 2026-03-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,20 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Added: `sunstone.packaging` module with reusable `push_group()` and `is_lfs_pointer()` for programmatic package uploads
-- Changed: `package push` CLI now delegates to `packaging.push_group()` using URLHandler plugins instead of hardcoded GCS client
-- Added: Plugin system with AuthProvider, URLHandler, and FormatHandler protocols
+- Added: Stream-based plugin IO — URLHandler.open(url, mode) returns file-like objects instead of downloading to temp files
+- Added: FormatHandler protocol now uses BinaryIO streams for read/write
+- Added: LocalFileHandler for local paths and file:// URLs
+- Added: GcsURLHandler for gs:// URLs (install with `sunstone-py[gcs]`)
+- Added: S3URLHandler for s3:// and r2:// URLs (install with `sunstone-py[s3]`)
+- Added: `sunstone.packaging` module for programmatic data package builds and uploads
 - Added: Plugin discovery via Python entry points (`sunstone.plugins` group)
 - Added: Cascading plugin config from pyproject.toml, datasets.yaml, and environment variables
-- Added: Auth header injection in dataset URL fetching
-- Added: Format handler integration in read and write pipelines
-- Changed: Built-in format handlers (CSV, JSON, Excel, Parquet, TSV) now registered as internal plugins
-- Changed: HTTP URL fetching now handled by internal HttpURLHandler plugin
-- Added: LocalFileHandler plugin for local filesystem paths and file:// URLs, registered as last fallback in URL handler chain
-- Changed: HttpURLHandler now uses stdlib urllib.request instead of requests library, with stream-based open() interface
-- Changed: Read pipeline in dataframe.py now routes through URLHandler.open() → stream → FormatHandler.read() instead of passing Path directly
-- Changed: Write pipeline in dataframe.py now routes through URLHandler.open() → stream → FormatHandler.write() for both tracked and untracked writes
-- Changed: LocalFileHandler is always registered in PluginRegistry (not only during plugin discovery)
+- Changed: All data reads/writes route through URLHandler.open() → FormatHandler stream pipeline
+- Changed: HTTP fetching uses stdlib urllib.request instead of requests
+- Changed: `package push` uses URLHandler plugins instead of hardcoded google-cloud-storage
+- Changed: `google-cloud-storage` moved to optional `[gcs]` extra
+- Removed: `requests` dependency (replaced by urllib.request)
+- Deprecated: `DatasetsManager.fetch_from_url()` — use `PluginRegistry.get().fetch()` instead
 
 ## [1.3.1] - 2026-03-26
 - Fixed: Use `as_posix()` for `script_path` in datasets.yaml to avoid backslashes on Windows CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added: `sunstone.packaging` module with reusable `push_group()` and `is_lfs_pointer()` for programmatic package uploads
+- Changed: `package push` CLI now delegates to `packaging.push_group()` using URLHandler plugins instead of hardcoded GCS client
 - Added: Plugin system with AuthProvider, URLHandler, and FormatHandler protocols
 - Added: Plugin discovery via Python entry points (`sunstone.plugins` group)
 - Added: Cascading plugin config from pyproject.toml, datasets.yaml, and environment variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added: Format handler integration in read and write pipelines
 - Changed: Built-in format handlers (CSV, JSON, Excel, Parquet, TSV) now registered as internal plugins
 - Changed: HTTP URL fetching now handled by internal HttpURLHandler plugin
+- Added: LocalFileHandler plugin for local filesystem paths and file:// URLs, registered as last fallback in URL handler chain
 
 ## [1.3.1] - 2026-03-26
 - Fixed: Use `as_posix()` for `script_path` in datasets.yaml to avoid backslashes on Windows CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Changed: Built-in format handlers (CSV, JSON, Excel, Parquet, TSV) now registered as internal plugins
 - Changed: HTTP URL fetching now handled by internal HttpURLHandler plugin
 - Added: LocalFileHandler plugin for local filesystem paths and file:// URLs, registered as last fallback in URL handler chain
+- Changed: HttpURLHandler now uses stdlib urllib.request instead of requests library, with stream-based open() interface
 
 ## [1.3.1] - 2026-03-26
 - Fixed: Use `as_posix()` for `script_path` in datasets.yaml to avoid backslashes on Windows CI

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Python library for managing datasets with lineage tracking in data science pro
 - **Automatic Lineage Tracking**: Track data provenance through all operations automatically
 - **Dataset Management**: Integration with `datasets.yaml` for organized dataset registration
 - **Pandas-Compatible API**: Familiar pandas-like interface via `from sunstone import pandas as pd` (CSV, Excel, JSON)
+- **Plugin System**: Extensible architecture for custom auth providers, URL handlers, and format handlers via entry points
 - **Strict/Relaxed Modes**: Control whether operations can modify `datasets.yaml`
 - **Validation Tools**: Check notebooks and scripts for correct import usage
 - **Full Type Hints**: Complete type hint support for better IDE integration
@@ -177,6 +178,44 @@ for path, result in results.items():
         print(result.summary())
 ```
 
+## Plugin System
+
+sunstone-py uses a plugin architecture for reading, writing, and fetching data. Built-in handlers cover common formats (CSV, JSON, Excel, Parquet, TSV) and HTTP/HTTPS, local file, GCS, and S3/R2 URLs.
+
+### Plugin Protocols
+
+Plugins implement one or more of these protocols:
+
+- **`AuthProvider`**: Injects authentication headers into HTTP requests
+- **`URLHandler`**: Opens URLs for reading/writing, returning file-like streams (`BinaryIO`/`TextIO`)
+- **`FormatHandler`**: Reads and writes data formats not built into sunstone
+
+### Installation Extras
+
+```bash
+pip install sunstone-py          # Core + HTTP + local file handling
+pip install sunstone-py[gcs]     # Adds GCS (gs://) support
+pip install sunstone-py[s3]      # Adds S3 (s3://) and R2 (r2://) support
+pip install sunstone-py[gcs,s3]  # Both
+```
+
+### Registering Custom Plugins
+
+Plugins are discovered via Python [entry points](https://packaging.python.org/en/latest/specifications/entry-points/):
+
+```toml
+[project.entry-points."sunstone.plugins"]
+my-plugin = "my_package:MyPlugin"
+```
+
+### Plugin Configuration
+
+Plugin config uses cascading precedence (later sources override earlier):
+
+1. `datasets.yaml` — `plugins.<name>` section
+2. `pyproject.toml` — `[tool.sunstone.plugins.<name>]` table
+3. Environment variables — `SUNSTONE_PLUGIN_<NAME>_<KEY>`
+
 ## Advanced Usage
 
 ### Direct DataFrame API
@@ -276,6 +315,25 @@ Manage `datasets.yaml` files:
 - `check_notebook_imports(notebook_path)`: Validate a single notebook
 - `validate_project_notebooks(project_path)`: Validate all notebooks in project
 
+### Plugin Protocols
+
+- `AuthProvider`: Implement `authenticate(url, headers, dataset) -> headers` to inject auth
+- `URLHandler`: Implement `can_handle(url) -> bool` and `open(url, mode) -> BinaryIO | TextIO`
+- `FormatHandler`: Implement `can_read(path, format)`, `read(stream, **kwargs)`, `can_write(path, format)`, `write(df, stream, **kwargs)`
+
+### PluginRegistry Class
+
+Singleton that discovers and manages plugins:
+
+- `PluginRegistry.get()`: Get the singleton registry instance
+- `get_auth_providers()`: Return all registered auth providers
+- `get_url_handlers()`: Return all registered URL handlers
+- `get_format_handlers()`: Return all registered format handlers
+- `find_url_handler(url)`: Find first handler that can handle a URL
+- `find_format_reader(path, format)`: Find first handler that can read a file
+- `find_format_writer(path, format)`: Find first handler that can write a file
+- `fetch(url, dest)`: Convenience — download URL to local file via `open()`
+
 ### Exceptions
 
 - `SunstoneError`: Base exception
@@ -287,6 +345,7 @@ Manage `datasets.yaml` files:
 ## Environment Variables
 
 - `SUNSTONE_DATAFRAME_STRICT`: Set to `"1"` or `"true"` to enable strict mode globally
+- `SUNSTONE_PLUGIN_<NAME>_<KEY>`: Override plugin configuration (highest precedence)
 
 ## Development
 

--- a/docs/superpowers/plans/2026-03-29-internal-plugins.md
+++ b/docs/superpowers/plans/2026-03-29-internal-plugins.md
@@ -1,0 +1,984 @@
+# Internal Plugins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert built-in format readers/writers and HTTP fetching into internal plugins that register through the same `PluginRegistry`, eliminating the separate fallback code paths in `dataframe.py` and `datasets.py`.
+
+**Architecture:** Create two internal plugin classes (`BuiltinFormatHandler` and `HttpURLHandler`) that implement the existing protocols. Register them in `PluginRegistry._discover()` as defaults that external plugins can override. Then simplify the consumer code in `dataframe.py` and `datasets.py` to just ask the registry — no more inline `reader_map`/`format_map` dicts or inline HTTP fetch logic.
+
+**Tech Stack:** Python 3.12+, existing `plugins.py` protocols, `requests`, `pandas`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| **Create:** `src/sunstone/handlers.py` | `BuiltinFormatHandler` and `HttpURLHandler` implementations |
+| **Create:** `tests/test_handlers.py` | Tests for internal handler classes |
+| **Modify:** `src/sunstone/plugins.py` | Register internal handlers as defaults in `_discover()` |
+| **Modify:** `src/sunstone/dataframe.py` | Remove inline format maps and fallback readers |
+| **Modify:** `src/sunstone/datasets.py` | Remove inline HTTP fetch code, move to `HttpURLHandler` |
+| **Modify:** `tests/test_plugins.py` | Update tests that relied on fallback behavior |
+
+---
+
+### Task 1: BuiltinFormatHandler
+
+**Files:**
+- Create: `src/sunstone/handlers.py`
+- Create: `tests/test_handlers.py`
+
+- [ ] **Step 1: Write tests for BuiltinFormatHandler**
+
+```python
+# tests/test_handlers.py
+"""Tests for internal plugin handlers."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sunstone.handlers import BuiltinFormatHandler
+
+
+@pytest.fixture
+def handler():
+    return BuiltinFormatHandler()
+
+
+class TestBuiltinFormatHandlerCanRead:
+    def test_csv(self, handler):
+        assert handler.can_read(Path("data.csv"), None)
+
+    def test_csv_with_format(self, handler):
+        assert handler.can_read(Path("data.whatever"), "csv")
+
+    def test_json(self, handler):
+        assert handler.can_read(Path("data.json"), None)
+
+    def test_excel_xlsx(self, handler):
+        assert handler.can_read(Path("data.xlsx"), None)
+
+    def test_excel_xls(self, handler):
+        assert handler.can_read(Path("data.xls"), None)
+
+    def test_parquet(self, handler):
+        assert handler.can_read(Path("data.parquet"), None)
+
+    def test_tsv(self, handler):
+        assert handler.can_read(Path("data.tsv"), None)
+
+    def test_txt_as_tsv(self, handler):
+        assert handler.can_read(Path("data.txt"), None)
+
+    def test_unknown_extension(self, handler):
+        assert not handler.can_read(Path("data.hdf5"), None)
+
+    def test_unknown_format_string(self, handler):
+        assert not handler.can_read(Path("data.whatever"), "hdf5")
+
+
+class TestBuiltinFormatHandlerCanWrite:
+    def test_csv(self, handler):
+        assert handler.can_write(Path("data.csv"), None)
+
+    def test_csv_with_format(self, handler):
+        assert handler.can_write(Path("data.whatever"), "csv")
+
+    def test_unknown(self, handler):
+        assert not handler.can_write(Path("data.hdf5"), None)
+
+
+class TestBuiltinFormatHandlerRead:
+    def test_read_csv(self, handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n1,2\n3,4\n")
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_read_tsv(self, handler, tmp_path):
+        f = tmp_path / "data.tsv"
+        f.write_text("a\tb\n1\t2\n3\t4\n")
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_read_txt_as_tsv(self, handler, tmp_path):
+        f = tmp_path / "data.txt"
+        f.write_text("a\tb\n1\t2\n")
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_json(self, handler, tmp_path):
+        f = tmp_path / "data.json"
+        f.write_text('[{"a": 1, "b": 2}]')
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_parquet(self, handler, tmp_path):
+        f = tmp_path / "data.parquet"
+        pd.DataFrame({"a": [1], "b": [2]}).to_parquet(f)
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_passes_kwargs(self, handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n1,2\n3,4\n")
+        df = handler.read(f, usecols=["a"])
+        assert list(df.columns) == ["a"]
+
+
+class TestBuiltinFormatHandlerWrite:
+    def test_write_csv(self, handler, tmp_path):
+        f = tmp_path / "out.csv"
+        df = pd.DataFrame({"x": [1, 2]})
+        handler.write(df, f, index=False)
+        result = pd.read_csv(f)
+        assert list(result.columns) == ["x"]
+        assert len(result) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_handlers.py -v`
+Expected: FAIL — `sunstone.handlers` module does not exist
+
+- [ ] **Step 3: Implement BuiltinFormatHandler**
+
+```python
+# src/sunstone/handlers.py
+"""
+Internal plugin implementations for built-in formats and HTTP fetching.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+
+
+# Extension -> format string mapping
+_EXTENSION_MAP: dict[str, str] = {
+    ".csv": "csv",
+    ".json": "json",
+    ".xlsx": "excel",
+    ".xls": "excel",
+    ".parquet": "parquet",
+    ".tsv": "tsv",
+    ".txt": "tsv",
+}
+
+# Format string -> pandas reader function
+_READER_MAP: dict[str, Callable[..., pd.DataFrame]] = {
+    "csv": pd.read_csv,
+    "json": pd.read_json,
+    "excel": pd.read_excel,
+    "parquet": pd.read_parquet,
+    "tsv": lambda path, **kw: pd.read_csv(path, sep="\t", **kw),
+}
+
+# Format string -> pandas writer method name on DataFrame
+_WRITER_MAP: dict[str, str] = {
+    "csv": "to_csv",
+}
+
+
+class BuiltinFormatHandler:
+    """Handles CSV, JSON, Excel, Parquet, and TSV formats using pandas."""
+
+    def _resolve_format(self, path: Path, format: str | None) -> str | None:
+        """Resolve a format string from explicit format or file extension."""
+        if format is not None:
+            return format if format in _READER_MAP or format in _WRITER_MAP else None
+        return _EXTENSION_MAP.get(path.suffix.lower())
+
+    def can_read(self, path: Path, format: str | None) -> bool:
+        fmt = self._resolve_format(path, format)
+        return fmt is not None and fmt in _READER_MAP
+
+    def read(self, path: Path, **kwargs: object) -> pd.DataFrame:
+        fmt = self._resolve_format(path, None)
+        reader = _READER_MAP[fmt]  # type: ignore[index]
+        return reader(path, **kwargs)
+
+    def can_write(self, path: Path, format: str | None) -> bool:
+        fmt = self._resolve_format(path, format)
+        return fmt is not None and fmt in _WRITER_MAP
+
+    def write(self, df: pd.DataFrame, path: Path, **kwargs: object) -> None:
+        fmt = self._resolve_format(path, None)
+        writer = getattr(df, _WRITER_MAP[fmt])  # type: ignore[index]
+        writer(path, **kwargs)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_handlers.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers.py tests/test_handlers.py
+git commit -m "Add BuiltinFormatHandler for CSV, JSON, Excel, Parquet, TSV"
+```
+
+---
+
+### Task 2: HttpURLHandler
+
+**Files:**
+- Modify: `src/sunstone/handlers.py`
+- Modify: `tests/test_handlers.py`
+
+- [ ] **Step 1: Write tests for HttpURLHandler**
+
+Append to `tests/test_handlers.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from sunstone.handlers import HttpURLHandler
+from sunstone.lineage import DatasetMetadata
+
+
+@pytest.fixture
+def http_handler():
+    return HttpURLHandler()
+
+
+class TestHttpURLHandlerCanHandle:
+    def test_http(self, http_handler):
+        assert http_handler.can_handle("http://example.com/data.csv")
+
+    def test_https(self, http_handler):
+        assert http_handler.can_handle("https://example.com/data.csv")
+
+    def test_s3(self, http_handler):
+        assert not http_handler.can_handle("s3://bucket/data.csv")
+
+    def test_gs(self, http_handler):
+        assert not http_handler.can_handle("gs://bucket/data.csv")
+
+    def test_ftp(self, http_handler):
+        assert not http_handler.can_handle("ftp://example.com/data.csv")
+
+    def test_bare_path(self, http_handler):
+        assert not http_handler.can_handle("/local/path/data.csv")
+
+    def test_relative_path(self, http_handler):
+        assert not http_handler.can_handle("data.csv")
+
+
+class TestHttpURLHandlerFetch:
+    def test_fetches_to_dest(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        mock_response = MagicMock()
+        mock_response.is_redirect = False
+        mock_response.content = b"a,b\n1,2\n"
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", return_value=mock_response),
+        ):
+            result = http_handler.fetch("https://example.com/data.csv", dest)
+            assert result == dest
+            assert dest.read_bytes() == b"a,b\n1,2\n"
+
+    def test_rejects_private_url(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        with patch("sunstone.handlers._is_public_url", return_value=False):
+            with pytest.raises(ValueError, match="not allowed"):
+                http_handler.fetch("http://192.168.1.1/data.csv", dest)
+
+    def test_follows_redirects(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://cdn.example.com/data.csv"}
+
+        final_response = MagicMock()
+        final_response.is_redirect = False
+        final_response.content = b"a,b\n1,2\n"
+        final_response.raise_for_status = MagicMock()
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", side_effect=[redirect_response, final_response]),
+        ):
+            result = http_handler.fetch("https://example.com/redirect", dest)
+            assert result == dest
+
+    def test_strips_auth_on_cross_origin_redirect(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://other.com/data.csv"}
+
+        final_response = MagicMock()
+        final_response.is_redirect = False
+        final_response.content = b"data"
+        final_response.raise_for_status = MagicMock()
+
+        http_handler.headers = {"Authorization": "Bearer secret"}
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", side_effect=[redirect_response, final_response]) as mock_get,
+        ):
+            http_handler.fetch("https://example.com/data.csv", dest)
+            # Second call (redirect) should not have Authorization header
+            second_call_headers = mock_get.call_args_list[1][1]["headers"]
+            assert "Authorization" not in second_call_headers
+
+    def test_too_many_redirects(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://example.com/loop"}
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", return_value=redirect_response),
+        ):
+            with pytest.raises(ValueError, match="Too many redirects"):
+                http_handler.fetch("https://example.com/data.csv", dest)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_handlers.py -v -k "Http"`
+Expected: FAIL — `HttpURLHandler` not defined
+
+- [ ] **Step 3: Implement HttpURLHandler**
+
+Add these imports to the top of `src/sunstone/handlers.py`:
+
+```python
+import ipaddress
+import logging
+import socket
+from urllib.parse import urljoin, urlparse
+
+import requests
+```
+
+Add `_is_public_url` function (move from `datasets.py` — we'll do the actual move in Task 4, for now copy it):
+
+```python
+logger = logging.getLogger(__name__)
+
+
+def _is_public_url(url: str) -> bool:
+    """
+    Validate that a URL points to a public (non-private) resource.
+
+    Prevents SSRF attacks by blocking non-HTTP(S) schemes, private IPs,
+    localhost, loopback, and link-local addresses.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            logger.warning("URL scheme '%s' not allowed (only http/https permitted)", parsed.scheme)
+            return False
+        if not parsed.hostname:
+            logger.warning("URL has no hostname")
+            return False
+        addrinfos = socket.getaddrinfo(parsed.hostname, None)
+        for addrinfo in addrinfos:
+            sockaddr = addrinfo[4]
+            ip = sockaddr[0]
+            ip_obj = ipaddress.ip_address(ip)
+            if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+                logger.warning(
+                    "URL hostname '%s' resolves to restricted IP address: %s",
+                    parsed.hostname,
+                    ip,
+                )
+                return False
+        return True
+    except socket.gaierror:
+        logger.warning("Unable to resolve hostname: %s", parsed.hostname)
+        return False
+    except ValueError as e:
+        logger.warning("Error validating URL '%s': %s", url, e)
+        return False
+    except Exception as e:
+        logger.exception("Unexpected error validating URL '%s': %s", url, e)
+        raise
+```
+
+Add the `HttpURLHandler` class:
+
+```python
+class HttpURLHandler:
+    """Fetches datasets from HTTP/HTTPS URLs with SSRF protection."""
+
+    def __init__(self, timeout: int = 30, max_redirects: int = 10) -> None:
+        self.timeout = timeout
+        self.max_redirects = max_redirects
+        self.headers: dict[str, str] = {}
+
+    def can_handle(self, url: str) -> bool:
+        parsed = urlparse(url)
+        return parsed.scheme in ("http", "https")
+
+    def fetch(self, url: str, dest: Path) -> Path:
+        if not _is_public_url(url):
+            raise ValueError(
+                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to public internet addresses are permitted."
+            )
+
+        logger.info("Fetching dataset from URL: %s", url)
+
+        current_url = url
+        response = requests.get(current_url, timeout=self.timeout, allow_redirects=False, headers=self.headers)
+        redirect_count = 0
+
+        while response.is_redirect and redirect_count < self.max_redirects:
+            redirect_url = response.headers.get("Location")
+            if not redirect_url:
+                raise ValueError("Redirect response without Location header")
+
+            redirect_url = urljoin(current_url, redirect_url)
+
+            if not _is_public_url(redirect_url):
+                raise ValueError(
+                    f"Redirect URL '{redirect_url}' is not allowed. Only HTTP/HTTPS URLs "
+                    "pointing to public internet addresses are permitted."
+                )
+
+            # Strip auth headers on cross-origin redirects
+            redirect_parsed = urlparse(redirect_url)
+            original_parsed = urlparse(url)
+            if redirect_parsed.scheme != original_parsed.scheme or redirect_parsed.netloc != original_parsed.netloc:
+                redirect_headers = {k: v for k, v in self.headers.items() if k.lower() != "authorization"}
+            else:
+                redirect_headers = self.headers
+
+            logger.info("Following redirect to: %s", redirect_url)
+            current_url = redirect_url
+            response = requests.get(current_url, timeout=self.timeout, allow_redirects=False, headers=redirect_headers)
+            redirect_count += 1
+
+        if response.is_redirect:
+            raise ValueError(f"Too many redirects (max: {self.max_redirects})")
+
+        response.raise_for_status()
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(dest, "wb") as f:
+            f.write(response.content)
+
+        logger.info("Successfully saved to %s (%d bytes)", dest, len(response.content))
+        return dest
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_handlers.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers.py tests/test_handlers.py
+git commit -m "Add HttpURLHandler with SSRF protection and redirect handling"
+```
+
+---
+
+### Task 3: Register internal handlers in PluginRegistry
+
+**Files:**
+- Modify: `src/sunstone/plugins.py`
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write tests for internal handler registration**
+
+Add to `tests/test_plugins.py`:
+
+```python
+from sunstone.handlers import BuiltinFormatHandler, HttpURLHandler
+
+
+def test_registry_registers_builtin_format_handler():
+    """BuiltinFormatHandler is registered as a default."""
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            handlers = registry.get_format_handlers()
+            assert any(isinstance(h, BuiltinFormatHandler) for h in handlers)
+
+
+def test_registry_registers_http_url_handler():
+    """HttpURLHandler is registered as a default."""
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            handlers = registry.get_url_handlers()
+            assert any(isinstance(h, HttpURLHandler) for h in handlers)
+
+
+def test_external_plugin_takes_priority_over_builtin():
+    """External plugins registered via entry points come before builtins."""
+
+    class ExternalCSVHandler:
+        def can_read(self, path, format):
+            return path.suffix == ".csv"
+
+        def read(self, path, **kwargs):
+            return pd.DataFrame({"external": [True]})
+
+        def can_write(self, path, format):
+            return path.suffix == ".csv"
+
+        def write(self, df, path, **kwargs):
+            pass
+
+    with patch(
+        "sunstone.plugins._get_entry_points",
+        return_value=[_make_entry_point("ext-csv", ExternalCSVHandler)],
+    ):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            handler = registry.find_format_reader(Path("data.csv"), None)
+            # External plugin should win because it's registered first
+            assert isinstance(handler, ExternalCSVHandler)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "builtin or http_url or priority"`
+Expected: FAIL — builtins not registered
+
+- [ ] **Step 3: Register internal handlers in _discover**
+
+In `src/sunstone/plugins.py`, modify the `_discover` method to register internal handlers AFTER external plugins (so externals take priority via `find_format_reader` which returns the first match):
+
+```python
+    def _discover(self) -> None:
+        """Load plugins from entry points, then register internal handlers."""
+        # External plugins first (they take priority)
+        for ep in _get_entry_points():
+            try:
+                plugin_cls = ep.load()
+                config = _load_plugin_config(ep.name)
+                plugin = plugin_cls(config) if config else plugin_cls()
+                self._register(ep.name, plugin)
+            except Exception:
+                logger.exception("Failed to load plugin '%s'", ep.name)
+
+        # Internal handlers last (fallback)
+        from .handlers import BuiltinFormatHandler, HttpURLHandler
+
+        self._format_handlers.append(BuiltinFormatHandler())
+        self._url_handlers.append(HttpURLHandler())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugins.py -v`
+Expected: PASS (all tests including new ones)
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS — existing behavior unchanged since builtins now serve as fallback through the registry
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "Register BuiltinFormatHandler and HttpURLHandler as default plugins"
+```
+
+---
+
+### Task 4: Simplify read_dataset — remove inline format fallback
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py`
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write test confirming the registry handles everything**
+
+Add to `tests/test_plugins.py`:
+
+```python
+def test_read_dataset_unknown_format_without_plugin(tmp_path):
+    """Unknown format raises ValueError when no handler matches."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Unknown Data\n"
+        "    slug: unknown-data\n"
+        "    location: inputs/data.xyz\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.xyz").write_text("stuff")
+
+    with pytest.raises(ValueError, match="No format handler found"):
+        DataFrame.read_dataset("unknown-data", project_path=tmp_path)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_plugins.py::test_read_dataset_unknown_format_without_plugin -v`
+Expected: FAIL — current error message says "Cannot auto-detect format"
+
+- [ ] **Step 3: Simplify read_dataset**
+
+In `src/sunstone/dataframe.py`, replace lines 160-203 (the format detection, plugin check, and builtin fallback) with:
+
+```python
+        # Find a format handler (plugin or builtin) for this file
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+
+        # Try explicit format string first, then extension-based detection
+        format_handler = registry.find_format_reader(absolute_path, format)
+
+        if format_handler is None:
+            extension = absolute_path.suffix.lower()
+            raise ValueError(
+                f"No format handler found for '{absolute_path.name}'"
+                + (f" (format='{format}')" if format else f" (extension='{extension}')")
+                + ". Install a plugin or check the file extension."
+            )
+
+        df = format_handler.read(absolute_path, **kwargs)
+```
+
+Also remove the now-unused `Callable` import from the `typing` import line at the top of the file (line 7). Change:
+```python
+from typing import Any, Callable, List, Optional, Union
+```
+to:
+```python
+from typing import Any, List, Optional, Union
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS — builtins in registry handle all existing formats, new test passes with new error message
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/dataframe.py tests/test_plugins.py
+git commit -m "Simplify read_dataset: delegate all format handling to plugin registry"
+```
+
+---
+
+### Task 5: Simplify read_csv and read_excel by-path to use registry
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py`
+
+- [ ] **Step 1: Write test for read_csv by-path using format handler**
+
+Add to `tests/test_plugins.py`:
+
+```python
+def test_read_csv_by_path_uses_registry(tmp_path):
+    """read_csv with a file path routes through the format handler registry."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: CSV Data\n"
+        "    slug: csv-data\n"
+        "    location: inputs/data.csv\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n")
+
+    # This should work via the builtin format handler in the registry
+    df = DataFrame.read_csv("inputs/data.csv", project_path=tmp_path)
+    assert list(df.data.columns) == ["a", "b"]
+```
+
+- [ ] **Step 2: Run test to verify it passes (it already works)**
+
+Run: `uv run pytest tests/test_plugins.py::test_read_csv_by_path_uses_registry -v`
+Expected: PASS (current code already works, this test locks the behavior)
+
+- [ ] **Step 3: Refactor read_csv by-path to use registry**
+
+In `src/sunstone/dataframe.py`, in the `read_csv` method, replace line 304-305:
+
+```python
+        # Read the CSV using pandas
+        df = pd.read_csv(absolute_path, **kwargs)
+```
+
+with:
+
+```python
+        # Read via format handler registry
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_handler = registry.find_format_reader(absolute_path, "csv")
+        if format_handler is None:
+            raise ValueError(f"No format handler found for CSV files")
+        df = format_handler.read(absolute_path, **kwargs)
+```
+
+- [ ] **Step 4: Do the same for read_excel by-path**
+
+In `src/sunstone/dataframe.py`, in the `read_excel` method, replace line 404-405:
+
+```python
+        # Read the Excel file using pandas
+        df = pd.read_excel(absolute_path, **kwargs)
+```
+
+with:
+
+```python
+        # Read via format handler registry
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_handler = registry.find_format_reader(absolute_path, "excel")
+        if format_handler is None:
+            raise ValueError(f"No format handler found for Excel files")
+        df = format_handler.read(absolute_path, **kwargs)
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/dataframe.py tests/test_plugins.py
+git commit -m "Route read_csv and read_excel by-path through format handler registry"
+```
+
+---
+
+### Task 6: Simplify fetch_from_url — delegate to registry
+
+**Files:**
+- Modify: `src/sunstone/datasets.py`
+- Modify: `tests/test_handlers.py`
+
+- [ ] **Step 1: Write test for auth header injection via HttpURLHandler**
+
+Add to `tests/test_handlers.py`:
+
+```python
+from sunstone.plugins import PluginRegistry
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset the singleton between tests."""
+    PluginRegistry._instance = None
+    yield
+    PluginRegistry._instance = None
+
+
+def test_fetch_from_url_delegates_auth_to_http_handler(tmp_path):
+    """Auth providers set headers on the HttpURLHandler before fetch."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Test Dataset\n"
+        "    slug: test-dataset\n"
+        "    location: inputs/test.csv\n"
+        "    source:\n"
+        "      name: Test Source\n"
+        "      location:\n"
+        "        data: https://example.com/test.csv\n"
+        "      attributedTo: Test Org\n"
+        "      acquiredAt: '2026-01-01'\n"
+        "      acquisitionMethod: manual-download\n"
+        "      license: CC-BY-4.0\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+
+    from sunstone.datasets import DatasetsManager
+
+    manager = DatasetsManager(tmp_path)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    class TestAuth:
+        def authenticate(self, url, headers, dataset):
+            headers["Authorization"] = "Bearer test-token"
+            return headers
+
+    registry = PluginRegistry()
+    registry._auth_providers.append(TestAuth())
+    registry._url_handlers.append(HttpURLHandler())
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_handlers.py::test_fetch_from_url_delegates_auth_to_http_handler -v`
+Expected: FAIL — fetch_from_url still has inline HTTP code
+
+- [ ] **Step 3: Simplify fetch_from_url**
+
+In `src/sunstone/datasets.py`, replace the `fetch_from_url` method (lines 721-837) with:
+
+```python
+    def fetch_from_url(
+        self,
+        dataset: DatasetMetadata,
+        timeout: int = 30,
+        force: bool = False,
+        max_redirects: int = 10,
+    ) -> Path:
+        """
+        Fetch a dataset from its source URL if available.
+
+        Delegates to URL handler plugins. Auth plugins inject headers
+        into the handler before fetching.
+
+        Args:
+            dataset: The dataset metadata containing source URL.
+            timeout: Request timeout in seconds.
+            force: If True, fetch even if local file exists.
+            max_redirects: Maximum number of redirects to follow (default: 10).
+
+        Returns:
+            Path to the local file (newly downloaded or existing).
+
+        Raises:
+            ValueError: If dataset has no source URL or no handler matches.
+            requests.RequestException: If the fetch fails.
+        """
+        if not dataset.source or not dataset.source.location.data:
+            raise ValueError(f"Dataset '{dataset.slug}' has no source URL")
+
+        local_path = self.get_absolute_path(dataset.location)
+
+        # Skip if file exists and not forcing
+        if local_path.exists() and not force:
+            logger.info("Using existing local file: %s", local_path)
+            return local_path
+
+        url = dataset.source.location.data
+
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        url_handler = registry.find_url_handler(url)
+
+        if url_handler is None:
+            raise ValueError(
+                f"No URL handler found for '{url}'. Install a plugin that handles this URL scheme."
+            )
+
+        # Inject auth headers if the handler supports it
+        if hasattr(url_handler, "headers"):
+            for auth in registry.get_auth_providers():
+                url_handler.headers = auth.authenticate(url, url_handler.headers, dataset)
+
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        return url_handler.fetch(url, local_path)
+```
+
+- [ ] **Step 4: Remove now-unused imports from datasets.py**
+
+Remove the following imports that are no longer needed in `datasets.py` since the HTTP logic moved to `handlers.py`:
+
+From the top of `datasets.py`, remove: `import ipaddress`, `import socket`, `from urllib.parse import urljoin, urlparse`. Keep `from urllib.parse import urljoin` if used elsewhere — check first with grep. Also remove the `_is_public_url` function (lines 52-110) and the `import requests` (line 14).
+
+**Important:** Check that `urljoin` and `urlparse` are still used in `datasets.py` before removing. `requests` may still be imported elsewhere. Only remove imports that are truly unused after the `fetch_from_url` simplification.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/datasets.py tests/test_handlers.py
+git commit -m "Simplify fetch_from_url: delegate entirely to URL handler plugins"
+```
+
+---
+
+### Task 7: Clean up old tests and update CHANGELOG
+
+**Files:**
+- Modify: `tests/test_plugins.py`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update tests that tested the old inline fallback**
+
+In `tests/test_plugins.py`, the following tests tested the old inline fallback behavior and need updating:
+
+1. `test_fetch_from_url_injects_auth_headers` — now auth goes through the handler's `headers` attribute, not `requests.get` kwargs directly. Update to patch `sunstone.handlers.requests.get` instead of `sunstone.datasets.requests.get`.
+
+2. `test_fetch_from_url_stacks_auth_providers` — same change.
+
+3. `test_fetch_from_url_no_auth_still_works` — same change.
+
+4. `test_fetch_from_url_uses_url_handler` — this should still pass as-is.
+
+5. `test_read_dataset_builtin_format_still_works` — remove the `patch.object(PluginRegistry, "get")` since the registry now always has builtins. The test should just work without mocking.
+
+6. `test_read_dataset_plugin_overrides_builtin` — keep as-is but the plugin must be registered before builtins in the registry.
+
+Review each test, run the suite, and fix any failures. The key change: `requests.get` is now called from `sunstone.handlers`, not `sunstone.datasets`.
+
+- [ ] **Step 2: Run full test suite and fix failures**
+
+Run: `uv run pytest tests/ -v`
+Fix any failing tests by updating mock paths and assertions.
+
+- [ ] **Step 3: Add CHANGELOG entry**
+
+Add under `## [Unreleased]` in `CHANGELOG.md`:
+
+```
+- Changed: Built-in format handlers (CSV, JSON, Excel, Parquet, TSV) now registered as internal plugins
+- Changed: HTTP URL fetching now handled by internal HttpURLHandler plugin
+```
+
+- [ ] **Step 4: Run full test suite one final time**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_plugins.py CHANGELOG.md
+git commit -m "Update tests for internal plugin architecture and add CHANGELOG entries"
+```

--- a/docs/superpowers/plans/2026-03-29-plugin-architecture.md
+++ b/docs/superpowers/plans/2026-03-29-plugin-architecture.md
@@ -1,0 +1,1272 @@
+# Plugin Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a plugin system to sunstone-py that supports auth providers, URL handlers, and format handlers, discovered via entry points and configured through cascading config.
+
+**Architecture:** New `sunstone/plugins.py` module defines three `Protocol` types and a singleton `PluginRegistry` that discovers plugins via entry points and classifies them by protocol conformance. The existing `DataFrame.read_dataset()` and `to_csv()` methods are refactored to route through a pipeline that checks plugins before falling back to builtins. Config cascades from `pyproject.toml` → `datasets.yaml` → environment variables.
+
+**Tech Stack:** Python 3.12+, `typing.Protocol`, `importlib.metadata`, `tomllib` (stdlib), existing `ruamel.yaml`
+
+**Note on sidecar lineage:** The spec lists `.lineage.json` sidecar files as in-scope. However, the existing `update_output_lineage()` in `DatasetsManager` already persists lineage to `datasets.yaml` regardless of format — this works for any format handler because lineage is separate from the data file. The `.lineage.json` sidecar pattern (issue #8) is for intermediate files that aren't registered in `datasets.yaml` at all, which is a separate concern best addressed as a follow-up.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| **Create:** `src/sunstone/plugins.py` | Protocol definitions, `PluginRegistry`, config loading, pipeline helpers |
+| **Create:** `tests/test_plugins.py` | All plugin infrastructure tests |
+| **Modify:** `src/sunstone/dataframe.py` | Refactor read/write methods to use plugin pipeline |
+| **Modify:** `src/sunstone/datasets.py` | Add auth header support to `fetch_from_url()` |
+| **Modify:** `src/sunstone/__init__.py` | Export plugin protocols and registry |
+
+---
+
+### Task 1: Protocol definitions
+
+**Files:**
+- Create: `src/sunstone/plugins.py`
+- Create: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write test for protocol structural typing**
+
+```python
+# tests/test_plugins.py
+"""Tests for the plugin infrastructure."""
+
+from pathlib import Path
+
+import pandas as pd
+
+from sunstone.plugins import AuthProvider, FormatHandler, URLHandler
+
+
+class FakeAuth:
+    def authenticate(self, url, headers, dataset):
+        headers["X-Test"] = "value"
+        return headers
+
+
+class FakeURLHandler:
+    def can_handle(self, url):
+        return url.startswith("fake://")
+
+    def fetch(self, url, dest):
+        dest.write_text("col1,col2\na,b\n")
+        return dest
+
+
+class FakeFormatHandler:
+    def can_read(self, path, format):
+        return path.suffix == ".fake"
+
+    def read(self, path, **kwargs):
+        return pd.DataFrame({"x": [1, 2, 3]})
+
+    def can_write(self, path, format):
+        return path.suffix == ".fake"
+
+    def write(self, df, path, **kwargs):
+        df.to_csv(path)
+
+
+class PartialFormatHandler:
+    """Only implements read, not write."""
+
+    def can_read(self, path, format):
+        return True
+
+    def read(self, path, **kwargs):
+        return pd.DataFrame()
+
+
+class NotAPlugin:
+    """Implements no protocol."""
+
+    pass
+
+
+def test_auth_provider_structural_typing():
+    assert isinstance(FakeAuth(), AuthProvider)
+
+
+def test_url_handler_structural_typing():
+    assert isinstance(FakeURLHandler(), URLHandler)
+
+
+def test_format_handler_structural_typing():
+    assert isinstance(FakeFormatHandler(), FormatHandler)
+
+
+def test_partial_format_handler_is_not_format_handler():
+    """FormatHandler requires both read and write methods."""
+    assert not isinstance(PartialFormatHandler(), FormatHandler)
+
+
+def test_not_a_plugin():
+    assert not isinstance(NotAPlugin(), AuthProvider)
+    assert not isinstance(NotAPlugin(), URLHandler)
+    assert not isinstance(NotAPlugin(), FormatHandler)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_plugins.py -v`
+Expected: FAIL — `sunstone.plugins` module does not exist
+
+- [ ] **Step 3: Implement protocol definitions**
+
+```python
+# src/sunstone/plugins.py
+"""
+Plugin system for extending sunstone with custom auth, URL handlers, and format handlers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import pandas as pd
+
+from .lineage import DatasetMetadata
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Provides authentication for HTTP requests."""
+
+    def authenticate(
+        self, url: str, headers: dict[str, str], dataset: DatasetMetadata
+    ) -> dict[str, str]:
+        """Return modified headers dict. Called before every HTTP fetch."""
+        ...
+
+
+@runtime_checkable
+class URLHandler(Protocol):
+    """Resolves custom URL schemes to local file paths."""
+
+    def can_handle(self, url: str) -> bool:
+        """Return True if this handler can resolve the given URL."""
+        ...
+
+    def fetch(self, url: str, dest: Path) -> Path:
+        """Download/resolve URL to a local file. Return path to the file."""
+        ...
+
+
+@runtime_checkable
+class FormatHandler(Protocol):
+    """Reads and writes data formats not built into sunstone."""
+
+    def can_read(self, path: Path, format: str | None) -> bool:
+        """Return True if this handler can read the given file/format."""
+        ...
+
+    def read(self, path: Path, **kwargs: object) -> pd.DataFrame:
+        """Read file into a pandas DataFrame."""
+        ...
+
+    def can_write(self, path: Path, format: str | None) -> bool:
+        """Return True if this handler can write the given file/format."""
+        ...
+
+    def write(self, df: pd.DataFrame, path: Path, **kwargs: object) -> None:
+        """Write DataFrame to file."""
+        ...
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugins.py -v`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "Add plugin protocol definitions: AuthProvider, URLHandler, FormatHandler"
+```
+
+---
+
+### Task 2: Plugin registry with discovery
+
+**Files:**
+- Modify: `src/sunstone/plugins.py`
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write tests for registry discovery and classification**
+
+Append to `tests/test_plugins.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from sunstone.plugins import PluginRegistry
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset the singleton between tests."""
+    PluginRegistry._instance = None
+    yield
+    PluginRegistry._instance = None
+
+
+def _make_entry_point(name, plugin_cls):
+    """Create a mock entry point."""
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = plugin_cls
+    return ep
+
+
+def test_registry_discovers_auth_provider():
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-auth", FakeAuth)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 1
+            assert len(registry.get_url_handlers()) == 0
+            assert len(registry.get_format_handlers()) == 0
+
+
+def test_registry_discovers_url_handler():
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-url", FakeURLHandler)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_url_handlers()) == 1
+
+
+def test_registry_discovers_format_handler():
+    with patch(
+        "sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-fmt", FakeFormatHandler)]
+    ):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_format_handlers()) == 1
+
+
+def test_registry_multi_protocol_plugin():
+    """A plugin implementing multiple protocols gets classified into all matching lists."""
+
+    class MultiPlugin:
+        def authenticate(self, url, headers, dataset):
+            return headers
+
+        def can_handle(self, url):
+            return url.startswith("multi://")
+
+        def fetch(self, url, dest):
+            return dest
+
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("multi", MultiPlugin)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 1
+            assert len(registry.get_url_handlers()) == 1
+
+
+def test_registry_ignores_non_plugin(caplog):
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("nope", NotAPlugin)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 0
+            assert len(registry.get_url_handlers()) == 0
+            assert len(registry.get_format_handlers()) == 0
+            assert "does not implement any known plugin protocol" in caplog.text
+
+
+def test_registry_no_plugins():
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 0
+            assert len(registry.get_url_handlers()) == 0
+            assert len(registry.get_format_handlers()) == 0
+
+
+def test_registry_passes_config_to_constructor():
+    class ConfigPlugin:
+        def __init__(self, config=None):
+            self.config = config
+
+        def authenticate(self, url, headers, dataset):
+            return headers
+
+    config = {"key": "value"}
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("cfg", ConfigPlugin)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=config):
+            registry = PluginRegistry.get()
+            providers = registry.get_auth_providers()
+            assert len(providers) == 1
+            assert providers[0].config == config
+
+
+def test_registry_singleton():
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            r1 = PluginRegistry.get()
+            r2 = PluginRegistry.get()
+            assert r1 is r2
+```
+
+Add `import pytest` at the top of the file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "registry"`
+Expected: FAIL — `PluginRegistry` not defined
+
+- [ ] **Step 3: Implement PluginRegistry**
+
+Add to `src/sunstone/plugins.py`:
+
+```python
+import importlib.metadata
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _get_entry_points() -> list:
+    """Get entry points for sunstone plugins. Separated for testability."""
+    return list(importlib.metadata.entry_points(group="sunstone.plugins"))
+
+
+def _load_plugin_config(name: str) -> dict | None:
+    """Load config for a plugin. Separated for testability. Implemented in Task 3."""
+    return None
+
+
+class PluginRegistry:
+    """Discovers and manages plugins."""
+
+    _instance: PluginRegistry | None = None
+
+    def __init__(self) -> None:
+        self._auth_providers: list[AuthProvider] = []
+        self._url_handlers: list[URLHandler] = []
+        self._format_handlers: list[FormatHandler] = []
+
+    @classmethod
+    def get(cls) -> PluginRegistry:
+        """Singleton - lazy-loads plugins on first access."""
+        if cls._instance is None:
+            cls._instance = cls()
+            cls._instance._discover()
+        return cls._instance
+
+    def _discover(self) -> None:
+        """Load plugins from entry points."""
+        for ep in _get_entry_points():
+            try:
+                plugin_cls = ep.load()
+                config = _load_plugin_config(ep.name)
+                plugin = plugin_cls(config) if config else plugin_cls()
+                self._register(ep.name, plugin)
+            except Exception:
+                logger.exception("Failed to load plugin '%s'", ep.name)
+
+    def _register(self, name: str, plugin: object) -> None:
+        """Classify plugin by protocol conformance."""
+        registered = False
+        if isinstance(plugin, AuthProvider):
+            self._auth_providers.append(plugin)
+            registered = True
+        if isinstance(plugin, URLHandler):
+            self._url_handlers.append(plugin)
+            registered = True
+        if isinstance(plugin, FormatHandler):
+            self._format_handlers.append(plugin)
+            registered = True
+        if not registered:
+            logger.warning("Plugin '%s' does not implement any known plugin protocol", name)
+
+    def get_auth_providers(self) -> list[AuthProvider]:
+        """Return all registered auth providers."""
+        return self._auth_providers
+
+    def get_url_handlers(self) -> list[URLHandler]:
+        """Return all registered URL handlers."""
+        return self._url_handlers
+
+    def get_format_handlers(self) -> list[FormatHandler]:
+        """Return all registered format handlers."""
+        return self._format_handlers
+
+    def find_url_handler(self, url: str) -> URLHandler | None:
+        """Find the first URL handler that can handle the given URL."""
+        for handler in self._url_handlers:
+            if handler.can_handle(url):
+                return handler
+        return None
+
+    def find_format_reader(self, path: Path, format: str | None) -> FormatHandler | None:
+        """Find the first format handler that can read the given file."""
+        for handler in self._format_handlers:
+            if handler.can_read(path, format):
+                return handler
+        return None
+
+    def find_format_writer(self, path: Path, format: str | None) -> FormatHandler | None:
+        """Find the first format handler that can write the given file."""
+        for handler in self._format_handlers:
+            if handler.can_write(path, format):
+                return handler
+        return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugins.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "Add PluginRegistry with entry point discovery and protocol classification"
+```
+
+---
+
+### Task 3: Cascading config loading
+
+**Files:**
+- Modify: `src/sunstone/plugins.py`
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write tests for cascading config**
+
+Append to `tests/test_plugins.py`:
+
+```python
+import os
+
+from sunstone.plugins import _load_cascading_config
+
+
+def test_config_from_pyproject(tmp_path):
+    """Config loaded from pyproject.toml [tool.sunstone.plugins.<name>]."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.sunstone.plugins.s3]\nregion = "eu-west-1"\n')
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "eu-west-1"}
+
+
+def test_config_from_datasets_yaml(tmp_path):
+    """Config loaded from datasets.yaml plugins section when no pyproject.toml."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\nplugins:\n  s3:\n    region: eu-west-1\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "eu-west-1"}
+
+
+def test_config_pyproject_overrides_datasets_yaml(tmp_path):
+    """pyproject.toml takes precedence over datasets.yaml."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.sunstone.plugins.s3]\nregion = "us-east-1"\n')
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\nplugins:\n  s3:\n    region: eu-west-1\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "us-east-1"}
+
+
+def test_config_env_var_override(tmp_path, monkeypatch):
+    """Environment variables override file-based config."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.sunstone.plugins.s3]\nregion = "eu-west-1"\n')
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    monkeypatch.setenv("SUNSTONE_PLUGIN_S3_REGION", "ap-southeast-1")
+    config = _load_cascading_config("s3", tmp_path)
+    assert config["region"] == "ap-southeast-1"
+
+
+def test_config_env_var_hyphen_to_underscore(tmp_path, monkeypatch):
+    """Plugin names with hyphens convert to underscores in env vars."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    monkeypatch.setenv("SUNSTONE_PLUGIN_BEARER_AUTH_TOKEN", "secret123")
+    config = _load_cascading_config("bearer-auth", tmp_path)
+    assert config == {"token": "secret123"}
+
+
+def test_config_no_config_returns_none(tmp_path):
+    """Returns None when no config found anywhere."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    config = _load_cascading_config("nonexistent", tmp_path)
+    assert config is None
+
+
+def test_config_no_pyproject_no_error(tmp_path):
+    """Missing pyproject.toml doesn't cause an error."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\nplugins:\n  s3:\n    region: eu-west-1\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "eu-west-1"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "config"`
+Expected: FAIL — `_load_cascading_config` not defined
+
+- [ ] **Step 3: Implement cascading config loading**
+
+Add to `src/sunstone/plugins.py`:
+
+```python
+import os
+import tomllib
+
+from ruamel.yaml import YAML
+
+_config_yaml = YAML()
+
+
+def _load_cascading_config(name: str, project_path: Path) -> dict | None:
+    """
+    Load plugin config with cascading precedence:
+    1. pyproject.toml [tool.sunstone.plugins.<name>]
+    2. datasets.yaml plugins.<name>
+    3. Environment variables SUNSTONE_PLUGIN_<NAME>_<KEY>
+
+    Later sources override earlier ones. Returns None if no config found.
+    """
+    config: dict = {}
+
+    # Source 1: datasets.yaml
+    datasets_path = project_path / "datasets.yaml"
+    if datasets_path.exists():
+        with open(datasets_path) as f:
+            data = _config_yaml.load(f) or {}
+        plugins_section = data.get("plugins", {})
+        if name in plugins_section and plugins_section[name]:
+            config.update(plugins_section[name])
+
+    # Source 2: pyproject.toml (overrides datasets.yaml)
+    pyproject_path = project_path / "pyproject.toml"
+    if pyproject_path.exists():
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+        plugin_config = pyproject.get("tool", {}).get("sunstone", {}).get("plugins", {}).get(name)
+        if plugin_config:
+            config.update(plugin_config)
+
+    # Source 3: environment variables (override everything)
+    env_prefix = f"SUNSTONE_PLUGIN_{name.upper().replace('-', '_')}_"
+    for key, value in os.environ.items():
+        if key.startswith(env_prefix):
+            config_key = key[len(env_prefix) :].lower()
+            config[config_key] = value
+
+    return config if config else None
+```
+
+Update `_load_plugin_config` to delegate to `_load_cascading_config`:
+
+```python
+def _load_plugin_config(name: str) -> dict | None:
+    """Load config for a plugin using cascading lookup from cwd."""
+    return _load_cascading_config(name, Path.cwd())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugins.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "Add cascading plugin config: pyproject.toml, datasets.yaml, env vars"
+```
+
+---
+
+### Task 4: Pipeline helpers (find_url_handler, find_format_reader/writer)
+
+**Files:**
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write tests for pipeline helper methods**
+
+Append to `tests/test_plugins.py`:
+
+```python
+def test_find_url_handler_matching():
+    registry = PluginRegistry()
+    handler = FakeURLHandler()
+    registry._url_handlers.append(handler)
+
+    result = registry.find_url_handler("fake://bucket/file.csv")
+    assert result is handler
+
+
+def test_find_url_handler_no_match():
+    registry = PluginRegistry()
+    handler = FakeURLHandler()
+    registry._url_handlers.append(handler)
+
+    result = registry.find_url_handler("https://example.com/file.csv")
+    assert result is None
+
+
+def test_find_format_reader_matching():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_reader(Path("data.fake"), None)
+    assert result is handler
+
+
+def test_find_format_reader_no_match():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_reader(Path("data.csv"), None)
+    assert result is None
+
+
+def test_find_format_writer_matching():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_writer(Path("data.fake"), None)
+    assert result is handler
+
+
+def test_find_format_writer_no_match():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_writer(Path("data.csv"), None)
+    assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+These methods are already implemented in Task 2. Run to confirm:
+
+Run: `uv run pytest tests/test_plugins.py -v -k "find_"`
+Expected: PASS (all 6 tests)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_plugins.py
+git commit -m "Add tests for pipeline helper methods (find_url_handler, find_format_reader/writer)"
+```
+
+---
+
+### Task 5: Integrate auth providers into fetch_from_url
+
+**Files:**
+- Modify: `src/sunstone/datasets.py`
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write test for auth header injection**
+
+Append to `tests/test_plugins.py`:
+
+```python
+from unittest.mock import MagicMock, patch, PropertyMock
+from sunstone.datasets import DatasetsManager
+from sunstone.lineage import DatasetMetadata, Source, SourceLocation
+
+
+@pytest.fixture
+def dataset_with_url(tmp_path):
+    """Create a minimal project with a dataset that has a source URL."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Test Dataset\n"
+        "    slug: test-dataset\n"
+        "    location: inputs/test.csv\n"
+        "    source:\n"
+        "      name: Test Source\n"
+        "      location:\n"
+        "        data: https://example.com/test.csv\n"
+        "      attributedTo: Test Org\n"
+        "      acquiredAt: '2026-01-01'\n"
+        "      acquisitionMethod: manual-download\n"
+        "      license: CC-BY-4.0\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    return tmp_path
+
+
+def test_fetch_from_url_injects_auth_headers(dataset_with_url):
+    class TestAuth:
+        def authenticate(self, url, headers, dataset):
+            headers["Authorization"] = "Bearer test-token"
+            return headers
+
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()
+    registry._auth_providers.append(TestAuth())
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.datasets._is_public_url", return_value=True),
+        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+
+
+def test_fetch_from_url_stacks_auth_providers(dataset_with_url):
+    class AuthA:
+        def authenticate(self, url, headers, dataset):
+            headers["X-Auth-A"] = "a"
+            return headers
+
+    class AuthB:
+        def authenticate(self, url, headers, dataset):
+            headers["X-Auth-B"] = "b"
+            return headers
+
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()
+    registry._auth_providers.append(AuthA())
+    registry._auth_providers.append(AuthB())
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.datasets._is_public_url", return_value=True),
+        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["X-Auth-A"] == "a"
+        assert kwargs["headers"]["X-Auth-B"] == "b"
+
+
+def test_fetch_from_url_no_auth_still_works(dataset_with_url):
+    """Without auth plugins, fetch works exactly as before."""
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()  # No auth providers
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.datasets._is_public_url", return_value=True),
+        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"] == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "fetch_from_url"`
+Expected: FAIL — `fetch_from_url` doesn't accept/pass headers
+
+- [ ] **Step 3: Modify fetch_from_url to inject auth headers**
+
+In `src/sunstone/datasets.py`, modify the `fetch_from_url` method. Add the import at the top of the method and inject headers from auth providers:
+
+At the top of `datasets.py`, do NOT add an import of `PluginRegistry` at module level (to avoid circular imports). Instead, import it inside the method.
+
+Replace the `fetch_from_url` method body (lines 721-811) with:
+
+```python
+    def fetch_from_url(
+        self,
+        dataset: DatasetMetadata,
+        timeout: int = 30,
+        force: bool = False,
+        max_redirects: int = 10,
+    ) -> Path:
+        """
+        Fetch a dataset from its source URL if available.
+
+        Auth plugins are consulted to inject headers before each HTTP request.
+
+        Args:
+            dataset: The dataset metadata containing source URL.
+            timeout: Request timeout in seconds.
+            force: If True, fetch even if local file exists.
+            max_redirects: Maximum number of redirects to follow (default: 10).
+
+        Returns:
+            Path to the local file (newly downloaded or existing).
+
+        Raises:
+            ValueError: If dataset has no source URL or URL is not allowed.
+            requests.RequestException: If the fetch fails.
+        """
+        if not dataset.source or not dataset.source.location.data:
+            raise ValueError(f"Dataset '{dataset.slug}' has no source URL")
+
+        local_path = self.get_absolute_path(dataset.location)
+
+        # Skip if file exists and not forcing
+        if local_path.exists() and not force:
+            logger.info("Using existing local file: %s", local_path)
+            return local_path
+
+        url = dataset.source.location.data
+
+        # Check if a URL handler plugin can handle this URL
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        url_handler = registry.find_url_handler(url)
+
+        if url_handler:
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            return url_handler.fetch(url, local_path)
+
+        # Fall back to built-in HTTP fetch
+        # Validate URL points to public resource to prevent SSRF attacks
+        if not _is_public_url(url):
+            raise ValueError(
+                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to public internet addresses are permitted."
+            )
+
+        # Collect auth headers from plugins
+        headers: dict[str, str] = {}
+        for auth in registry.get_auth_providers():
+            headers = auth.authenticate(url, headers, dataset)
+
+        logger.info("Fetching dataset from URL: %s", url)
+
+        try:
+            # Disable automatic redirects and handle them manually to prevent SSRF bypass
+            # An attacker could use a public URL that redirects to a private IP
+            current_url = url
+            response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=headers)
+            redirect_count = 0
+
+            while response.is_redirect and redirect_count < max_redirects:
+                redirect_url = response.headers.get("Location")
+                if not redirect_url:
+                    raise ValueError("Redirect response without Location header")
+
+                # Resolve relative URLs against the current URL
+                redirect_url = urljoin(current_url, redirect_url)
+
+                # Validate the redirect target URL for SSRF protection
+                if not _is_public_url(redirect_url):
+                    raise ValueError(
+                        f"Redirect URL '{redirect_url}' is not allowed. Only HTTP/HTTPS URLs "
+                        "pointing to public internet addresses are permitted."
+                    )
+
+                logger.info("Following redirect to: %s", redirect_url)
+                current_url = redirect_url
+                response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=headers)
+                redirect_count += 1
+
+            if response.is_redirect:
+                raise ValueError(f"Too many redirects (max: {max_redirects})")
+
+            response.raise_for_status()
+
+            # Ensure parent directory exists
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save to local file
+            with open(local_path, "wb") as f:
+                f.write(response.content)
+
+            logger.info("✓ Successfully saved to %s (%d bytes)", local_path, len(response.content))
+            return local_path
+
+        except requests.Timeout:
+            logger.error("Request timed out after %d seconds", timeout)
+            raise
+        except requests.RequestException as e:
+            logger.error("Failed to fetch from URL: %s", e)
+            raise
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "fetch_from_url"`
+Expected: PASS (all 3 tests)
+
+- [ ] **Step 5: Run full test suite to verify no regressions**
+
+Run: `uv run pytest -v`
+Expected: PASS (all existing tests still pass)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/datasets.py tests/test_plugins.py
+git commit -m "Integrate auth providers and URL handlers into fetch_from_url"
+```
+
+---
+
+### Task 6: Integrate format handlers into read_dataset
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py`
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write test for format handler in read_dataset**
+
+Append to `tests/test_plugins.py`:
+
+```python
+from sunstone.dataframe import DataFrame
+
+
+@pytest.fixture
+def project_with_fake_format(tmp_path):
+    """Create a project with a dataset using a custom format."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Fake Data\n"
+        "    slug: fake-data\n"
+        "    location: inputs/data.fake\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.fake").write_text("custom format content")
+    return tmp_path
+
+
+def test_read_dataset_uses_format_handler(project_with_fake_format):
+    registry = PluginRegistry()
+    registry._format_handlers.append(FakeFormatHandler())
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        df = DataFrame.read_dataset("fake-data", project_path=project_with_fake_format)
+        assert list(df.data.columns) == ["x"]
+        assert len(df.data) == 3
+
+
+def test_read_dataset_builtin_format_still_works(tmp_path):
+    """CSV reading still works without any plugins."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: CSV Data\n"
+        "    slug: csv-data\n"
+        "    location: inputs/data.csv\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n3,4\n")
+
+    registry = PluginRegistry()  # No format handlers
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        df = DataFrame.read_dataset("csv-data", project_path=tmp_path)
+        assert list(df.data.columns) == ["a", "b"]
+        assert len(df.data) == 2
+
+
+def test_read_dataset_plugin_overrides_builtin(tmp_path):
+    """A plugin that handles .csv overrides the builtin CSV reader."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: CSV Data\n"
+        "    slug: csv-data\n"
+        "    location: inputs/data.csv\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n")
+
+    class CustomCSVHandler:
+        def can_read(self, path, format):
+            return path.suffix == ".csv"
+
+        def read(self, path, **kwargs):
+            return pd.DataFrame({"custom": [True]})
+
+        def can_write(self, path, format):
+            return False
+
+        def write(self, df, path, **kwargs):
+            pass
+
+    registry = PluginRegistry()
+    registry._format_handlers.append(CustomCSVHandler())
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        df = DataFrame.read_dataset("csv-data", project_path=tmp_path)
+        assert list(df.data.columns) == ["custom"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "read_dataset"`
+Expected: FAIL — `read_dataset` doesn't consult format handlers
+
+- [ ] **Step 3: Refactor read_dataset to use plugin pipeline**
+
+In `src/sunstone/dataframe.py`, modify the `read_dataset` classmethod. Replace lines 160-194 (the format detection and reading section) with:
+
+```python
+        # Determine format from extension (for builtin fallback)
+        extension = absolute_path.suffix.lower()
+        if format is None:
+            format_map = {
+                ".csv": "csv",
+                ".json": "json",
+                ".xlsx": "excel",
+                ".xls": "excel",
+                ".parquet": "parquet",
+                ".tsv": "tsv",
+                ".txt": "tsv",  # Assume tab-delimited for .txt
+            }
+            format = format_map.get(extension)
+
+        # Check plugin format handlers first
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_handler = registry.find_format_reader(absolute_path, format)
+
+        if format_handler:
+            df = format_handler.read(absolute_path, **kwargs)
+        else:
+            # Fall back to built-in readers
+            if format is None:
+                raise ValueError(
+                    f"Cannot auto-detect format for file extension '{extension}'. "
+                    f"Supported extensions: .csv, .json, .xlsx, .xls, .parquet, .tsv, .txt. "
+                    f"Please specify format explicitly using the 'format' parameter."
+                )
+
+            reader_map: dict[str, Callable[..., pd.DataFrame]] = {
+                "csv": pd.read_csv,
+                "json": pd.read_json,
+                "excel": pd.read_excel,
+                "parquet": pd.read_parquet,
+                "tsv": lambda path, **kw: pd.read_csv(path, sep="\t", **kw),
+            }
+
+            reader = reader_map.get(format)
+            if reader is None:
+                raise ValueError(
+                    f"Unsupported format '{format}'. Supported formats: {', '.join(reader_map.keys())}"
+                )
+
+            df = reader(absolute_path, **kwargs)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "read_dataset"`
+Expected: PASS (all 3 tests)
+
+- [ ] **Step 5: Run full test suite to verify no regressions**
+
+Run: `uv run pytest -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/dataframe.py tests/test_plugins.py
+git commit -m "Integrate format handler plugins into read_dataset pipeline"
+```
+
+---
+
+### Task 7: Integrate format handlers into to_csv (write path)
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py`
+- Modify: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write test for format handler in write path**
+
+Append to `tests/test_plugins.py`:
+
+```python
+def test_to_csv_uses_format_writer(tmp_path):
+    """When a format handler matches, it handles the write."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs: []\n"
+        "outputs:\n"
+        "  - name: Fake Output\n"
+        "    slug: fake-output\n"
+        "    location: outputs/data.fake\n"
+        "    fields:\n"
+        "      - name: x\n"
+        "        type: integer\n"
+    )
+    (tmp_path / "outputs").mkdir()
+
+    write_called = []
+
+    class TrackingFormatHandler:
+        def can_read(self, path, format):
+            return path.suffix == ".fake"
+
+        def read(self, path, **kwargs):
+            return pd.DataFrame()
+
+        def can_write(self, path, format):
+            return path.suffix == ".fake"
+
+        def write(self, df, path, **kwargs):
+            write_called.append(path)
+            df.to_csv(path)
+
+    registry = PluginRegistry()
+    registry._format_handlers.append(TrackingFormatHandler())
+
+    df = DataFrame(data=pd.DataFrame({"x": [1, 2, 3]}), project_path=tmp_path)
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.dataframe.compute_dataframe_hash", return_value="abc123"),
+        patch("sunstone.session.detect_execution_context", return_value={}),
+    ):
+        df.to_csv("outputs/data.fake", index=False)
+
+    assert len(write_called) == 1
+    assert write_called[0].name == "data.fake"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "to_csv_uses_format_writer"`
+Expected: FAIL — `to_csv` doesn't consult format handlers
+
+- [ ] **Step 3: Modify to_csv to check format handlers**
+
+In `src/sunstone/dataframe.py`, in the `to_csv` method, replace the line `self.data.to_csv(absolute_path, **pandas_kwargs)` (line 486) with:
+
+```python
+        # Check if a format handler plugin can write this file
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_writer = registry.find_format_writer(absolute_path, None)
+
+        if format_writer:
+            format_writer.write(self.data, absolute_path, **pandas_kwargs)
+        else:
+            self.data.to_csv(absolute_path, **pandas_kwargs)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugins.py -v -k "to_csv"`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/dataframe.py tests/test_plugins.py
+git commit -m "Integrate format handler plugins into to_csv write pipeline"
+```
+
+---
+
+### Task 8: Export plugins from __init__.py and add CHANGELOG entry
+
+**Files:**
+- Modify: `src/sunstone/__init__.py`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add plugin exports to __init__.py**
+
+In `src/sunstone/__init__.py`, add after the existing lineage imports:
+
+```python
+# Plugin system
+from .plugins import AuthProvider, FormatHandler, PluginRegistry, URLHandler
+```
+
+And add to `__all__`:
+
+```python
+    # Plugin system
+    "AuthProvider",
+    "URLHandler",
+    "FormatHandler",
+    "PluginRegistry",
+```
+
+- [ ] **Step 2: Verify imports work**
+
+Run: `uv run python -c "from sunstone import AuthProvider, URLHandler, FormatHandler, PluginRegistry; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Add CHANGELOG entry**
+
+Add to the `[Unreleased]` section of `CHANGELOG.md`:
+
+```
+- Added: Plugin system with AuthProvider, URLHandler, and FormatHandler protocols
+- Added: Plugin discovery via Python entry points (`sunstone.plugins` group)
+- Added: Cascading plugin config from pyproject.toml, datasets.yaml, and environment variables
+- Added: Auth header injection in dataset URL fetching
+- Added: Format handler integration in read and write pipelines
+```
+
+- [ ] **Step 4: Run full test suite one final time**
+
+Run: `uv run pytest -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/__init__.py CHANGELOG.md
+git commit -m "Export plugin protocols and add CHANGELOG entries"
+```

--- a/docs/superpowers/plans/2026-04-03-stream-based-plugin-io.md
+++ b/docs/superpowers/plans/2026-04-03-stream-based-plugin-io.md
@@ -1,0 +1,1884 @@
+# Stream-Based Plugin IO Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace path-based plugin IO with stream-based `open()` protocol so all data reads/writes (local, HTTP, GCS, S3/R2) go through a uniform file-like interface.
+
+**Architecture:** URLHandler gets `open(url, mode) -> BinaryIO | TextIO` as its core method. FormatHandler shifts from `Path` to `BinaryIO` streams. A new `LocalFileHandler` makes even local paths go through the plugin system. Cloud handlers (GCS, S3/R2) become optional extras. The CLI's GCS upload logic moves into a `packaging.py` library module that uses URLHandler for uploads. `requests` is replaced by `urllib.request`.
+
+**Tech Stack:** Python 3.12+ typing (`BinaryIO`, `TextIO`, `Literal`, `overload`), `urllib.request`, `io` module, `google-cloud-storage` (optional), `boto3` (optional)
+
+---
+
+### Task 1: Update URLHandler protocol to stream-based `open()`
+
+**Files:**
+- Modify: `src/sunstone/plugins.py:22-42` (URLHandler protocol)
+- Test: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write failing test for new URLHandler protocol**
+
+In `tests/test_plugins.py`, replace `FakeURLHandler` and add a test for the new protocol shape:
+
+```python
+class FakeURLHandler:
+    def can_handle(self, url):
+        return url.startswith("fake://")
+
+    def open(self, url, mode="rb"):
+        import io
+        if "b" in mode:
+            return io.BytesIO(b"col1,col2\na,b\n")
+        else:
+            return io.StringIO("col1,col2\na,b\n")
+
+
+def test_url_handler_structural_typing():
+    assert isinstance(FakeURLHandler(), URLHandler)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_plugins.py::test_url_handler_structural_typing -v`
+Expected: FAIL — FakeURLHandler has `open()` but protocol still expects `fetch()`
+
+- [ ] **Step 3: Update URLHandler protocol in plugins.py**
+
+Replace the URLHandler protocol definition in `src/sunstone/plugins.py`:
+
+```python
+from typing import BinaryIO, Literal, TextIO, Protocol, overload, runtime_checkable
+
+@runtime_checkable
+class URLHandler(Protocol):
+    """Resolves URLs to readable/writable streams."""
+
+    def can_handle(self, url: str) -> bool:
+        """Return True if this handler can resolve the given URL."""
+        ...
+
+    @overload
+    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
+
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        """Open a URL for reading or writing. Returns a file-like object."""
+        ...
+```
+
+- [ ] **Step 4: Add `fetch()` convenience method to PluginRegistry**
+
+In `src/sunstone/plugins.py`, add to PluginRegistry:
+
+```python
+import builtins
+import shutil
+
+class PluginRegistry:
+    # ... existing methods ...
+
+    def fetch(self, url: str, dest: Path) -> Path:
+        """Convenience: download url to local file via open()."""
+        handler = self.find_url_handler(url)
+        if handler is None:
+            raise ValueError(f"No URL handler found for: {url}")
+        with handler.open(url, "rb") as src, builtins.open(dest, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        return dest
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_plugins.py::test_url_handler_structural_typing -v`
+Expected: PASS
+
+- [ ] **Step 6: Write test for PluginRegistry.fetch() convenience**
+
+```python
+def test_registry_fetch_convenience(tmp_path):
+    registry = PluginRegistry()
+    registry._url_handlers.append(FakeURLHandler())
+
+    dest = tmp_path / "out.csv"
+    result = registry.fetch("fake://data.csv", dest)
+    assert result == dest
+    assert dest.read_bytes() == b"col1,col2\na,b\n"
+
+
+def test_registry_fetch_no_handler():
+    registry = PluginRegistry()
+    with pytest.raises(ValueError, match="No URL handler found"):
+        registry.fetch("unknown://data.csv", Path("/tmp/out"))
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `uv run pytest tests/test_plugins.py::test_registry_fetch_convenience tests/test_plugins.py::test_registry_fetch_no_handler -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "Change URLHandler protocol to stream-based open()"
+```
+
+---
+
+### Task 2: Update FormatHandler protocol to stream-based IO
+
+**Files:**
+- Modify: `src/sunstone/plugins.py:44-62` (FormatHandler protocol)
+- Test: `tests/test_plugins.py`
+
+- [ ] **Step 1: Update FakeFormatHandler and write failing test**
+
+In `tests/test_plugins.py`, update the fake handlers to use streams:
+
+```python
+class FakeFormatHandler:
+    def can_read(self, path, format):
+        return str(path).endswith(".fake")
+
+    def read(self, stream, **kwargs):
+        import io
+        return pd.read_csv(stream)
+
+    def can_write(self, path, format):
+        return str(path).endswith(".fake")
+
+    def write(self, df, stream, **kwargs):
+        df.to_csv(stream)
+
+
+class PartialFormatHandler:
+    """Only implements read, not write."""
+
+    def can_read(self, path, format):
+        return True
+
+    def read(self, stream, **kwargs):
+        return pd.DataFrame()
+
+
+def test_format_handler_structural_typing():
+    assert isinstance(FakeFormatHandler(), FormatHandler)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_plugins.py::test_format_handler_structural_typing -v`
+Expected: FAIL — protocol still expects `Path` parameters
+
+- [ ] **Step 3: Update FormatHandler protocol in plugins.py**
+
+Replace the FormatHandler protocol definition:
+
+```python
+@runtime_checkable
+class FormatHandler(Protocol):
+    """Reads and writes data formats."""
+
+    def can_read(self, path: str, format: str | None) -> bool:
+        """Return True if this handler can read the given format. path is used for extension detection."""
+        ...
+
+    def read(self, stream: BinaryIO, **kwargs: object) -> pd.DataFrame:
+        """Read stream into a pandas DataFrame."""
+        ...
+
+    def can_write(self, path: str, format: str | None) -> bool:
+        """Return True if this handler can write the given format. path is used for extension detection."""
+        ...
+
+    def write(self, df: pd.DataFrame, stream: BinaryIO, **kwargs: object) -> None:
+        """Write DataFrame to stream."""
+        ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_plugins.py::test_format_handler_structural_typing -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "Change FormatHandler protocol to use BinaryIO streams"
+```
+
+---
+
+### Task 3: Implement LocalFileHandler
+
+**Files:**
+- Modify: `src/sunstone/handlers.py` (add LocalFileHandler)
+- Test: `tests/test_handlers.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_handlers.py`:
+
+```python
+from sunstone.handlers import LocalFileHandler
+
+
+@pytest.fixture
+def local_handler():
+    return LocalFileHandler()
+
+
+class TestLocalFileHandlerCanHandle:
+    def test_bare_relative_path(self, local_handler):
+        assert local_handler.can_handle("data.csv")
+
+    def test_bare_absolute_path(self, local_handler):
+        assert local_handler.can_handle("/tmp/data.csv")
+
+    def test_file_scheme(self, local_handler):
+        assert local_handler.can_handle("file:///tmp/data.csv")
+
+    def test_http_scheme(self, local_handler):
+        assert not local_handler.can_handle("http://example.com/data.csv")
+
+    def test_gs_scheme(self, local_handler):
+        assert not local_handler.can_handle("gs://bucket/data.csv")
+
+    def test_s3_scheme(self, local_handler):
+        assert not local_handler.can_handle("s3://bucket/data.csv")
+
+    def test_r2_scheme(self, local_handler):
+        assert not local_handler.can_handle("r2://bucket/data.csv")
+
+
+class TestLocalFileHandlerOpen:
+    def test_read_binary(self, local_handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_bytes(b"a,b\n1,2\n")
+        with local_handler.open(str(f), "rb") as stream:
+            assert stream.read() == b"a,b\n1,2\n"
+
+    def test_read_text(self, local_handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n1,2\n")
+        with local_handler.open(str(f), "r") as stream:
+            assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_binary(self, local_handler, tmp_path):
+        f = tmp_path / "out.csv"
+        with local_handler.open(str(f), "wb") as stream:
+            stream.write(b"a,b\n1,2\n")
+        assert f.read_bytes() == b"a,b\n1,2\n"
+
+    def test_write_text(self, local_handler, tmp_path):
+        f = tmp_path / "out.csv"
+        with local_handler.open(str(f), "w") as stream:
+            stream.write("a,b\n1,2\n")
+        assert f.read_text() == "a,b\n1,2\n"
+
+    def test_file_scheme(self, local_handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_bytes(b"a,b\n1,2\n")
+        with local_handler.open(f"file://{f}", "rb") as stream:
+            assert stream.read() == b"a,b\n1,2\n"
+
+    def test_creates_parent_dirs_on_write(self, local_handler, tmp_path):
+        f = tmp_path / "sub" / "dir" / "out.csv"
+        with local_handler.open(str(f), "wb") as stream:
+            stream.write(b"data")
+        assert f.read_bytes() == b"data"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_handlers.py::TestLocalFileHandlerCanHandle tests/test_handlers.py::TestLocalFileHandlerOpen -v`
+Expected: FAIL — LocalFileHandler doesn't exist yet
+
+- [ ] **Step 3: Implement LocalFileHandler**
+
+Add to `src/sunstone/handlers.py`:
+
+```python
+import builtins
+from typing import BinaryIO, TextIO
+from urllib.parse import urlparse
+
+
+_REMOTE_SCHEMES = {"http", "https", "gs", "s3", "r2"}
+
+
+class LocalFileHandler:
+    """Handles local filesystem paths and file:// URLs."""
+
+    def can_handle(self, url: str) -> bool:
+        parsed = urlparse(url)
+        return parsed.scheme in ("", "file") and parsed.scheme not in _REMOTE_SCHEMES
+
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        parsed = urlparse(url)
+        if parsed.scheme == "file":
+            path = Path(parsed.path)
+        else:
+            path = Path(url)
+
+        if "w" in mode:
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+        return builtins.open(path, mode)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_handlers.py::TestLocalFileHandlerCanHandle tests/test_handlers.py::TestLocalFileHandlerOpen -v`
+Expected: PASS
+
+- [ ] **Step 5: Register LocalFileHandler as last fallback in PluginRegistry._discover()**
+
+In `src/sunstone/plugins.py`, update `_discover()`:
+
+```python
+def _discover(self) -> None:
+    """Load plugins from entry points, then register internal handlers."""
+    for ep in _get_entry_points():
+        try:
+            plugin_cls = ep.load()
+            config = _load_plugin_config(ep.name)
+            plugin = plugin_cls(config) if config else plugin_cls()
+            self._register(ep.name, plugin)
+        except Exception:
+            logger.exception("Failed to load plugin '%s'", ep.name)
+
+    from .handlers import BuiltinFormatHandler, HttpURLHandler, LocalFileHandler
+
+    self._format_handlers.append(BuiltinFormatHandler())
+    self._url_handlers.append(HttpURLHandler())
+    self._url_handlers.append(LocalFileHandler())  # last fallback
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/handlers.py src/sunstone/plugins.py tests/test_handlers.py
+git commit -m "Add LocalFileHandler for local paths and file:// URLs"
+```
+
+---
+
+### Task 4: Refactor BuiltinFormatHandler to use streams
+
+**Files:**
+- Modify: `src/sunstone/handlers.py:44-69` (BuiltinFormatHandler)
+- Modify: `tests/test_handlers.py`
+
+- [ ] **Step 1: Update tests to use streams**
+
+Replace the read/write test classes in `tests/test_handlers.py`:
+
+```python
+import io
+
+
+class TestBuiltinFormatHandlerCanRead:
+    def test_csv(self, handler):
+        assert handler.can_read("data.csv", None)
+
+    def test_csv_with_format(self, handler):
+        assert handler.can_read("data.whatever", "csv")
+
+    def test_json(self, handler):
+        assert handler.can_read("data.json", None)
+
+    def test_excel_xlsx(self, handler):
+        assert handler.can_read("data.xlsx", None)
+
+    def test_excel_xls(self, handler):
+        assert handler.can_read("data.xls", None)
+
+    def test_parquet(self, handler):
+        assert handler.can_read("data.parquet", None)
+
+    def test_tsv(self, handler):
+        assert handler.can_read("data.tsv", None)
+
+    def test_txt_as_tsv(self, handler):
+        assert handler.can_read("data.txt", None)
+
+    def test_unknown_extension(self, handler):
+        assert not handler.can_read("data.hdf5", None)
+
+    def test_unknown_format_string(self, handler):
+        assert not handler.can_read("data.whatever", "hdf5")
+
+    def test_url_path(self, handler):
+        assert handler.can_read("gs://bucket/data.csv", None)
+
+    def test_url_path_with_format(self, handler):
+        assert handler.can_read("gs://bucket/data.whatever", "csv")
+
+
+class TestBuiltinFormatHandlerCanWrite:
+    def test_csv(self, handler):
+        assert handler.can_write("data.csv", None)
+
+    def test_csv_with_format(self, handler):
+        assert handler.can_write("data.whatever", "csv")
+
+    def test_unknown(self, handler):
+        assert not handler.can_write("data.hdf5", None)
+
+
+class TestBuiltinFormatHandlerRead:
+    def test_read_csv(self, handler):
+        stream = io.BytesIO(b"a,b\n1,2\n3,4\n")
+        df = handler.read(stream)
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_read_tsv(self, handler):
+        stream = io.BytesIO(b"a\tb\n1\t2\n3\t4\n")
+        df = handler.read(stream, sep="\t")
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_read_json(self, handler):
+        stream = io.BytesIO(b'[{"a": 1, "b": 2}]')
+        df = handler.read(stream)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_parquet(self, handler, tmp_path):
+        # Parquet needs real bytes, create via file
+        f = tmp_path / "data.parquet"
+        pd.DataFrame({"a": [1], "b": [2]}).to_parquet(f)
+        stream = io.BytesIO(f.read_bytes())
+        df = handler.read(stream)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_passes_kwargs(self, handler):
+        stream = io.BytesIO(b"a,b\n1,2\n3,4\n")
+        df = handler.read(stream, usecols=["a"])
+        assert list(df.columns) == ["a"]
+
+
+class TestBuiltinFormatHandlerWrite:
+    def test_write_csv(self, handler):
+        stream = io.BytesIO()
+        df = pd.DataFrame({"x": [1, 2]})
+        handler.write(df, stream, index=False)
+        stream.seek(0)
+        result = pd.read_csv(stream)
+        assert list(result.columns) == ["x"]
+        assert len(result) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_handlers.py::TestBuiltinFormatHandlerRead tests/test_handlers.py::TestBuiltinFormatHandlerWrite -v`
+Expected: FAIL — handler still expects Path, not stream
+
+- [ ] **Step 3: Refactor BuiltinFormatHandler**
+
+Note: `can_read`/`can_write` now take a `str` (path or URL) for extension detection. `read`/`write` take `BinaryIO` streams. The handler needs to know the format for `read()` — this is passed via a `format` kwarg or stored when `can_read` is called. Simplest approach: `read()` receives a `format` kwarg from the caller (the pipeline in dataframe.py).
+
+Actually, the cleaner design: `BuiltinFormatHandler` stores the resolved format from `can_read`/`can_write` as instance state. But since the registry might call `can_read` and then `read` on the same instance, this creates coupling. Better: the pipeline passes format explicitly, or the handler re-resolves from a path string.
+
+Simplest: add an optional `format` kwarg to `read()` and `write()` and pass the path string so the handler can re-resolve:
+
+```python
+from typing import BinaryIO
+from pathlib import PurePosixPath
+from urllib.parse import urlparse
+
+
+class BuiltinFormatHandler:
+    """Handles CSV, JSON, Excel, Parquet, and TSV formats using pandas."""
+
+    def _resolve_format(self, path: str, format: str | None) -> str | None:
+        """Resolve a format string from explicit format or file extension."""
+        if format is not None:
+            return format if format in _READER_MAP or format in _WRITER_MAP else None
+        # Extract extension from path or URL
+        parsed = urlparse(path)
+        file_path = parsed.path if parsed.scheme else path
+        suffix = PurePosixPath(file_path).suffix.lower()
+        return _EXTENSION_MAP.get(suffix)
+
+    def can_read(self, path: str, format: str | None) -> bool:
+        fmt = self._resolve_format(path, format)
+        return fmt is not None and fmt in _READER_MAP
+
+    def read(self, stream: BinaryIO, **kwargs: object) -> pd.DataFrame:
+        # The caller must pass format= or path= so we know which reader to use.
+        # Convention: pipeline passes format= when calling read().
+        fmt = kwargs.pop("format", None)
+        path = kwargs.pop("path", None)
+        if fmt is None and path is not None:
+            fmt = self._resolve_format(str(path), None)
+        if fmt is None:
+            fmt = "csv"  # safe default for BinaryIO
+        reader = _READER_MAP[fmt]
+        return reader(stream, **kwargs)
+
+    def can_write(self, path: str, format: str | None) -> bool:
+        fmt = self._resolve_format(path, format)
+        return fmt is not None and fmt in _WRITER_MAP
+
+    def write(self, df: pd.DataFrame, stream: BinaryIO, **kwargs: object) -> None:
+        fmt = kwargs.pop("format", None)
+        path = kwargs.pop("path", None)
+        if fmt is None and path is not None:
+            fmt = self._resolve_format(str(path), None)
+        if fmt is None:
+            fmt = "csv"
+        method_name = _WRITER_MAP[fmt]
+        writer = getattr(df, method_name)
+        writer(stream, **kwargs)
+```
+
+Also update the `_READER_MAP` to remove the old tsv lambda (since TSV is now just `pd.read_csv` with `sep="\t"` passed by the caller or by the pipeline):
+
+Actually, keep TSV in the reader map — it's cleaner:
+
+```python
+_READER_MAP: dict[str, Callable[..., pd.DataFrame]] = {
+    "csv": pd.read_csv,
+    "json": pd.read_json,
+    "excel": pd.read_excel,
+    "parquet": pd.read_parquet,
+    "tsv": lambda stream, **kw: pd.read_csv(stream, sep="\t", **kw),
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_handlers.py::TestBuiltinFormatHandlerCanRead tests/test_handlers.py::TestBuiltinFormatHandlerCanWrite tests/test_handlers.py::TestBuiltinFormatHandlerRead tests/test_handlers.py::TestBuiltinFormatHandlerWrite -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers.py tests/test_handlers.py
+git commit -m "Refactor BuiltinFormatHandler to use BinaryIO streams"
+```
+
+---
+
+### Task 5: Refactor HttpURLHandler to use `urllib.request` and `open()`
+
+**Files:**
+- Modify: `src/sunstone/handlers.py:72-175` (HttpURLHandler)
+- Modify: `tests/test_handlers.py`
+
+- [ ] **Step 1: Write new tests for stream-based HttpURLHandler**
+
+Replace `TestHttpURLHandlerFetch` in `tests/test_handlers.py`:
+
+```python
+import io
+from urllib.error import HTTPError
+
+
+class TestHttpURLHandlerOpen:
+    def test_read_binary(self, http_handler):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"a,b\n1,2\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.urlopen", return_value=mock_response),
+        ):
+            stream = http_handler.open("https://example.com/data.csv", "rb")
+            assert stream.read() == b"a,b\n1,2\n"
+
+    def test_read_text(self, http_handler):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"a,b\n1,2\n"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.urlopen", return_value=mock_response),
+        ):
+            stream = http_handler.open("https://example.com/data.csv", "r")
+            assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_raises(self, http_handler):
+        with pytest.raises(NotImplementedError):
+            http_handler.open("https://example.com/data.csv", "wb")
+
+    def test_rejects_private_url(self, http_handler):
+        with patch("sunstone.handlers._is_public_url", return_value=False):
+            with pytest.raises(ValueError, match="not allowed"):
+                http_handler.open("http://192.168.1.1/data.csv", "rb")
+
+    def test_strips_auth_on_cross_origin_redirect(self, http_handler):
+        # First request returns redirect
+        redirect_error = HTTPError(
+            "https://example.com/data.csv", 302, "Redirect",
+            {"Location": "https://other.com/data.csv"}, io.BytesIO(b"")
+        )
+        final_response = MagicMock()
+        final_response.read.return_value = b"data"
+        final_response.__enter__ = MagicMock(return_value=final_response)
+        final_response.__exit__ = MagicMock(return_value=False)
+
+        http_handler.headers = {"Authorization": "Bearer secret"}
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.urlopen", side_effect=[redirect_error, final_response]) as mock_urlopen,
+        ):
+            http_handler.open("https://example.com/data.csv", "rb")
+            second_call = mock_urlopen.call_args_list[1]
+            request = second_call[0][0]
+            assert "Authorization" not in request.headers
+```
+
+Note: The redirect handling with `urllib` differs from `requests` — we'll use a custom opener with redirect handling disabled, or handle `HTTPError` for redirects. The implementation will clarify the exact mock shape. Tests may need minor adjustments during implementation.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_handlers.py::TestHttpURLHandlerOpen -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement stream-based HttpURLHandler**
+
+Replace HttpURLHandler in `src/sunstone/handlers.py`:
+
+```python
+import io
+from typing import BinaryIO, TextIO
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+
+class HttpURLHandler:
+    """Fetches datasets from HTTP/HTTPS URLs with SSRF protection."""
+
+    def __init__(self, timeout: int = 30, max_redirects: int = 10) -> None:
+        self.timeout = timeout
+        self.max_redirects = max_redirects
+        self.headers: dict[str, str] = {}
+
+    def can_handle(self, url: str) -> bool:
+        parsed = urlparse(url)
+        return parsed.scheme in ("http", "https")
+
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        if "w" in mode:
+            raise NotImplementedError(
+                "HTTP write is not supported. Use a cloud storage handler (gs://, s3://) for uploads."
+            )
+
+        if not _is_public_url(url):
+            raise ValueError(
+                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to "
+                "public internet addresses are permitted."
+            )
+
+        logger.info("Fetching dataset from URL: %s", url)
+
+        current_url = url
+        current_headers = dict(self.headers)
+        redirect_count = 0
+
+        while redirect_count <= self.max_redirects:
+            request = Request(current_url, headers=current_headers)
+            try:
+                response = urlopen(request, timeout=self.timeout)  # noqa: S310
+                break
+            except HTTPError as e:
+                if e.status in (301, 302, 303, 307, 308):
+                    redirect_url = e.headers.get("Location")
+                    if not redirect_url:
+                        raise ValueError("Redirect response without Location header") from e
+
+                    redirect_url = urljoin(current_url, redirect_url)
+
+                    if not _is_public_url(redirect_url):
+                        raise ValueError(
+                            f"Redirect URL '{redirect_url}' is not allowed. Only HTTP/HTTPS URLs "
+                            "pointing to public internet addresses are permitted."
+                        ) from e
+
+                    # Strip auth headers on cross-origin redirects
+                    redirect_parsed = urlparse(redirect_url)
+                    original_parsed = urlparse(url)
+                    if (redirect_parsed.scheme != original_parsed.scheme
+                            or redirect_parsed.netloc != original_parsed.netloc):
+                        current_headers = {
+                            k: v for k, v in current_headers.items()
+                            if k.lower() != "authorization"
+                        }
+
+                    logger.info("Following redirect to: %s", redirect_url)
+                    current_url = redirect_url
+                    redirect_count += 1
+                else:
+                    raise
+        else:
+            raise ValueError(f"Too many redirects (max: {self.max_redirects})")
+
+        data = response.read()
+        logger.info("Fetched %d bytes from %s", len(data), current_url)
+
+        if "b" in mode:
+            return io.BytesIO(data)
+        else:
+            return io.TextIOWrapper(io.BytesIO(data), encoding="utf-8")
+```
+
+Also add `from urllib.error import HTTPError` to the imports and remove `import requests`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_handlers.py::TestHttpURLHandlerOpen tests/test_handlers.py::TestHttpURLHandlerCanHandle -v`
+Expected: PASS (may need to adjust mocks for urllib vs requests patterns — fix as needed)
+
+- [ ] **Step 5: Update the auth integration test**
+
+Update `test_fetch_from_url_delegates_auth_to_http_handler` in `tests/test_handlers.py` to use the new `open()` and `registry.fetch()` flow:
+
+```python
+def test_fetch_from_url_delegates_auth_to_http_handler(tmp_path):
+    """Auth providers set headers on the HttpURLHandler before fetch."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Test Dataset\n"
+        "    slug: test-dataset\n"
+        "    location: inputs/test.csv\n"
+        "    source:\n"
+        "      name: Test Source\n"
+        "      location:\n"
+        "        data: https://example.com/test.csv\n"
+        "      attributedTo: Test Org\n"
+        "      acquiredAt: '2026-01-01'\n"
+        "      acquisitionMethod: manual-download\n"
+        "      license: CC-BY-4.0\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+
+    from sunstone.datasets import DatasetsManager
+    from sunstone.plugins import PluginRegistry
+
+    manager = DatasetsManager(tmp_path)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    class TestAuth:
+        def authenticate(self, url, headers, dataset):
+            headers["Authorization"] = "Bearer test-token"
+            return headers
+
+    handler = HttpURLHandler()
+    registry = PluginRegistry()
+    registry._auth_providers.append(TestAuth())
+    registry._url_handlers.append(handler)
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.urlopen") as mock_urlopen,
+    ):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"col1,col2\na,b\n"
+        mock_urlopen.return_value = mock_response
+
+        manager.fetch_from_url(dataset, force=True)
+
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.get_header("Authorization") == "Bearer test-token"
+```
+
+- [ ] **Step 6: Run all handler tests**
+
+Run: `uv run pytest tests/test_handlers.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sunstone/handlers.py tests/test_handlers.py
+git commit -m "Refactor HttpURLHandler to use urllib.request and open()"
+```
+
+---
+
+### Task 6: Update fetch_from_url to use registry.fetch()
+
+**Files:**
+- Modify: `src/sunstone/datasets.py:656-708`
+- Test: `tests/test_datasets.py`
+
+- [ ] **Step 1: Write test for deprecated fetch_from_url using registry.fetch()**
+
+Check existing tests in `tests/test_datasets.py` that call `fetch_from_url`. Update them to work with the new flow if needed. Add a deprecation test:
+
+```python
+import warnings
+
+def test_fetch_from_url_emits_deprecation_warning(tmp_path):
+    """fetch_from_url should emit a DeprecationWarning."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Test\n"
+        "    slug: test\n"
+        "    location: inputs/test.csv\n"
+        "    source:\n"
+        "      name: Source\n"
+        "      location:\n"
+        "        data: https://example.com/test.csv\n"
+        "      attributedTo: Org\n"
+        "      acquiredAt: '2026-01-01'\n"
+        "      acquisitionMethod: manual-download\n"
+        "      license: CC-BY-4.0\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+
+    from sunstone.datasets import DatasetsManager
+    from sunstone.plugins import PluginRegistry
+
+    manager = DatasetsManager(tmp_path)
+    dataset = manager.find_dataset_by_slug("test")
+
+    registry = PluginRegistry()
+    mock_handler = MagicMock()
+    mock_handler.can_handle.return_value = True
+    mock_handler.open.return_value = io.BytesIO(b"data")
+    registry._url_handlers.append(mock_handler)
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        warnings.catch_warnings(record=True) as w,
+    ):
+        warnings.simplefilter("always")
+        manager.fetch_from_url(dataset, force=True)
+        assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+```
+
+- [ ] **Step 2: Refactor fetch_from_url**
+
+Replace the body of `fetch_from_url` in `src/sunstone/datasets.py`:
+
+```python
+import warnings
+
+def fetch_from_url(
+    self,
+    dataset: DatasetMetadata,
+    timeout: int = 30,
+    force: bool = False,
+    max_redirects: int = 10,
+) -> Path:
+    """Fetch a dataset from its source URL. Deprecated: use PluginRegistry.fetch() directly."""
+    warnings.warn(
+        "fetch_from_url is deprecated. Use PluginRegistry.get().fetch(url, dest) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    if not dataset.source or not dataset.source.location.data:
+        raise ValueError(f"Dataset '{dataset.slug}' has no source URL")
+
+    local_path = self.get_absolute_path(dataset.location)
+
+    if local_path.exists() and not force:
+        logger.info("Using existing local file: %s", local_path)
+        return local_path
+
+    url = dataset.source.location.data
+
+    from .plugins import PluginRegistry
+
+    registry = PluginRegistry.get()
+
+    # Inject auth into the URL handler if applicable
+    url_handler = registry.find_url_handler(url)
+    if url_handler is None:
+        raise ValueError(f"No URL handler found for '{url}'.")
+
+    if hasattr(url_handler, "headers"):
+        for auth in registry.get_auth_providers():
+            url_handler.headers = auth.authenticate(url, url_handler.headers, dataset)
+
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    return registry.fetch(url, local_path)
+```
+
+- [ ] **Step 3: Remove unused imports from datasets.py**
+
+Remove `import requests`, `import ipaddress`, `import socket`, `from urllib.parse import urljoin, urlparse` if no longer used elsewhere in the file. Check carefully before removing.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_datasets.py tests/test_handlers.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/datasets.py tests/test_datasets.py
+git commit -m "Deprecate fetch_from_url, delegate to registry.fetch()"
+```
+
+---
+
+### Task 7: Update dataframe.py read pipeline to use streams
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py` (read_dataset, read_csv, read_excel)
+- Test: `tests/test_plugins.py`, `tests/test_dataframe.py`
+
+- [ ] **Step 1: Write test for stream-based read pipeline**
+
+Add to `tests/test_plugins.py`:
+
+```python
+def test_read_dataset_uses_stream_pipeline(tmp_path):
+    """read_dataset should open a stream via URLHandler and pass to FormatHandler."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Test\n"
+        "    slug: test\n"
+        "    location: inputs/test.csv\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "test.csv").write_text("a,b\n1,2\n")
+
+    df = DataFrame.read_dataset("test", project_path=tmp_path)
+    assert list(df.data.columns) == ["a", "b"]
+    assert len(df.data) == 1
+```
+
+This test should already pass with the current code, but serves as a regression test. The real validation is that the internal flow uses `handler.open()` → `format_handler.read(stream)`.
+
+- [ ] **Step 2: Update read_dataset to use stream pipeline**
+
+In `src/sunstone/dataframe.py`, update the read_dataset method's format handling section (around line 160-176):
+
+```python
+        # Open stream via URL handler and read via format handler
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+
+        location = str(absolute_path)
+        format_handler = registry.find_format_reader(location, format)
+
+        if format_handler is None:
+            extension = absolute_path.suffix.lower()
+            raise ValueError(
+                f"No format handler found for '{absolute_path.name}'"
+                + (f" (format='{format}')" if format else f" (extension='{extension}')")
+                + ". Install a plugin or check the file extension."
+            )
+
+        url_handler = registry.find_url_handler(location)
+        if url_handler is None:
+            raise ValueError(f"No URL handler found for '{location}'")
+
+        with url_handler.open(location, "rb") as stream:
+            df = format_handler.read(stream, format=format, path=location, **kwargs)
+```
+
+- [ ] **Step 3: Update read_csv by-path branch similarly**
+
+In the file-path branch of `read_csv` (around line 277-284):
+
+```python
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        location = str(absolute_path)
+        format_handler = registry.find_format_reader(location, "csv")
+        if format_handler is None:
+            raise ValueError("No format handler found for CSV files")
+
+        url_handler = registry.find_url_handler(location)
+        if url_handler is None:
+            raise ValueError(f"No URL handler found for '{location}'")
+
+        with url_handler.open(location, "rb") as stream:
+            df = format_handler.read(stream, format="csv", path=location, **kwargs)
+```
+
+- [ ] **Step 4: Update read_excel by-path branch similarly**
+
+Same pattern as read_csv, with `"excel"` format.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/dataframe.py
+git commit -m "Update read pipeline to use URL handler streams"
+```
+
+---
+
+### Task 8: Update dataframe.py write pipeline to use streams
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py` (to_csv)
+- Test: `tests/test_dataframe.py`
+
+- [ ] **Step 1: Write test for stream-based write**
+
+Add to `tests/test_dataframe.py` or `tests/test_plugins.py`:
+
+```python
+def test_to_csv_uses_stream_pipeline(tmp_path):
+    """to_csv should open a stream via URLHandler and pass to FormatHandler."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text("inputs: []\noutputs: []\n")
+
+    df = DataFrame(
+        data=pd.DataFrame({"a": [1, 2]}),
+        project_path=tmp_path,
+    )
+    df.to_csv("outputs/test.csv", slug="test", name="Test", index=False)
+    result = pd.read_csv(tmp_path / "outputs" / "test.csv")
+    assert list(result.columns) == ["a"]
+    assert len(result) == 2
+```
+
+- [ ] **Step 2: Update to_csv tracked write path**
+
+In `src/sunstone/dataframe.py`, replace the write section (around line 477-490):
+
+```python
+        # Write the data via URL handler + format handler
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        location = str(absolute_path)
+
+        url_handler = registry.find_url_handler(location)
+        format_writer = registry.find_format_writer(location, None)
+
+        if url_handler and format_writer:
+            with url_handler.open(location, "wb") as stream:
+                format_writer.write(self.data, stream, format=None, path=location, **pandas_kwargs)
+        elif format_writer:
+            with open(absolute_path, "wb") as stream:
+                format_writer.write(self.data, stream, format=None, path=location, **pandas_kwargs)
+        else:
+            self.data.to_csv(absolute_path, **pandas_kwargs)
+```
+
+- [ ] **Step 3: Update to_csv untracked write path (track=False)**
+
+Replace the untracked path (around line 445-449):
+
+```python
+        if not track:
+            from .plugins import PluginRegistry
+
+            registry = PluginRegistry.get()
+            location = str(path_or_buf)
+
+            url_handler = registry.find_url_handler(location)
+            if url_handler:
+                with url_handler.open(location, "wb") as stream:
+                    self.data.to_csv(stream, **pandas_kwargs)
+            else:
+                path = Path(path_or_buf)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                self.data.to_csv(path, **pandas_kwargs)
+            return
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/dataframe.py
+git commit -m "Update write pipeline to use URL handler streams"
+```
+
+---
+
+### Task 9: Remove `requests` dependency, add optional extras
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/sunstone/handlers.py` (remove requests import if still present)
+
+- [ ] **Step 1: Update pyproject.toml**
+
+Remove `requests` from dependencies. Add optional extras. Move `google-cloud-storage` to optional:
+
+```toml
+dependencies = [
+    "typer>=0.15",
+    "frictionless>=5.18.1",
+    "google-auth>=2.43.0",
+    "openpyxl>=3.1.0",
+    "pandas>=2.0.0",
+    "pyyaml>=6.0",
+    "ruamel-yaml>=0.18",
+    "pyarrow>=23.0.1",
+]
+
+[project.optional-dependencies]
+gcs = ["google-cloud-storage>=2.0"]
+s3 = ["boto3>=1.28"]
+```
+
+- [ ] **Step 2: Verify no remaining `import requests` in source**
+
+Run: `grep -r "import requests" src/sunstone/`
+Expected: No matches
+
+- [ ] **Step 3: Run uv sync and full test suite**
+
+```bash
+uv sync
+uv run pytest tests/ -v
+```
+
+Expected: PASS (if tests mock requests, those mocks need to be updated to urllib — should already be done in Task 5)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/sunstone/handlers.py
+git commit -m "Remove requests dependency, add gcs and s3 optional extras"
+```
+
+---
+
+### Task 10: Implement GcsURLHandler
+
+**Files:**
+- Create: `src/sunstone/handlers_gcs.py`
+- Test: `tests/test_handlers_gcs.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/test_handlers_gcs.py`:
+
+```python
+"""Tests for GCS URL handler (mocked — no real GCS calls)."""
+
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def gcs_handler():
+    with patch.dict("sys.modules", {"google.cloud": MagicMock(), "google.cloud.storage": MagicMock()}):
+        from sunstone.handlers_gcs import GcsURLHandler
+        return GcsURLHandler()
+
+
+class TestGcsURLHandlerCanHandle:
+    def test_gs_scheme(self, gcs_handler):
+        assert gcs_handler.can_handle("gs://bucket/path/data.csv")
+
+    def test_http_scheme(self, gcs_handler):
+        assert not gcs_handler.can_handle("http://example.com/data.csv")
+
+    def test_s3_scheme(self, gcs_handler):
+        assert not gcs_handler.can_handle("s3://bucket/data.csv")
+
+    def test_local_path(self, gcs_handler):
+        assert not gcs_handler.can_handle("data.csv")
+
+
+class TestGcsURLHandlerOpen:
+    def test_read_binary(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_blob.download_as_bytes.return_value = b"a,b\n1,2\n"
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client = MagicMock()
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/data.csv", "rb")
+        assert stream.read() == b"a,b\n1,2\n"
+
+    def test_read_text(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_blob.download_as_bytes.return_value = b"a,b\n1,2\n"
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client = MagicMock()
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/data.csv", "r")
+        assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_binary(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client = MagicMock()
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/out.csv", "wb")
+        stream.write(b"a,b\n1,2\n")
+        stream.close()
+
+        mock_blob.upload_from_file.assert_called_once()
+
+    def test_write_text(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client = MagicMock()
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/out.csv", "w")
+        stream.write("a,b\n1,2\n")
+        stream.close()
+
+        mock_blob.upload_from_file.assert_called_once()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_handlers_gcs.py -v`
+Expected: FAIL — module doesn't exist
+
+- [ ] **Step 3: Implement GcsURLHandler**
+
+Create `src/sunstone/handlers_gcs.py`:
+
+```python
+"""GCS URL handler. Requires google-cloud-storage (install with sunstone-py[gcs])."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import BinaryIO, TextIO
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class _GcsWriteStream(io.BytesIO):
+    """A BytesIO that uploads to GCS on close()."""
+
+    def __init__(self, blob: object) -> None:
+        super().__init__()
+        self._blob = blob
+
+    def close(self) -> None:
+        if not self.closed:
+            self.seek(0)
+            self._blob.upload_from_file(self)  # type: ignore[union-attr]
+        super().close()
+
+
+class GcsURLHandler:
+    """Handles gs:// URLs using google-cloud-storage."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        from google.cloud import storage  # type: ignore[import-untyped]
+
+        self._client = storage.Client()
+
+    def can_handle(self, url: str) -> bool:
+        return urlparse(url).scheme == "gs"
+
+    def _get_blob(self, url: str) -> object:
+        parsed = urlparse(url)
+        bucket = self._client.bucket(parsed.netloc)
+        blob_path = parsed.path.lstrip("/")
+        return bucket.blob(blob_path)
+
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        blob = self._get_blob(url)
+
+        if "w" in mode:
+            stream = _GcsWriteStream(blob)
+            if "b" not in mode:
+                return io.TextIOWrapper(stream, encoding="utf-8")
+            return stream
+
+        data = blob.download_as_bytes()
+        logger.info("Downloaded %d bytes from %s", len(data), url)
+        binary_stream = io.BytesIO(data)
+
+        if "b" in mode:
+            return binary_stream
+        return io.TextIOWrapper(binary_stream, encoding="utf-8")
+```
+
+- [ ] **Step 4: Register GcsURLHandler in PluginRegistry._discover()**
+
+In `src/sunstone/plugins.py`, add conditional registration in `_discover()`:
+
+```python
+        # Optional cloud handlers
+        try:
+            from .handlers_gcs import GcsURLHandler
+            self._url_handlers.append(GcsURLHandler())
+        except ImportError:
+            pass  # google-cloud-storage not installed
+```
+
+Add this before the LocalFileHandler registration (cloud handlers should have higher priority than local fallback).
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_handlers_gcs.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/handlers_gcs.py src/sunstone/plugins.py tests/test_handlers_gcs.py
+git commit -m "Add GcsURLHandler for gs:// URLs with optional gcs extra"
+```
+
+---
+
+### Task 11: Implement S3URLHandler (covers S3 and R2)
+
+**Files:**
+- Create: `src/sunstone/handlers_s3.py`
+- Test: `tests/test_handlers_s3.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/test_handlers_s3.py`:
+
+```python
+"""Tests for S3/R2 URL handler (mocked — no real AWS calls)."""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def s3_handler():
+    with patch.dict("sys.modules", {"boto3": MagicMock()}):
+        from sunstone.handlers_s3 import S3URLHandler
+        return S3URLHandler()
+
+
+@pytest.fixture
+def r2_handler():
+    with patch.dict("sys.modules", {"boto3": MagicMock()}):
+        from sunstone.handlers_s3 import S3URLHandler
+        return S3URLHandler(config={"endpoint_url": "https://abc123.r2.cloudflarestorage.com"})
+
+
+class TestS3URLHandlerCanHandle:
+    def test_s3_scheme(self, s3_handler):
+        assert s3_handler.can_handle("s3://bucket/data.csv")
+
+    def test_r2_scheme(self, s3_handler):
+        assert s3_handler.can_handle("r2://bucket/data.csv")
+
+    def test_gs_scheme(self, s3_handler):
+        assert not s3_handler.can_handle("gs://bucket/data.csv")
+
+    def test_http_scheme(self, s3_handler):
+        assert not s3_handler.can_handle("http://example.com/data.csv")
+
+
+class TestS3URLHandlerOpen:
+    def test_read_binary(self, s3_handler):
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"a,b\n1,2\n"
+        s3_handler._client = MagicMock()
+        s3_handler._client.get_object.return_value = {"Body": mock_body}
+
+        stream = s3_handler.open("s3://my-bucket/data.csv", "rb")
+        assert stream.read() == b"a,b\n1,2\n"
+
+    def test_read_text(self, s3_handler):
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"a,b\n1,2\n"
+        s3_handler._client = MagicMock()
+        s3_handler._client.get_object.return_value = {"Body": mock_body}
+
+        stream = s3_handler.open("s3://my-bucket/data.csv", "r")
+        assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_binary(self, s3_handler):
+        s3_handler._client = MagicMock()
+
+        stream = s3_handler.open("s3://my-bucket/out.csv", "wb")
+        stream.write(b"a,b\n1,2\n")
+        stream.close()
+
+        s3_handler._client.upload_fileobj.assert_called_once()
+
+    def test_r2_uses_s3_scheme_internally(self, r2_handler):
+        """r2:// URLs should be converted to s3:// bucket/key internally."""
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"data"
+        r2_handler._client = MagicMock()
+        r2_handler._client.get_object.return_value = {"Body": mock_body}
+
+        r2_handler.open("r2://my-bucket/data.csv", "rb")
+        r2_handler._client.get_object.assert_called_once_with(
+            Bucket="my-bucket", Key="data.csv"
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_handlers_s3.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement S3URLHandler**
+
+Create `src/sunstone/handlers_s3.py`:
+
+```python
+"""S3/R2 URL handler. Requires boto3 (install with sunstone-py[s3])."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import BinaryIO, TextIO
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class _S3WriteStream(io.BytesIO):
+    """A BytesIO that uploads to S3 on close()."""
+
+    def __init__(self, client: object, bucket: str, key: str) -> None:
+        super().__init__()
+        self._client = client
+        self._bucket = bucket
+        self._key = key
+
+    def close(self) -> None:
+        if not self.closed:
+            self.seek(0)
+            self._client.upload_fileobj(self, self._bucket, self._key)  # type: ignore[union-attr]
+        super().close()
+
+
+class S3URLHandler:
+    """Handles s3:// and r2:// URLs using boto3."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        import boto3  # type: ignore[import-untyped]
+
+        config = config or {}
+        endpoint_url = config.get("endpoint_url")
+        self._client = boto3.client("s3", endpoint_url=endpoint_url)
+
+    def can_handle(self, url: str) -> bool:
+        return urlparse(url).scheme in ("s3", "r2")
+
+    def _parse_url(self, url: str) -> tuple[str, str]:
+        parsed = urlparse(url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        return bucket, key
+
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        bucket, key = self._parse_url(url)
+
+        if "w" in mode:
+            stream = _S3WriteStream(self._client, bucket, key)
+            if "b" not in mode:
+                return io.TextIOWrapper(stream, encoding="utf-8")
+            return stream
+
+        response = self._client.get_object(Bucket=bucket, Key=key)
+        data = response["Body"].read()
+        logger.info("Downloaded %d bytes from %s", len(data), url)
+        binary_stream = io.BytesIO(data)
+
+        if "b" in mode:
+            return binary_stream
+        return io.TextIOWrapper(binary_stream, encoding="utf-8")
+```
+
+- [ ] **Step 4: Register S3URLHandler in PluginRegistry._discover()**
+
+In `src/sunstone/plugins.py`, add conditional registration:
+
+```python
+        try:
+            from .handlers_s3 import S3URLHandler
+            s3_config = _load_plugin_config("s3")
+            self._url_handlers.append(S3URLHandler(config=s3_config))
+        except ImportError:
+            pass  # boto3 not installed
+```
+
+Add this after GcsURLHandler and before LocalFileHandler.
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_handlers_s3.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/handlers_s3.py src/sunstone/plugins.py tests/test_handlers_s3.py
+git commit -m "Add S3URLHandler for s3:// and r2:// URLs with optional s3 extra"
+```
+
+---
+
+### Task 12: Extract packaging library from CLI
+
+**Files:**
+- Create: `src/sunstone/packaging.py`
+- Modify: `src/sunstone/cli.py`
+- Test: `tests/test_packaging.py`
+
+- [ ] **Step 1: Write tests for packaging library functions**
+
+Create `tests/test_packaging.py`:
+
+```python
+"""Tests for packaging library functions."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sunstone.datasets import DatasetsManager
+
+
+def test_push_datapackage_uses_url_handler(tmp_path):
+    """push_datapackage should use URLHandler for uploads."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs: []\n"
+        "outputs:\n"
+        "  - name: Test Output\n"
+        "    slug: test-output\n"
+        "    location: outputs/data.csv\n"
+        "    publish:\n"
+        "      enabled: true\n"
+        "      to: gs://test-bucket/\n"
+    )
+    (tmp_path / "outputs").mkdir()
+    (tmp_path / "outputs" / "data.csv").write_text("a,b\n1,2\n")
+
+    from sunstone.packaging import push_datapackage
+    from sunstone.plugins import PluginRegistry
+
+    mock_handler = MagicMock()
+    mock_handler.can_handle.return_value = True
+    mock_stream = MagicMock()
+    mock_handler.open.return_value.__enter__ = MagicMock(return_value=mock_stream)
+    mock_handler.open.return_value.__exit__ = MagicMock(return_value=False)
+
+    registry = PluginRegistry()
+    registry._url_handlers.append(mock_handler)
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        push_datapackage(project_path=tmp_path)
+
+    assert mock_handler.open.called
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_packaging.py -v`
+Expected: FAIL — module doesn't exist
+
+- [ ] **Step 3: Extract packaging functions from cli.py**
+
+Create `src/sunstone/packaging.py` with the core logic extracted from `push_group_to_gcs` and `package_build`, rewritten to use URLHandler:
+
+```python
+"""Library functions for building and pushing data packages."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+from .datasets import DatasetsManager, DatasetMetadata, PublishConfig
+from .plugins import PluginRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def is_lfs_pointer(file_path: Path) -> bool:
+    """Check if a file is a Git LFS pointer."""
+    try:
+        if file_path.stat().st_size > 1024:
+            return False
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        return content.startswith("version https://git-lfs.github.com/spec/v1\n")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def push_group(
+    dest_url: str,
+    datasets: list[DatasetMetadata],
+    manager: DatasetsManager,
+    project_slug: str,
+    publish_config: PublishConfig,
+    build_resource_dict_fn: Any,
+    package_metadata_fn: Any,
+    rdf_prefixes: dict[str, str],
+    top_level_props: dict[str, Any],
+    methodology_files: list[tuple[Path, str]],
+) -> list[str]:
+    """
+    Push a group of datasets to a remote destination via URLHandler.
+
+    Returns list of uploaded paths for reporting.
+    """
+    registry = PluginRegistry.get()
+    uploaded: list[str] = []
+
+    # Resolve datapackage.json path
+    if not dest_url.endswith(".json"):
+        if not dest_url.endswith("/"):
+            dest_url += "/"
+        datapackage_url = dest_url + "datapackage.json"
+    else:
+        datapackage_url = dest_url
+
+    parsed = urlparse(datapackage_url)
+    base_dir = str(PurePosixPath(parsed.path.lstrip("/")).parent)
+    if base_dir and base_dir != ".":
+        base_dir = base_dir + "/"
+    else:
+        base_dir = ""
+
+    resources = []
+    data_files: list[tuple[Path, str, str]] = []
+
+    for ds in datasets:
+        resource_dict = build_resource_dict_fn(ds, manager, publish_config)
+        if not resource_dict:
+            continue
+
+        data_path = manager.get_absolute_path(ds.location)
+        if publish_config.flatten:
+            remote_path = base_dir + data_path.name
+            resource_path = data_path.name
+        else:
+            remote_path = base_dir + ds.location
+            resource_path = ds.location
+
+        resources.append(resource_dict)
+        data_files.append((data_path, remote_path, resource_path))
+
+    if not resources:
+        return []
+
+    # Guard: check for LFS pointer files
+    lfs_pointers = [rp for lp, _, rp in data_files if is_lfs_pointer(lp)]
+    if lfs_pointers:
+        raise ValueError(
+            "Git LFS pointer files detected (run 'git lfs pull'): "
+            + ", ".join(lfs_pointers)
+        )
+
+    # Build datapackage
+    datapackage: dict[str, Any] = {
+        "name": project_slug,
+        "resources": resources,
+    }
+
+    pkg_meta = manager.get_package_metadata()
+    if pkg_meta:
+        datapackage.update(package_metadata_fn(pkg_meta))
+
+    if top_level_props:
+        datapackage.update(top_level_props)
+
+    # Upload datapackage.json
+    handler = registry.find_url_handler(datapackage_url)
+    if handler is None:
+        raise ValueError(f"No URL handler for: {datapackage_url}")
+
+    with handler.open(datapackage_url, "w") as f:
+        json.dump(datapackage, f, indent=2)
+    uploaded.append(str(PurePosixPath(parsed.path.lstrip("/"))))
+
+    # Upload data files
+    for local_path, remote_path, resource_path in data_files:
+        scheme = parsed.scheme
+        remote_url = f"{scheme}://{parsed.netloc}/{remote_path}"
+        file_handler = registry.find_url_handler(remote_url)
+        if file_handler is None:
+            raise ValueError(f"No URL handler for: {remote_url}")
+
+        with open(local_path, "rb") as src, file_handler.open(remote_url, "wb") as dst:
+            dst.write(src.read())
+        uploaded.append(resource_path)
+
+    # Upload methodology files
+    for abs_path, _resolved_uri in methodology_files:
+        if publish_config.flatten:
+            methodology_remote = base_dir + abs_path.name
+        else:
+            methodology_remote = base_dir + abs_path.relative_to(manager.project_path).as_posix()
+        remote_url = f"{parsed.scheme}://{parsed.netloc}/{methodology_remote}"
+        meth_handler = registry.find_url_handler(remote_url)
+        if meth_handler is None:
+            raise ValueError(f"No URL handler for: {remote_url}")
+
+        with open(abs_path, "rb") as src, meth_handler.open(remote_url, "wb") as dst:
+            dst.write(src.read())
+        uploaded.append(methodology_remote)
+
+    return uploaded
+```
+
+- [ ] **Step 4: Update cli.py to use packaging.push_group**
+
+Replace the body of `push_group_to_gcs` in `cli.py` to delegate to `packaging.push_group`, keeping the CLI output (typer.echo) in the CLI layer:
+
+```python
+def push_group_to_gcs(
+    dest_url: str,
+    datasets: list[DatasetMetadata],
+    manager: DatasetsManager,
+    project_slug: str,
+    publish_config: PublishConfig,
+) -> None:
+    from .packaging import push_group
+
+    uploaded = push_group(
+        dest_url=dest_url,
+        datasets=datasets,
+        manager=manager,
+        project_slug=project_slug,
+        publish_config=publish_config,
+        build_resource_dict_fn=build_resource_dict,
+        package_metadata_fn=_package_metadata_to_dict,
+        rdf_prefixes={**STANDARD_RDF_PREFIXES, **manager.get_default_rdf_prefixes()},
+        top_level_props=expand_custom_properties(
+            manager.get_top_level_custom_properties(),
+            {**STANDARD_RDF_PREFIXES, **manager.get_default_rdf_prefixes()},
+            base_url=publish_config.as_url,
+            flatten=publish_config.flatten,
+        ),
+        methodology_files=collect_methodology_files(
+            datasets,
+            manager.get_top_level_custom_properties(),
+            {**STANDARD_RDF_PREFIXES, **manager.get_default_rdf_prefixes()},
+            manager,
+            publish_config.as_url,
+        ),
+    )
+
+    for path in uploaded:
+        typer.echo(f"✓ Uploaded {path}")
+
+    parsed = urlparse(dest_url)
+    typer.echo(f"✓ Package pushed to: {parsed.scheme}://{parsed.netloc}/")
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/packaging.py src/sunstone/cli.py tests/test_packaging.py
+git commit -m "Extract packaging library, use URLHandler for uploads"
+```
+
+---
+
+### Task 13: Update exports and documentation
+
+**Files:**
+- Modify: `src/sunstone/__init__.py`
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update __init__.py exports**
+
+Add the new handlers and packaging module to `__init__.py`:
+
+```python
+# Plugin system
+from .plugins import AuthProvider, FormatHandler, PluginRegistry, URLHandler
+
+# Import packaging for library usage
+from . import packaging
+```
+
+Add `"packaging"` to `__all__`.
+
+- [ ] **Step 2: Update CLAUDE.md package structure**
+
+Add `handlers_gcs.py`, `handlers_s3.py`, and `packaging.py` to the tree. Add `test_handlers_gcs.py`, `test_handlers_s3.py`, and `test_packaging.py` to the tests tree.
+
+- [ ] **Step 3: Update README.md**
+
+Update the URLHandler protocol example in the Plugin System section to show `open()` instead of `fetch()`. Update the API reference for the new protocol signatures.
+
+- [ ] **Step 4: Update CHANGELOG.md**
+
+Add to `[Unreleased]`:
+
+```markdown
+- Changed: URLHandler protocol now uses `open(url, mode)` returning file-like streams instead of `fetch(url, dest)`
+- Changed: FormatHandler protocol now uses `BinaryIO` streams instead of `Path`
+- Added: `LocalFileHandler` for local filesystem paths and `file://` URLs
+- Added: `GcsURLHandler` for `gs://` URLs (install with `sunstone-py[gcs]`)
+- Added: `S3URLHandler` for `s3://` and `r2://` URLs (install with `sunstone-py[s3]`)
+- Added: `sunstone.packaging` module with library functions for building and pushing data packages
+- Changed: HTTP fetching uses `urllib.request` instead of `requests`
+- Removed: `requests` dependency
+- Changed: `google-cloud-storage` moved to optional `[gcs]` extra
+- Deprecated: `DatasetsManager.fetch_from_url()` — use `PluginRegistry.get().fetch()` instead
+```
+
+- [ ] **Step 5: Run full test suite one final time**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/__init__.py CLAUDE.md README.md CHANGELOG.md
+git commit -m "Update exports, docs, and changelog for stream-based plugin IO"
+```

--- a/docs/superpowers/specs/2026-03-29-plugin-architecture-design.md
+++ b/docs/superpowers/specs/2026-03-29-plugin-architecture-design.md
@@ -9,7 +9,7 @@ A plugin system for sunstone-py that supports three plugin types: authentication
 - **Typed Protocols** (structural typing) for plugin contracts — no inheritance required
 - **Entry point discovery** via `sunstone.plugins` group in `pyproject.toml`
 - **Pipeline composition** with defined phases: resolve URL -> authenticate -> fetch -> read format
-- **Plugin config** in `[tool.sunstone.plugins.<name>]` sections of the data project's `pyproject.toml`
+- **Cascading plugin config** — `pyproject.toml` -> `datasets.yaml` -> env vars, so projects use whichever they have
 - **Plugins take priority** over builtins — a custom CSV handler overrides the default
 - **Zero overhead** when no plugins installed — existing code paths run unchanged
 
@@ -46,7 +46,7 @@ class PluginRegistry:
         """Load plugins from entry points."""
         for ep in importlib.metadata.entry_points(group="sunstone.plugins"):
             plugin_cls = ep.load()
-            config = self._load_config(ep.name)
+            config = self._load_config(ep.name)  # cascading: pyproject.toml -> datasets.yaml -> env vars
             plugin = plugin_cls(config) if config else plugin_cls()
             self._register(ep.name, plugin)
 
@@ -62,15 +62,34 @@ class PluginRegistry:
 
 ### Config loading
 
-Plugin-specific configuration lives in the data project's `pyproject.toml`:
+Plugin config uses a cascading lookup. Sources are checked in order, with later sources overriding earlier ones:
+
+1. **`pyproject.toml`** — `[tool.sunstone.plugins.<name>]` section. For Python-packaged projects.
+2. **`datasets.yaml`** — `plugins:` top-level key. For notebook-only projects without a `pyproject.toml`.
+3. **Environment variables** — `SUNSTONE_PLUGIN_<NAME>_<KEY>=value`. For CI/Docker overrides.
 
 ```toml
+# Option 1: pyproject.toml
 [tool.sunstone.plugins.s3]
 region = "eu-west-1"
 role_arn = "arn:aws:iam::123:role/data-reader"
 ```
 
-The config dict is passed to the plugin constructor. Plugins that need no config accept no arguments.
+```yaml
+# Option 2: datasets.yaml
+plugins:
+  s3:
+    region: eu-west-1
+    role_arn: arn:aws:iam::123:role/data-reader
+```
+
+```bash
+# Option 3: environment variables (override any file-based config)
+SUNSTONE_PLUGIN_S3_REGION=eu-west-1
+SUNSTONE_PLUGIN_S3_ROLE_ARN=arn:aws:iam::123:role/data-reader
+```
+
+The merged config dict is passed to the plugin constructor. Plugins that need no config accept no arguments. Environment variables use uppercase plugin name and key, with hyphens converted to underscores (e.g. `bearer-auth` becomes `SUNSTONE_PLUGIN_BEARER_AUTH_`).
 
 ## Protocol Definitions
 
@@ -327,7 +346,7 @@ These live in sunstone-py's test suite. Plugin packages have their own tests for
 - `sunstone/plugins.py` module — `PluginRegistry`, three `Protocol` definitions, pipeline helpers
 - Refactor `dataframe.py` read/write methods to call through the pipeline
 - Add auth header injection to `datasets.py` HTTP fetch
-- Config loading from `pyproject.toml` `[tool.sunstone.plugins.*]`
+- Cascading config loading from `pyproject.toml`, `datasets.yaml`, and environment variables
 - Test suite for plugin infrastructure with test doubles
 - Sidecar `.lineage.json` for plugin-handled formats (core feature, not plugin)
 

--- a/docs/superpowers/specs/2026-03-29-plugin-architecture-design.md
+++ b/docs/superpowers/specs/2026-03-29-plugin-architecture-design.md
@@ -1,0 +1,351 @@
+# Plugin Architecture Design
+
+## Overview
+
+A plugin system for sunstone-py that supports three plugin types: authentication providers, URL handlers, and format handlers. Plugins are discovered via Python entry points, configured in `pyproject.toml`, and composed in a pipeline that extends sunstone's read/write operations.
+
+## Design Decisions
+
+- **Typed Protocols** (structural typing) for plugin contracts — no inheritance required
+- **Entry point discovery** via `sunstone.plugins` group in `pyproject.toml`
+- **Pipeline composition** with defined phases: resolve URL -> authenticate -> fetch -> read format
+- **Plugin config** in `[tool.sunstone.plugins.<name>]` sections of the data project's `pyproject.toml`
+- **Plugins take priority** over builtins — a custom CSV handler overrides the default
+- **Zero overhead** when no plugins installed — existing code paths run unchanged
+
+## Plugin Discovery & Registry
+
+Plugins are discovered via Python entry points and managed by a central `PluginRegistry`.
+
+### Entry point registration
+
+```toml
+# In a plugin's pyproject.toml
+[project.entry-points."sunstone.plugins"]
+s3 = "sunstone_s3:S3Plugin"
+```
+
+### Registry
+
+```python
+# sunstone/plugins.py
+class PluginRegistry:
+    """Discovers and manages plugins."""
+
+    _instance: PluginRegistry | None = None
+
+    @classmethod
+    def get(cls) -> PluginRegistry:
+        """Singleton - lazy-loads plugins on first access."""
+        if cls._instance is None:
+            cls._instance = cls()
+            cls._instance._discover()
+        return cls._instance
+
+    def _discover(self) -> None:
+        """Load plugins from entry points."""
+        for ep in importlib.metadata.entry_points(group="sunstone.plugins"):
+            plugin_cls = ep.load()
+            config = self._load_config(ep.name)
+            plugin = plugin_cls(config) if config else plugin_cls()
+            self._register(ep.name, plugin)
+
+    def _register(self, name: str, plugin: object) -> None:
+        """Classify plugin by protocol conformance."""
+        if isinstance(plugin, AuthProvider):
+            self._auth_providers.append(plugin)
+        if isinstance(plugin, URLHandler):
+            self._url_handlers.append(plugin)
+        if isinstance(plugin, FormatHandler):
+            self._format_handlers.append(plugin)
+```
+
+### Config loading
+
+Plugin-specific configuration lives in the data project's `pyproject.toml`:
+
+```toml
+[tool.sunstone.plugins.s3]
+region = "eu-west-1"
+role_arn = "arn:aws:iam::123:role/data-reader"
+```
+
+The config dict is passed to the plugin constructor. Plugins that need no config accept no arguments.
+
+## Protocol Definitions
+
+Three `@runtime_checkable` protocols define plugin contracts.
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Provides authentication for HTTP requests."""
+
+    def authenticate(self, url: str, headers: dict[str, str],
+                     dataset: DatasetMetadata) -> dict[str, str]:
+        """Return modified headers dict. Called before every HTTP fetch."""
+        ...
+
+@runtime_checkable
+class URLHandler(Protocol):
+    """Resolves custom URL schemes to local file paths."""
+
+    def can_handle(self, url: str) -> bool:
+        """Return True if this handler can resolve the given URL."""
+        ...
+
+    def fetch(self, url: str, dest: Path, config: dict) -> Path:
+        """Download/resolve URL to a local file. Return path to the file."""
+        ...
+
+@runtime_checkable
+class FormatHandler(Protocol):
+    """Reads and writes data formats not built into sunstone."""
+
+    def can_read(self, path: Path, format: str | None) -> bool:
+        """Return True if this handler can read the given file/format."""
+        ...
+
+    def read(self, path: Path, **kwargs) -> pd.DataFrame:
+        """Read file into a pandas DataFrame."""
+        ...
+
+    def can_write(self, path: Path, format: str | None) -> bool:
+        """Return True if this handler can write the given file/format."""
+        ...
+
+    def write(self, df: pd.DataFrame, path: Path, **kwargs) -> None:
+        """Write DataFrame to file."""
+        ...
+```
+
+Design notes:
+
+- `@runtime_checkable` enables `isinstance()` checks in the registry for structural typing at runtime.
+- `AuthProvider` returns headers (not a requests object) to stay transport-agnostic. URL handlers that use non-HTTP transports (e.g. boto3 for S3) handle their own auth by also implementing `AuthProvider`.
+- `URLHandler.fetch` takes a `dest` path so the caller decides file location (consistent with existing `fetch_from_url` behavior).
+- `FormatHandler` splits `can_read`/`can_write` because a plugin might support reading but not writing a format (or vice versa).
+- `FormatHandler` does not handle lineage. Sidecar `.lineage.json` is a core feature, not a plugin responsibility.
+
+## The Pipeline
+
+### Read pipeline
+
+```
+resolve URL -> authenticate -> fetch -> read format -> (lineage tracking)
+```
+
+```python
+def _resolve_and_fetch(self, dataset: DatasetMetadata, dest: Path) -> Path:
+    url = dataset.source.location.data
+    registry = PluginRegistry.get()
+
+    # Find a URL handler for this scheme
+    handler = registry.find_url_handler(url)
+
+    if handler:
+        # Plugin handles fetch (e.g. s3://, gs://, sftp://)
+        return handler.fetch(url, dest, config=registry.get_config(handler))
+
+    # Fall back to built-in HTTP fetch
+    if not _is_public_url(url):
+        raise ValueError(...)
+
+    headers = {}
+    # Run all auth providers for HTTP URLs
+    for auth in registry.get_auth_providers():
+        headers = auth.authenticate(url, headers, dataset)
+
+    return self._http_fetch(url, dest, headers=headers)
+```
+
+```python
+def _read_file(self, path: Path, format: str | None, **kwargs) -> pd.DataFrame:
+    registry = PluginRegistry.get()
+
+    # Check plugin format handlers first
+    handler = registry.find_format_handler(path, format, mode="read")
+    if handler:
+        return handler.read(path, **kwargs)
+
+    # Fall back to built-in readers (csv, json, excel, parquet, tsv)
+    reader = self._builtin_readers.get(format)
+    if reader is None:
+        raise ValueError(f"Unsupported format '{format}'...")
+    return reader(path, **kwargs)
+```
+
+### Key behaviors
+
+- **Plugins take priority over builtins** — registering a custom CSV handler overrides the default.
+- **Auth providers stack** — all matching auth providers run, each adding/modifying headers.
+- **URL handlers are exclusive** — first handler where `can_handle(url)` returns `True` wins.
+- **Write pipeline mirrors read** — same pattern: find format handler, plugin or builtin, then lineage/sidecar tracking (always core).
+- **No plugins installed = no overhead** — `PluginRegistry.get()` finds no entry points and existing code paths run unchanged.
+
+## Integration Points
+
+Changes to existing code are minimal:
+
+### `dataframe.py:read_dataset()` (line ~149-194)
+
+Currently has inline format detection and reader dispatch. Refactor to:
+- Extract `_resolve_and_fetch()` — replaces the direct `manager.fetch_from_url()` call
+- Extract `_read_file()` — replaces the `format_map` / `reader_map` dicts
+
+### `dataframe.py:read_csv()` (line ~264 onward)
+
+Currently calls `pd.read_csv()` directly after resolving the path. Route through `_read_file()` so format plugins can intercept.
+
+### `datasets.py:fetch_from_url()` (line ~721)
+
+Becomes the `_http_fetch()` fallback inside `_resolve_and_fetch()`, with auth provider headers injected. SSRF protection stays exactly where it is — it only applies to HTTP fetches, not plugin-handled URLs (S3/GCS plugins handle their own security).
+
+### `dataframe.py:to_csv()` and future write methods
+
+Mirror the read pipeline: check for format handler plugin, fall back to builtin. Sidecar `.lineage.json` is written by core after the format handler's `write()` returns.
+
+### What doesn't change
+
+- `DatasetsManager` — still owns `datasets.yaml`, lineage persistence, strict/relaxed mode
+- `LineageSession` — still accumulates reads and flushes on write
+- `pandas.py` — still the user-facing API, delegates to `DataFrame` methods
+- SSRF protection — stays in `datasets.py`, untouched
+
+## Example Plugins
+
+### Auth plugin — Bearer token from environment
+
+```python
+# sunstone_auth_bearer/plugin.py
+class BearerAuthPlugin:
+    def __init__(self, config: dict | None = None):
+        self.env_var = (config or {}).get("env_var", "SUNSTONE_API_TOKEN")
+        self.url_pattern = (config or {}).get("url_pattern", None)
+
+    def authenticate(self, url: str, headers: dict[str, str],
+                     dataset: DatasetMetadata) -> dict[str, str]:
+        if self.url_pattern and self.url_pattern not in url:
+            return headers
+        token = os.environ.get(self.env_var)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+```
+
+```toml
+# Project's pyproject.toml
+[tool.sunstone.plugins.bearer-auth]
+env_var = "DATA_PORTAL_TOKEN"
+url_pattern = "data.sunstone.institute"
+```
+
+### URL handler — S3
+
+```python
+# sunstone_s3/plugin.py
+class S3Plugin:
+    def __init__(self, config: dict | None = None):
+        self.region = (config or {}).get("region", "us-east-1")
+
+    def can_handle(self, url: str) -> bool:
+        return url.startswith("s3://")
+
+    def fetch(self, url: str, dest: Path, config: dict) -> Path:
+        import boto3
+        bucket, key = self._parse_s3_url(url)
+        s3 = boto3.client("s3", region_name=self.region)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        s3.download_file(bucket, key, str(dest))
+        return dest
+```
+
+### Format handler — HDF5 (addresses issue #8)
+
+```python
+# sunstone_hdf5/plugin.py
+class HDF5Plugin:
+    def __init__(self, config: dict | None = None):
+        self.default_key = (config or {}).get("key", "data")
+
+    def can_read(self, path: Path, format: str | None) -> bool:
+        return format == "hdf5" or path.suffix in (".h5", ".hdf5")
+
+    def read(self, path: Path, **kwargs) -> pd.DataFrame:
+        key = kwargs.pop("key", self.default_key)
+        return pd.read_hdf(path, key=key, **kwargs)
+
+    def can_write(self, path: Path, format: str | None) -> bool:
+        return format == "hdf5" or path.suffix in (".h5", ".hdf5")
+
+    def write(self, df: pd.DataFrame, path: Path, **kwargs) -> None:
+        key = kwargs.pop("key", self.default_key)
+        df.to_hdf(path, key=key, **kwargs)
+```
+
+## Testing Strategy
+
+### Core infrastructure tests (in sunstone-py)
+
+- **Registry discovery** — mock entry points, verify plugins classified by protocol
+- **Pipeline fallback** — no plugins installed, existing behavior unchanged
+- **Plugin priority** — plugin format handler beats builtin for same extension
+- **Auth stacking** — two auth providers both modify headers
+- **URL handler routing** — correct handler selected by `can_handle()`
+- **Config loading** — `[tool.sunstone.plugins.foo]` passed to constructor correctly
+- **Bad plugins** — plugin implementing no protocol logs warning, doesn't crash
+
+### Test doubles
+
+```python
+class FakeAuthProvider:
+    def authenticate(self, url, headers, dataset):
+        headers["X-Test"] = "injected"
+        return headers
+
+class FakeURLHandler:
+    def can_handle(self, url): return url.startswith("fake://")
+    def fetch(self, url, dest, config):
+        dest.write_text("col1,col2\na,b\n")
+        return dest
+
+class FakeFormatHandler:
+    def can_read(self, path, format): return path.suffix == ".fake"
+    def read(self, path, **kwargs): return pd.DataFrame({"x": [1, 2, 3]})
+    def can_write(self, path, format): return path.suffix == ".fake"
+    def write(self, df, path, **kwargs): df.to_csv(path)
+```
+
+These live in sunstone-py's test suite. Plugin packages have their own tests for actual S3/GCS/HDF5 behavior.
+
+## Scope
+
+### In scope (v1)
+
+- `sunstone/plugins.py` module — `PluginRegistry`, three `Protocol` definitions, pipeline helpers
+- Refactor `dataframe.py` read/write methods to call through the pipeline
+- Add auth header injection to `datasets.py` HTTP fetch
+- Config loading from `pyproject.toml` `[tool.sunstone.plugins.*]`
+- Test suite for plugin infrastructure with test doubles
+- Sidecar `.lineage.json` for plugin-handled formats (core feature, not plugin)
+
+### Deferred — future plugin types
+
+- Lineage enrichers (`on_write` hooks)
+- License rule providers (issue #13)
+- Validation hooks (pre-read / post-write)
+- Publishing destinations (issue #33)
+- Reference data providers (issue #9)
+- Attribution generators (issue #14)
+- Event hook system (generic version of the above)
+
+### Deferred — ecosystem
+
+- Actual S3/GCS/HDF5 plugin packages (infrastructure first, plugins later)
+- Plugin versioning / compatibility checks
+- CLI commands for listing installed plugins (`sunstone plugin list`)
+- Sandboxing or permission model for untrusted plugins
+
+The deferred plugin types all follow the same pattern: add a new `Protocol`, add a phase to the pipeline, add `isinstance` check in the registry. The architecture supports this without breaking existing plugins.

--- a/docs/superpowers/specs/2026-03-29-plugin-architecture-design.md
+++ b/docs/superpowers/specs/2026-03-29-plugin-architecture-design.md
@@ -96,7 +96,7 @@ class URLHandler(Protocol):
         """Return True if this handler can resolve the given URL."""
         ...
 
-    def fetch(self, url: str, dest: Path, config: dict) -> Path:
+    def fetch(self, url: str, dest: Path) -> Path:
         """Download/resolve URL to a local file. Return path to the file."""
         ...
 
@@ -125,7 +125,7 @@ Design notes:
 
 - `@runtime_checkable` enables `isinstance()` checks in the registry for structural typing at runtime.
 - `AuthProvider` returns headers (not a requests object) to stay transport-agnostic. URL handlers that use non-HTTP transports (e.g. boto3 for S3) handle their own auth by also implementing `AuthProvider`.
-- `URLHandler.fetch` takes a `dest` path so the caller decides file location (consistent with existing `fetch_from_url` behavior).
+- `URLHandler.fetch` takes a `dest` path so the caller decides file location (consistent with existing `fetch_from_url` behavior). Config is received via the constructor, not passed per-call.
 - `FormatHandler` splits `can_read`/`can_write` because a plugin might support reading but not writing a format (or vice versa).
 - `FormatHandler` does not handle lineage. Sidecar `.lineage.json` is a core feature, not a plugin responsibility.
 
@@ -147,7 +147,7 @@ def _resolve_and_fetch(self, dataset: DatasetMetadata, dest: Path) -> Path:
 
     if handler:
         # Plugin handles fetch (e.g. s3://, gs://, sftp://)
-        return handler.fetch(url, dest, config=registry.get_config(handler))
+        return handler.fetch(url, dest)
 
     # Fall back to built-in HTTP fetch
     if not _is_public_url(url):
@@ -253,7 +253,7 @@ class S3Plugin:
     def can_handle(self, url: str) -> bool:
         return url.startswith("s3://")
 
-    def fetch(self, url: str, dest: Path, config: dict) -> Path:
+    def fetch(self, url: str, dest: Path) -> Path:
         import boto3
         bucket, key = self._parse_s3_url(url)
         s3 = boto3.client("s3", region_name=self.region)
@@ -307,7 +307,7 @@ class FakeAuthProvider:
 
 class FakeURLHandler:
     def can_handle(self, url): return url.startswith("fake://")
-    def fetch(self, url, dest, config):
+    def fetch(self, url, dest):
         dest.write_text("col1,col2\na,b\n")
         return dest
 

--- a/docs/superpowers/specs/2026-04-03-stream-based-plugin-io-design.md
+++ b/docs/superpowers/specs/2026-04-03-stream-based-plugin-io-design.md
@@ -1,0 +1,249 @@
+# Stream-Based Plugin IO Design
+
+**Date:** 2026-04-03
+**Status:** Draft
+**Supersedes:** Portions of 2026-03-29-plugin-architecture-design.md (URLHandler and FormatHandler protocols)
+
+## Problem
+
+The plugin system introduced in v1.3.1+ handles local-file IO well but has no abstraction
+for remote IO. Specific gaps:
+
+1. **GCS upload logic is hardcoded** in `cli.py` (`push_group_to_gcs`). Adding S3 or R2
+   support means editing the CLI directly.
+2. **No universal file-like interface.** URLHandler only supports `fetch(url, dest) -> Path`
+   (download to local file). There's no way to `open()` a remote URL and get a stream
+   that works with `print(..., file=)`, `json.dump(..., f)`, or other standard Python IO.
+3. **Two-step fetch-then-read** is wasteful for large files. Streaming directly from URL
+   to pandas avoids the temp file.
+
+## Design Decisions
+
+- **Approach C (stream-first with fetch convenience):** `open()` is the core protocol
+  method. `fetch()` becomes a default utility on `PluginRegistry` implemented in terms of
+  `open()`. Plugin authors only implement `open()`.
+- **Mirror Python's `open()` semantics:** `open(url, "rb") -> BinaryIO`,
+  `open(url, "r") -> TextIO`, and write modes likewise.
+- **AuthProvider stays separate.** HTTP-oriented handlers call auth providers internally.
+  Cloud-native handlers (GCS, S3) use their own credential systems.
+- **Optional extras for cloud dependencies:** `sunstone-py[gcs]` and `sunstone-py[s3]`.
+- **Drop `requests` dependency.** `HttpURLHandler` uses `urllib.request` from the stdlib.
+
+## Protocol Definitions
+
+### URLHandler
+
+```python
+from typing import BinaryIO, Literal, TextIO, Protocol, overload, runtime_checkable
+
+@runtime_checkable
+class URLHandler(Protocol):
+    def can_handle(self, url: str) -> bool: ...
+
+    @overload
+    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO: ...
+```
+
+Plugin authors implement `can_handle()` and `open()`. That's the full contract.
+
+### FormatHandler
+
+```python
+@runtime_checkable
+class FormatHandler(Protocol):
+    def can_read(self, path: str, format: str | None) -> bool: ...
+    def read(self, stream: BinaryIO, **kwargs: object) -> pd.DataFrame: ...
+
+    def can_write(self, path: str, format: str | None) -> bool: ...
+    def write(self, df: pd.DataFrame, stream: BinaryIO, **kwargs: object) -> None: ...
+```
+
+- `path` in `can_read`/`can_write` is a string (URL or path) used for format detection
+  via extension sniffing. It is not the data source.
+- `read()` and `write()` operate on `BinaryIO` streams.
+- FormatHandler wraps with `io.TextIOWrapper` internally if the underlying pandas
+  function needs text.
+
+### AuthProvider (unchanged)
+
+```python
+@runtime_checkable
+class AuthProvider(Protocol):
+    def authenticate(self, url: str, headers: dict[str, str],
+                     dataset: DatasetMetadata) -> dict[str, str]: ...
+```
+
+HTTP-oriented URLHandlers call `registry.get_auth_providers()` inside their `open()`
+before making requests. Cloud-native handlers ignore AuthProvider and use their own
+credential systems.
+
+### PluginRegistry additions
+
+```python
+class PluginRegistry:
+    # Existing methods unchanged...
+
+    def fetch(self, url: str, dest: Path) -> Path:
+        """Convenience: download url to local file via open()."""
+        handler = self.find_url_handler(url)
+        if handler is None:
+            raise ValueError(f"No URL handler found for: {url}")
+        with handler.open(url, "rb") as src, builtins.open(dest, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        return dest
+```
+
+## Built-in Handlers
+
+### LocalFileHandler (new)
+
+Handles local filesystem paths and `file://` URLs.
+
+- `can_handle(url)` — True for `file://` scheme and bare paths. Detection: parse with
+  `urllib.parse.urlparse()`; if scheme is empty or `file`, it's local. This means relative
+  paths like `outputs/data.csv` and absolute paths like `/tmp/data.csv` are both handled.
+- `open(url, mode)` — returns `builtins.open(resolved_path, mode)`
+- Registered as the last fallback (after all other handlers)
+
+This is key: even local file IO goes through the plugin system. Changing a location in
+`datasets.yaml` from `outputs/data.csv` to `gs://bucket/data.csv` just works.
+
+### HttpURLHandler (refactored)
+
+Handles `http://` and `https://` URLs. Uses `urllib.request` from the stdlib (no
+`requests` dependency).
+
+- `open(url, "rb")` — fetches URL, returns `io.BytesIO(response_body)`
+- `open(url, "r")` — wraps the above with `io.TextIOWrapper`
+- Write modes (`"w"`, `"wb"`) — raise `NotImplementedError` (HTTP upload semantics are
+  too protocol-specific for a sensible default)
+- SSRF protection: validates all URLs (including redirect targets) against private/loopback
+  IPs before connecting
+- Redirect handling: follows redirects manually, re-validates each target, strips
+  `Authorization` header on cross-origin redirects
+- Auth: calls `registry.get_auth_providers()` inside `open()` before the request
+
+### GcsURLHandler (new, requires `[gcs]` extra)
+
+Handles `gs://` URLs. Uses `google-cloud-storage`.
+
+- `can_handle(url)` — True for `gs://` scheme
+- `open(url, "rb")` — downloads blob into `BytesIO`, returns it
+- `open(url, "wb")` — returns a `GcsWriteStream` (a `BytesIO` subclass that calls
+  `blob.upload_from_file()` on `close()`)
+- `open(url, "r"/"w")` — text wrappers around the binary modes
+- Auth: uses Application Default Credentials via `google-cloud-storage`
+
+Only registered if `google-cloud-storage` is importable.
+
+### S3URLHandler (new, requires `[s3]` extra)
+
+Handles `s3://` and `r2://` URLs. Uses `boto3`.
+
+- `can_handle(url)` — True for `s3://` and `r2://` schemes
+- For `r2://`, resolves endpoint URL from plugin config (Cloudflare account ID ->
+  `https://<account_id>.r2.cloudflarestorage.com`)
+- Same `open()` semantics as GcsURLHandler
+- Auth: uses `boto3` default credential chain (env vars, `~/.aws/credentials`, IAM role)
+- Config via cascading system: `SUNSTONE_PLUGIN_S3_ENDPOINT_URL`, etc.
+
+Only registered if `boto3` is importable.
+
+## pyproject.toml Changes
+
+```toml
+[project.optional-dependencies]
+gcs = ["google-cloud-storage>=2.0"]
+s3 = ["boto3>=1.28"]
+```
+
+`requests` is removed as a dependency. `urllib.request` from the stdlib replaces it.
+
+## Integration Points
+
+### Read path (dataframe.py)
+
+`read_dataset`, `read_csv`, `read_excel` all follow this flow:
+
+1. Resolve the location string (path or URL)
+2. `registry.find_url_handler(location)` -> handler
+3. `handler.open(location, "rb")` -> stream
+4. `registry.find_format_reader(location, format)` -> format handler
+5. `format_handler.read(stream, **kwargs)` -> DataFrame
+
+### Write path (dataframe.py)
+
+`to_csv` (and future `to_parquet`, etc.):
+
+1. Resolve the location string
+2. `registry.find_url_handler(location)` -> handler
+3. `handler.open(location, "wb")` -> stream
+4. `registry.find_format_writer(location, format)` -> format handler
+5. `format_handler.write(df, stream, **kwargs)`
+
+The `track=False` path also goes through the handler system so remote URLs work for
+untracked writes too.
+
+### fetch_from_url (datasets.py)
+
+Becomes a thin deprecated wrapper around `registry.fetch(url, dest)`. Existing callers
+keep working. Remove in a future release.
+
+### package build/push (cli.py -> packaging.py)
+
+Extract orchestration logic into a new `packaging.py` library module:
+
+- `build_datapackage(project_path, ...) -> dict` — builds the datapackage.json structure
+- `push_datapackage(project_path, ...) -> None` — iterates datasets, opens remote streams
+  via URLHandler, writes data
+
+The CLI becomes a thin shell calling these library functions. The actual upload calls
+become `handler.open(gs_url, "wb")` writes. LFS pointer detection stays as a pre-upload
+check in the orchestration logic.
+
+`package push` flow:
+1. Build datapackage.json
+2. For each dataset to push:
+   - Check for LFS pointer (reject if found)
+   - `handler.open(remote_url, "wb")` -> stream
+   - Write data to stream
+3. Write datapackage.json to remote via `handler.open(remote_url, "w")`
+
+## Migration and Backward Compatibility
+
+### Breaking changes
+
+Both `URLHandler` and `FormatHandler` protocols change signatures. This is acceptable
+because:
+- The plugin system is unreleased (all changes are in `[Unreleased]` in CHANGELOG)
+- No known external plugins exist yet
+
+### Deprecations
+
+- `DatasetsManager.fetch_from_url()` — deprecated, calls `registry.fetch()` internally
+- `requests` dependency — removed entirely
+
+### Dependency changes
+
+- `google-cloud-storage` moves from hard dependency to `[gcs]` extra
+- `boto3` added as `[s3]` extra
+- `requests` removed (replaced by `urllib.request`)
+
+## Testing Strategy
+
+- Unit tests for each handler with mocked IO (no real network/cloud calls)
+- `HttpURLHandler`: mock `urllib.request.urlopen`, test SSRF protection, redirect
+  handling, auth injection, text/binary modes
+- `GcsURLHandler`: mock `google.cloud.storage.Client`, test read/write/text modes
+- `S3URLHandler`: mock `boto3.client`, test S3 and R2 URL schemes, endpoint config
+- `LocalFileHandler`: test with real temp files, both path formats and `file://` URLs
+- Integration tests for the full read/write pipeline through PluginRegistry
+- Test that `registry.fetch()` convenience works correctly
+- Test that `package push` library function uses URLHandler (mock the handler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,16 @@ dependencies = [
     "typer>=0.15",
     "frictionless>=5.18.1",
     "google-auth>=2.43.0",
-    "google-cloud-storage>=2.0.0",
     "openpyxl>=3.1.0",
     "pandas>=2.0.0",
     "pyyaml>=6.0",
-    "requests>=2.31.0",
     "ruamel-yaml>=0.18",
     "pyarrow>=23.0.1",
 ]
+
+[project.optional-dependencies]
+gcs = ["google-cloud-storage>=2.0"]
+s3 = ["boto3>=1.28"]
 
 [project.license]
 text = "MIT"
@@ -96,7 +98,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "mypy>=1.0.0",
     "ruff>=0.1.0",
-    "types-requests>=2.32.4.20250913",
+
     "pandas-stubs>=2.3.2.250926",
     "types-pyyaml>=6.0.12.20250915",
     "markdown>=3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pyyaml>=6.0",
     "requests>=2.31.0",
     "ruamel-yaml>=0.18",
+    "pyarrow>=23.0.1",
 ]
 
 [project.license]

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -44,6 +44,9 @@ from .lineage import (
     SourceLocation,
 )
 
+# Plugin system
+from .plugins import AuthProvider, FormatHandler, PluginRegistry, URLHandler
+
 # Import pandas module for pd-like interface
 from . import pandas
 
@@ -99,6 +102,11 @@ __all__ = [
     "close_session",
     "LineageSession",
     "DatasetRead",
+    # Plugin system
+    "AuthProvider",
+    "URLHandler",
+    "FormatHandler",
+    "PluginRegistry",
     # Lineage queries
     "LineageNode",
     "get_upstream",

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -47,6 +47,9 @@ from .lineage import (
 # Plugin system
 from .plugins import AuthProvider, FormatHandler, PluginRegistry, URLHandler
 
+# Packaging (library functions for building and pushing data packages)
+from . import packaging
+
 # Import pandas module for pd-like interface
 from . import pandas
 
@@ -107,6 +110,8 @@ __all__ = [
     "URLHandler",
     "FormatHandler",
     "PluginRegistry",
+    # Packaging
+    "packaging",
     # Lineage queries
     "LineageNode",
     "get_upstream",

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -8,7 +8,7 @@ import re
 import sys
 import tomllib
 from enum import Enum
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
 
@@ -953,20 +953,11 @@ def package_build(
 def is_lfs_pointer(file_path: Path) -> bool:
     """Check if a file is a Git LFS pointer file instead of actual content.
 
-    LFS pointer files are small text files with a specific format:
-        version https://git-lfs.github.com/spec/v1
-        oid sha256:<hash>
-        size <size>
+    Delegates to :func:`sunstone.packaging.is_lfs_pointer`.
     """
-    try:
-        # LFS pointers are always small (< 200 bytes typically)
-        if file_path.stat().st_size > 1024:
-            return False
-        with open(file_path, "r", encoding="utf-8") as f:
-            content = f.read()
-        return content.startswith("version https://git-lfs.github.com/spec/v1\n")
-    except (OSError, UnicodeDecodeError):
-        return False
+    from .packaging import is_lfs_pointer as _is_lfs_pointer
+
+    return _is_lfs_pointer(file_path)
 
 
 def push_group_to_gcs(
@@ -977,84 +968,28 @@ def push_group_to_gcs(
     publish_config: PublishConfig,
 ) -> None:
     """
-    Push a group of datasets to a single GCS destination.
+    Push a group of datasets to a remote destination.
+
+    Delegates core logic to :func:`sunstone.packaging.push_group` and
+    prints progress output for the CLI.
 
     Args:
-        dest_url: The GCS destination URL (gs://...).
+        dest_url: The destination URL (gs://, s3://, r2://, etc.).
         datasets: The datasets to include in this datapackage.
         manager: The DatasetsManager instance.
         project_slug: The project slug for the datapackage name.
         publish_config: The effective publish config for this group.
     """
-    from google.cloud import storage  # type: ignore[import-untyped]
+    from .packaging import push_group
 
-    parsed = urlparse(dest_url)
-    if parsed.scheme != "gs":
-        typer.echo(f"Error: Destination must be a gs:// URL, got: {dest_url}", err=True)
-        sys.exit(1)
+    # Prepare package metadata callback
+    def package_metadata_fn() -> Optional[dict[str, Any]]:
+        pkg_meta = manager.get_package_metadata()
+        if pkg_meta:
+            return _package_metadata_to_dict(pkg_meta)
+        return None
 
-    # Resolve datapackage.json path and base directory
-    if not dest_url.endswith(".json"):
-        if not dest_url.endswith("/"):
-            dest_url += "/"
-        datapackage_url = dest_url + "datapackage.json"
-    else:
-        datapackage_url = dest_url
-
-    parsed = urlparse(datapackage_url)
-    bucket_name = parsed.netloc
-    datapackage_path = parsed.path.lstrip("/")
-
-    base_dir = str(PurePosixPath(datapackage_path).parent)
-    if base_dir and base_dir != ".":
-        base_dir = base_dir + "/"
-    else:
-        base_dir = ""
-
-    resources = []
-    data_files: list[tuple[Path, str, str]] = []
-
-    for ds in datasets:
-        resource_dict = build_resource_dict(ds, manager, publish_config)
-        if not resource_dict:
-            continue
-
-        data_path = manager.get_absolute_path(ds.location)
-        if publish_config.flatten:
-            remote_path = base_dir + data_path.name
-            resource_path = data_path.name
-        else:
-            remote_path = base_dir + ds.location
-            resource_path = ds.location
-
-        resources.append(resource_dict)
-        data_files.append((data_path, remote_path, resource_path))
-
-    if not resources:
-        typer.echo(f"Warning: No resources for destination: {dest_url}", err=True)
-        return
-
-    # Guard: check for LFS pointer files before uploading
-    lfs_pointers = [resource_path for local_path, _, resource_path in data_files if is_lfs_pointer(local_path)]
-    if lfs_pointers:
-        typer.echo("Error: The following files are Git LFS pointers, not actual content:", err=True)
-        for p in lfs_pointers:
-            typer.echo(f"  - {p}", err=True)
-        typer.echo("Run 'git lfs pull' to download the actual files before pushing.", err=True)
-        sys.exit(1)
-
-    datapackage: dict[str, Any] = {
-        "name": project_slug,
-        f"{STANDARD_RDF_PREFIXES['rdf']}type": f"{STANDARD_RDF_PREFIXES['dcat']}Dataset",
-        "resources": resources,
-    }
-
-    # Add standard package metadata (title, description, etc.)
-    pkg_meta = manager.get_package_metadata()
-    if pkg_meta:
-        datapackage.update(_package_metadata_to_dict(pkg_meta))
-
-    # Add top-level custom properties with RDF prefix expansion
+    # Prepare top-level properties with RDF prefix expansion
     top_level_props = manager.get_top_level_custom_properties()
     rdf_prefixes = {**STANDARD_RDF_PREFIXES, **manager.get_default_rdf_prefixes()}
     as_url = publish_config.as_url
@@ -1062,36 +997,41 @@ def push_group_to_gcs(
         top_level_props = expand_custom_properties(
             top_level_props, rdf_prefixes, base_url=as_url, flatten=publish_config.flatten
         )
-    datapackage.update(top_level_props)
 
     # Collect methodology files for upload
     methodology_files = collect_methodology_files(
         datasets, manager.get_top_level_custom_properties(), rdf_prefixes, manager, as_url
     )
 
-    client = storage.Client()
-    bucket = client.bucket(bucket_name)
+    try:
+        uploaded = push_group(
+            dest_url=dest_url,
+            datasets=datasets,
+            manager=manager,
+            project_slug=project_slug,
+            publish_config=publish_config,
+            build_resource_dict_fn=build_resource_dict,
+            package_metadata_fn=package_metadata_fn,
+            rdf_prefixes=rdf_prefixes,
+            top_level_props=top_level_props or {},
+            methodology_files=methodology_files,
+        )
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        sys.exit(1)
 
-    datapackage_blob = bucket.blob(datapackage_path)
-    datapackage_blob.upload_from_string(json.dumps(datapackage, indent=2), content_type="application/json")
-    typer.echo(f"✓ Uploaded {datapackage_path}")
+    if not uploaded:
+        typer.echo(f"Warning: No resources for destination: {dest_url}", err=True)
+        return
 
-    for local_path, remote_path, resource_path in data_files:
-        data_blob = bucket.blob(remote_path)
-        data_blob.upload_from_filename(str(local_path))
-        typer.echo(f"✓ Uploaded {resource_path}")
+    for path in uploaded:
+        typer.echo(f"✓ Uploaded {path}")
 
-    # Upload methodology files alongside resources
-    for abs_path, _resolved_uri in methodology_files:
-        if publish_config.flatten:
-            methodology_remote = base_dir + abs_path.name
-        else:
-            methodology_remote = base_dir + abs_path.relative_to(manager.project_path).as_posix()
-        methodology_blob = bucket.blob(methodology_remote)
-        methodology_blob.upload_from_filename(str(abs_path))
-        typer.echo(f"✓ Uploaded {methodology_remote}")
-
-    typer.echo(f"✓ Package pushed to: gs://{bucket_name}/{base_dir}")
+    # Determine the base URL for the final summary
+    parsed = urlparse(dest_url)
+    typer.echo(
+        f"✓ Package pushed to: {parsed.scheme}://{parsed.netloc}/{uploaded[0].rsplit('/', 1)[0] + '/' if '/' in uploaded[0] else ''}"
+    )
 
 
 class EnvChoice(str, Enum):

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -157,10 +157,9 @@ class DataFrame:
                     f"File not found: {absolute_path}\nDataset '{dataset.slug}' has no source URL to fetch from."
                 )
 
-        # Determine format
+        # Determine format from extension (for builtin fallback)
+        extension = absolute_path.suffix.lower()
         if format is None:
-            # Auto-detect from file extension
-            extension = absolute_path.suffix.lower()
             format_map = {
                 ".csv": "csv",
                 ".json": "json",
@@ -171,27 +170,37 @@ class DataFrame:
                 ".txt": "tsv",  # Assume tab-delimited for .txt
             }
             format = format_map.get(extension)
+
+        # Check plugin format handlers first
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_handler = registry.find_format_reader(absolute_path, format)
+
+        if format_handler:
+            df = format_handler.read(absolute_path, **kwargs)
+        else:
+            # Fall back to built-in readers
             if format is None:
                 raise ValueError(
                     f"Cannot auto-detect format for file extension '{extension}'. "
-                    f"Supported extensions: {', '.join(format_map.keys())}. "
+                    f"Supported extensions: .csv, .json, .xlsx, .xls, .parquet, .tsv, .txt. "
                     f"Please specify format explicitly using the 'format' parameter."
                 )
 
-        # Read using appropriate pandas function
-        reader_map: dict[str, Callable[..., pd.DataFrame]] = {
-            "csv": pd.read_csv,
-            "json": pd.read_json,
-            "excel": pd.read_excel,
-            "parquet": pd.read_parquet,
-            "tsv": lambda path, **kw: pd.read_csv(path, sep="\t", **kw),
-        }
+            reader_map: dict[str, Callable[..., pd.DataFrame]] = {
+                "csv": pd.read_csv,
+                "json": pd.read_json,
+                "excel": pd.read_excel,
+                "parquet": pd.read_parquet,
+                "tsv": lambda path, **kw: pd.read_csv(path, sep="\t", **kw),
+            }
 
-        reader = reader_map.get(format)
-        if reader is None:
-            raise ValueError(f"Unsupported format '{format}'. Supported formats: {', '.join(reader_map.keys())}")
+            reader = reader_map.get(format)
+            if reader is None:
+                raise ValueError(f"Unsupported format '{format}'. Supported formats: {', '.join(reader_map.keys())}")
 
-        df = reader(absolute_path, **kwargs)
+            df = reader(absolute_path, **kwargs)
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -163,7 +163,8 @@ class DataFrame:
         registry = PluginRegistry.get()
 
         # Try explicit format string first, then extension-based detection
-        format_handler = registry.find_format_reader(absolute_path, format)
+        location = str(absolute_path)
+        format_handler = registry.find_format_reader(location, format)
 
         if format_handler is None:
             extension = absolute_path.suffix.lower()
@@ -173,7 +174,12 @@ class DataFrame:
                 + ". Install a plugin or check the file extension."
             )
 
-        df = format_handler.read(absolute_path, **kwargs)  # type: ignore[arg-type]  # TODO: update in Task 7
+        url_handler = registry.find_url_handler(location)
+        if url_handler is None:
+            raise ValueError(f"No URL handler found for '{location}'")
+
+        with url_handler.open(location, "rb") as stream:
+            df = format_handler.read(stream, format=format, path=location, **kwargs)
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))
@@ -278,10 +284,17 @@ class DataFrame:
         from .plugins import PluginRegistry
 
         registry = PluginRegistry.get()
-        format_handler = registry.find_format_reader(absolute_path, "csv")
+        location = str(absolute_path)
+        format_handler = registry.find_format_reader(location, "csv")
         if format_handler is None:
             raise ValueError("No format handler found for CSV files")
-        df = format_handler.read(absolute_path, **kwargs)  # type: ignore[arg-type]  # TODO: update in Task 7
+
+        url_handler = registry.find_url_handler(location)
+        if url_handler is None:
+            raise ValueError(f"No URL handler found for '{location}'")
+
+        with url_handler.open(location, "rb") as stream:
+            df = format_handler.read(stream, format="csv", path=location, **kwargs)
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))
@@ -384,10 +397,17 @@ class DataFrame:
         from .plugins import PluginRegistry
 
         registry = PluginRegistry.get()
-        format_handler = registry.find_format_reader(absolute_path, "excel")
+        location = str(absolute_path)
+        format_handler = registry.find_format_reader(location, "excel")
         if format_handler is None:
             raise ValueError("No format handler found for Excel files")
-        df = format_handler.read(absolute_path, **kwargs)  # type: ignore[arg-type]  # TODO: update in Task 7
+
+        url_handler = registry.find_url_handler(location)
+        if url_handler is None:
+            raise ValueError(f"No URL handler found for '{location}'")
+
+        with url_handler.open(location, "rb") as stream:
+            df = format_handler.read(stream, format="excel", path=location, **kwargs)
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -4,7 +4,7 @@ DataFrame wrapper with lineage tracking for Sunstone projects.
 
 import os
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import pandas as pd
 
@@ -157,50 +157,23 @@ class DataFrame:
                     f"File not found: {absolute_path}\nDataset '{dataset.slug}' has no source URL to fetch from."
                 )
 
-        # Determine format from extension (for builtin fallback)
-        extension = absolute_path.suffix.lower()
-        if format is None:
-            format_map = {
-                ".csv": "csv",
-                ".json": "json",
-                ".xlsx": "excel",
-                ".xls": "excel",
-                ".parquet": "parquet",
-                ".tsv": "tsv",
-                ".txt": "tsv",  # Assume tab-delimited for .txt
-            }
-            format = format_map.get(extension)
-
-        # Check plugin format handlers first
+        # Find a format handler (plugin or builtin) for this file
         from .plugins import PluginRegistry
 
         registry = PluginRegistry.get()
+
+        # Try explicit format string first, then extension-based detection
         format_handler = registry.find_format_reader(absolute_path, format)
 
-        if format_handler:
-            df = format_handler.read(absolute_path, **kwargs)
-        else:
-            # Fall back to built-in readers
-            if format is None:
-                raise ValueError(
-                    f"Cannot auto-detect format for file extension '{extension}'. "
-                    f"Supported extensions: .csv, .json, .xlsx, .xls, .parquet, .tsv, .txt. "
-                    f"Please specify format explicitly using the 'format' parameter."
-                )
+        if format_handler is None:
+            extension = absolute_path.suffix.lower()
+            raise ValueError(
+                f"No format handler found for '{absolute_path.name}'"
+                + (f" (format='{format}')" if format else f" (extension='{extension}')")
+                + ". Install a plugin or check the file extension."
+            )
 
-            reader_map: dict[str, Callable[..., pd.DataFrame]] = {
-                "csv": pd.read_csv,
-                "json": pd.read_json,
-                "excel": pd.read_excel,
-                "parquet": pd.read_parquet,
-                "tsv": lambda path, **kw: pd.read_csv(path, sep="\t", **kw),
-            }
-
-            reader = reader_map.get(format)
-            if reader is None:
-                raise ValueError(f"Unsupported format '{format}'. Supported formats: {', '.join(reader_map.keys())}")
-
-            df = reader(absolute_path, **kwargs)
+        df = format_handler.read(absolute_path, **kwargs)
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -463,9 +463,19 @@ class DataFrame:
         pandas_kwargs = {k: v for k, v in kwargs.items() if k not in self._SUNSTONE_KWARGS}
 
         if not track:
-            path = Path(path_or_buf)
-            path.parent.mkdir(parents=True, exist_ok=True)
-            self.data.to_csv(path, **pandas_kwargs)
+            from .plugins import PluginRegistry
+
+            registry = PluginRegistry.get()
+            location = str(path_or_buf)
+
+            url_handler = registry.find_url_handler(location)
+            if url_handler:
+                with url_handler.open(location, "wb") as stream:
+                    self.data.to_csv(stream, **pandas_kwargs)
+            else:
+                path = Path(path_or_buf)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                self.data.to_csv(path, **pandas_kwargs)
             return
 
         manager = self._get_datasets_manager()
@@ -496,16 +506,21 @@ class DataFrame:
 
         # Write the data
         absolute_path = manager.get_absolute_path(dataset.location)
-        absolute_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check if a format handler plugin can write this file
         from .plugins import PluginRegistry
 
         registry = PluginRegistry.get()
-        format_writer = registry.find_format_writer(absolute_path, None)
+        location = str(absolute_path)
 
-        if format_writer:
-            format_writer.write(self.data, absolute_path, **pandas_kwargs)  # type: ignore[arg-type]  # TODO: update in Task 8
+        url_handler = registry.find_url_handler(location)
+        format_writer = registry.find_format_writer(location, None)
+
+        if url_handler and format_writer:
+            with url_handler.open(location, "wb") as stream:
+                format_writer.write(self.data, stream, format=None, path=location, **pandas_kwargs)
+        elif format_writer:
+            with open(absolute_path, "wb") as stream:
+                format_writer.write(self.data, stream, format=None, path=location, **pandas_kwargs)
         else:
             self.data.to_csv(absolute_path, **pandas_kwargs)
 

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -489,10 +489,20 @@ class DataFrame:
                 # Register the new output
                 dataset = manager.add_output_dataset(name=name, slug=slug, location=location, fields=fields)
 
-        # Write the CSV
+        # Write the data
         absolute_path = manager.get_absolute_path(dataset.location)
         absolute_path.parent.mkdir(parents=True, exist_ok=True)
-        self.data.to_csv(absolute_path, **pandas_kwargs)
+
+        # Check if a format handler plugin can write this file
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_writer = registry.find_format_writer(absolute_path, None)
+
+        if format_writer:
+            format_writer.write(self.data, absolute_path, **pandas_kwargs)
+        else:
+            self.data.to_csv(absolute_path, **pandas_kwargs)
 
         # Compute content hash for change detection
         content_hash = compute_dataframe_hash(self.data)

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -173,7 +173,7 @@ class DataFrame:
                 + ". Install a plugin or check the file extension."
             )
 
-        df = format_handler.read(absolute_path, **kwargs)
+        df = format_handler.read(absolute_path, **kwargs)  # type: ignore[arg-type]  # TODO: update in Task 7
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))
@@ -281,7 +281,7 @@ class DataFrame:
         format_handler = registry.find_format_reader(absolute_path, "csv")
         if format_handler is None:
             raise ValueError("No format handler found for CSV files")
-        df = format_handler.read(absolute_path, **kwargs)
+        df = format_handler.read(absolute_path, **kwargs)  # type: ignore[arg-type]  # TODO: update in Task 7
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))
@@ -387,7 +387,7 @@ class DataFrame:
         format_handler = registry.find_format_reader(absolute_path, "excel")
         if format_handler is None:
             raise ValueError("No format handler found for Excel files")
-        df = format_handler.read(absolute_path, **kwargs)
+        df = format_handler.read(absolute_path, **kwargs)  # type: ignore[arg-type]  # TODO: update in Task 7
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))
@@ -485,7 +485,7 @@ class DataFrame:
         format_writer = registry.find_format_writer(absolute_path, None)
 
         if format_writer:
-            format_writer.write(self.data, absolute_path, **pandas_kwargs)
+            format_writer.write(self.data, absolute_path, **pandas_kwargs)  # type: ignore[arg-type]  # TODO: update in Task 8
         else:
             self.data.to_csv(absolute_path, **pandas_kwargs)
 

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -274,8 +274,14 @@ class DataFrame:
                     f"File not found: {absolute_path}\nDataset '{dataset.slug}' has no source URL to fetch from."
                 )
 
-        # Read the CSV using pandas
-        df = pd.read_csv(absolute_path, **kwargs)
+        # Read via format handler registry
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_handler = registry.find_format_reader(absolute_path, "csv")
+        if format_handler is None:
+            raise ValueError("No format handler found for CSV files")
+        df = format_handler.read(absolute_path, **kwargs)
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))
@@ -374,8 +380,14 @@ class DataFrame:
                     f"File not found: {absolute_path}\nDataset '{dataset.slug}' has no source URL to fetch from."
                 )
 
-        # Read the Excel file using pandas
-        df = pd.read_excel(absolute_path, **kwargs)
+        # Read via format handler registry
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        format_handler = registry.find_format_reader(absolute_path, "excel")
+        if format_handler is None:
+            raise ValueError("No format handler found for Excel files")
+        df = format_handler.read(absolute_path, **kwargs)
 
         # Create lineage metadata
         lineage = LineageMetadata(project_path=str(manager.project_path))

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -160,7 +160,7 @@ class DataFrame:
         # Find a format handler (plugin or builtin) for this file
         from .plugins import PluginRegistry
 
-        registry = PluginRegistry.get()
+        registry = PluginRegistry.get(manager.project_path)
 
         # Try explicit format string first, then extension-based detection
         location = str(absolute_path)
@@ -283,7 +283,7 @@ class DataFrame:
         # Read via format handler registry
         from .plugins import PluginRegistry
 
-        registry = PluginRegistry.get()
+        registry = PluginRegistry.get(manager.project_path)
         location = str(absolute_path)
         format_handler = registry.find_format_reader(location, "csv")
         if format_handler is None:
@@ -396,7 +396,7 @@ class DataFrame:
         # Read via format handler registry
         from .plugins import PluginRegistry
 
-        registry = PluginRegistry.get()
+        registry = PluginRegistry.get(manager.project_path)
         location = str(absolute_path)
         format_handler = registry.find_format_reader(location, "excel")
         if format_handler is None:
@@ -465,7 +465,7 @@ class DataFrame:
         if not track:
             from .plugins import PluginRegistry
 
-            registry = PluginRegistry.get()
+            registry = PluginRegistry.get(Path(self.project_path) if self.project_path is not None else None)
             location = str(path_or_buf)
 
             url_handler = registry.find_url_handler(location)
@@ -509,7 +509,7 @@ class DataFrame:
 
         from .plugins import PluginRegistry
 
-        registry = PluginRegistry.get()
+        registry = PluginRegistry.get(manager.project_path)
         location = str(absolute_path)
 
         url_handler = registry.find_url_handler(location)

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -4,6 +4,7 @@ Parser and manager for datasets.yaml files.
 
 import logging
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -698,24 +699,25 @@ class DatasetsManager:
 
         url = dataset.source.location.data
 
-        from urllib.parse import urlparse as _urlparse
-
+        from .handlers import HttpURLHandler, LocalFileHandler
         from .plugins import PluginRegistry
 
-        _scheme = _urlparse(url).scheme
-        if _scheme not in ("http", "https", "gs", "s3", "r2"):
-            raise ValueError(f"No URL handler found for '{url}'. Install a plugin that handles this URL scheme.")
-
-        registry = PluginRegistry.get()
+        registry = PluginRegistry.get(self.project_path)
         url_handler = registry.find_url_handler(url)
 
         if url_handler is None:
             raise ValueError(f"No URL handler found for '{url}'. Install a plugin that handles this URL scheme.")
-
-        # Inject auth headers if the handler supports it
-        if hasattr(url_handler, "headers"):
-            for auth in registry.get_auth_providers():
-                url_handler.headers = auth.authenticate(url, url_handler.headers, dataset)
+        if isinstance(url_handler, LocalFileHandler):
+            raise ValueError(f"No URL handler found for '{url}'. Install a plugin that handles this URL scheme.")
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if isinstance(url_handler, HttpURLHandler):
+            headers: dict[str, str] = {}
+            for auth in registry.get_auth_providers():
+                headers = auth.authenticate(url, headers, dataset)
+            with url_handler.open(url, "rb", headers=headers) as src, open(local_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            return local_path
+
         return registry.fetch(url, local_path)

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -2,16 +2,12 @@
 Parser and manager for datasets.yaml files.
 """
 
-import ipaddress
 import logging
 import os
-import socket
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urljoin, urlparse
 
-import requests
 from ruamel.yaml import YAML
 
 from .exceptions import DatasetNotFoundError, DatasetValidationError
@@ -47,67 +43,6 @@ def _field_schema_to_dict(field: FieldSchema) -> dict:
     if field.source:
         d["source"] = field.source
     return d
-
-
-def _is_public_url(url: str) -> bool:
-    """
-    Validate that a URL points to a public (non-private) resource.
-
-    This function prevents SSRF attacks by blocking:
-    - Non-HTTP(S) schemes (e.g., file://, ftp://)
-    - Private IP addresses (10.x.x.x, 172.16-31.x.x, 192.168.x.x)
-    - Localhost and loopback addresses
-    - Link-local addresses (169.254.x.x)
-
-    Args:
-        url: The URL to validate.
-
-    Returns:
-        True if the URL points to a public resource, False otherwise.
-
-    Raises:
-        Exception: Re-raises unexpected exceptions after logging.
-    """
-    try:
-        parsed = urlparse(url)
-
-        # Only allow HTTP and HTTPS schemes
-        if parsed.scheme not in ("http", "https"):
-            logger.warning("URL scheme '%s' not allowed (only http/https permitted)", parsed.scheme)
-            return False
-
-        # Ensure hostname is present
-        if not parsed.hostname:
-            logger.warning("URL has no hostname")
-            return False
-
-        # Resolve hostname to all IP addresses (IPv4 and IPv6) and check each
-        addrinfos = socket.getaddrinfo(parsed.hostname, None)
-        for addrinfo in addrinfos:
-            sockaddr = addrinfo[4]
-            ip = sockaddr[0]
-            ip_obj = ipaddress.ip_address(ip)
-
-            # Block private, loopback, and link-local addresses
-            if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
-                logger.warning(
-                    "URL hostname '%s' resolves to restricted IP address: %s",
-                    parsed.hostname,
-                    ip,
-                )
-                return False
-
-        return True
-
-    except socket.gaierror:
-        logger.warning("Unable to resolve hostname: %s", parsed.hostname)
-        return False
-    except ValueError as e:
-        logger.warning("Error validating URL '%s': %s", url, e)
-        return False
-    except Exception as e:
-        logger.exception("Unexpected error validating URL '%s': %s", url, e)
-        raise
 
 
 class DatasetsManager:
@@ -728,7 +663,8 @@ class DatasetsManager:
         """
         Fetch a dataset from its source URL if available.
 
-        Auth plugins are consulted to inject headers before each HTTP request.
+        Delegates to URL handler plugins. Auth plugins inject headers
+        into the handler before fetching.
 
         Args:
             dataset: The dataset metadata containing source URL.
@@ -740,7 +676,7 @@ class DatasetsManager:
             Path to the local file (newly downloaded or existing).
 
         Raises:
-            ValueError: If dataset has no source URL or URL is not allowed.
+            ValueError: If dataset has no source URL or no handler matches.
             requests.RequestException: If the fetch fails.
         """
         if not dataset.source or not dataset.source.location.data:
@@ -755,83 +691,18 @@ class DatasetsManager:
 
         url = dataset.source.location.data
 
-        # Check if a URL handler plugin can handle this URL
         from .plugins import PluginRegistry
 
         registry = PluginRegistry.get()
         url_handler = registry.find_url_handler(url)
 
-        if url_handler:
-            local_path.parent.mkdir(parents=True, exist_ok=True)
-            return url_handler.fetch(url, local_path)
+        if url_handler is None:
+            raise ValueError(f"No URL handler found for '{url}'. Install a plugin that handles this URL scheme.")
 
-        # Fall back to built-in HTTP fetch
-        # Validate URL points to public resource to prevent SSRF attacks
-        if not _is_public_url(url):
-            raise ValueError(
-                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to public internet addresses are permitted."
-            )
+        # Inject auth headers if the handler supports it
+        if hasattr(url_handler, "headers"):
+            for auth in registry.get_auth_providers():
+                url_handler.headers = auth.authenticate(url, url_handler.headers, dataset)
 
-        # Collect auth headers from plugins
-        headers: dict[str, str] = {}
-        for auth in registry.get_auth_providers():
-            headers = auth.authenticate(url, headers, dataset)
-
-        logger.info("Fetching dataset from URL: %s", url)
-
-        try:
-            # Disable automatic redirects and handle them manually to prevent SSRF bypass
-            # An attacker could use a public URL that redirects to a private IP
-            current_url = url
-            response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=headers)
-            redirect_count = 0
-
-            while response.is_redirect and redirect_count < max_redirects:
-                redirect_url = response.headers.get("Location")
-                if not redirect_url:
-                    raise ValueError("Redirect response without Location header")
-
-                # Resolve relative URLs against the current URL
-                redirect_url = urljoin(current_url, redirect_url)
-
-                # Validate the redirect target URL for SSRF protection
-                if not _is_public_url(redirect_url):
-                    raise ValueError(
-                        f"Redirect URL '{redirect_url}' is not allowed. Only HTTP/HTTPS URLs "
-                        "pointing to public internet addresses are permitted."
-                    )
-
-                # Strip auth headers on cross-origin redirects to prevent credential leaking
-                redirect_parsed = urlparse(redirect_url)
-                original_parsed = urlparse(url)
-                if redirect_parsed.scheme != original_parsed.scheme or redirect_parsed.netloc != original_parsed.netloc:
-                    redirect_headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
-                else:
-                    redirect_headers = headers
-
-                logger.info("Following redirect to: %s", redirect_url)
-                current_url = redirect_url
-                response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=redirect_headers)
-                redirect_count += 1
-
-            if response.is_redirect:
-                raise ValueError(f"Too many redirects (max: {max_redirects})")
-
-            response.raise_for_status()
-
-            # Ensure parent directory exists
-            local_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Save to local file
-            with open(local_path, "wb") as f:
-                f.write(response.content)
-
-            logger.info("✓ Successfully saved to %s (%d bytes)", local_path, len(response.content))
-            return local_path
-
-        except requests.Timeout:
-            logger.error("Request timed out after %d seconds", timeout)
-            raise
-        except requests.RequestException as e:
-            logger.error("Failed to fetch from URL: %s", e)
-            raise
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        return url_handler.fetch(url, local_path)

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -663,8 +663,8 @@ class DatasetsManager:
         """
         Fetch a dataset from its source URL if available.
 
-        Delegates to URL handler plugins. Auth plugins inject headers
-        into the handler before fetching.
+        .. deprecated::
+            Use ``PluginRegistry.get().fetch(url, dest)`` instead.
 
         Args:
             dataset: The dataset metadata containing source URL.
@@ -677,8 +677,15 @@ class DatasetsManager:
 
         Raises:
             ValueError: If dataset has no source URL or no handler matches.
-            requests.RequestException: If the fetch fails.
         """
+        import warnings
+
+        warnings.warn(
+            "fetch_from_url is deprecated. Use PluginRegistry.get().fetch(url, dest) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if not dataset.source or not dataset.source.location.data:
             raise ValueError(f"Dataset '{dataset.slug}' has no source URL")
 
@@ -691,7 +698,13 @@ class DatasetsManager:
 
         url = dataset.source.location.data
 
+        from urllib.parse import urlparse as _urlparse
+
         from .plugins import PluginRegistry
+
+        _scheme = _urlparse(url).scheme
+        if _scheme not in ("http", "https", "gs", "s3", "r2"):
+            raise ValueError(f"No URL handler found for '{url}'. Install a plugin that handles this URL scheme.")
 
         registry = PluginRegistry.get()
         url_handler = registry.find_url_handler(url)
@@ -705,6 +718,4 @@ class DatasetsManager:
                 url_handler.headers = auth.authenticate(url, url_handler.headers, dataset)
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        with url_handler.open(url, "rb") as stream:  # type: ignore[attr-defined]
-            local_path.write_bytes(stream.read())
-        return local_path
+        return registry.fetch(url, local_path)

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -705,4 +705,4 @@ class DatasetsManager:
                 url_handler.headers = auth.authenticate(url, url_handler.headers, dataset)
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        return url_handler.fetch(url, local_path)
+        return url_handler.fetch(url, local_path)  # type: ignore[attr-defined, no-any-return]  # TODO: update in Task 6

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -801,9 +801,17 @@ class DatasetsManager:
                         "pointing to public internet addresses are permitted."
                     )
 
+                # Strip auth headers on cross-origin redirects to prevent credential leaking
+                redirect_parsed = urlparse(redirect_url)
+                original_parsed = urlparse(url)
+                if redirect_parsed.scheme != original_parsed.scheme or redirect_parsed.netloc != original_parsed.netloc:
+                    redirect_headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
+                else:
+                    redirect_headers = headers
+
                 logger.info("Following redirect to: %s", redirect_url)
                 current_url = redirect_url
-                response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=headers)
+                response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=redirect_headers)
                 redirect_count += 1
 
             if response.is_redirect:

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -705,4 +705,6 @@ class DatasetsManager:
                 url_handler.headers = auth.authenticate(url, url_handler.headers, dataset)
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        return url_handler.fetch(url, local_path)  # type: ignore[attr-defined, no-any-return]  # TODO: update in Task 6
+        with url_handler.open(url, "rb") as stream:  # type: ignore[attr-defined]
+            local_path.write_bytes(stream.read())
+        return local_path

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -728,6 +728,8 @@ class DatasetsManager:
         """
         Fetch a dataset from its source URL if available.
 
+        Auth plugins are consulted to inject headers before each HTTP request.
+
         Args:
             dataset: The dataset metadata containing source URL.
             timeout: Request timeout in seconds.
@@ -753,11 +755,27 @@ class DatasetsManager:
 
         url = dataset.source.location.data
 
+        # Check if a URL handler plugin can handle this URL
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        url_handler = registry.find_url_handler(url)
+
+        if url_handler:
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            return url_handler.fetch(url, local_path)
+
+        # Fall back to built-in HTTP fetch
         # Validate URL points to public resource to prevent SSRF attacks
         if not _is_public_url(url):
             raise ValueError(
                 f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to public internet addresses are permitted."
             )
+
+        # Collect auth headers from plugins
+        headers: dict[str, str] = {}
+        for auth in registry.get_auth_providers():
+            headers = auth.authenticate(url, headers, dataset)
 
         logger.info("Fetching dataset from URL: %s", url)
 
@@ -765,7 +783,7 @@ class DatasetsManager:
             # Disable automatic redirects and handle them manually to prevent SSRF bypass
             # An attacker could use a public URL that redirects to a private IP
             current_url = url
-            response = requests.get(current_url, timeout=timeout, allow_redirects=False)
+            response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=headers)
             redirect_count = 0
 
             while response.is_redirect and redirect_count < max_redirects:
@@ -785,7 +803,7 @@ class DatasetsManager:
 
                 logger.info("Following redirect to: %s", redirect_url)
                 current_url = redirect_url
-                response = requests.get(current_url, timeout=timeout, allow_redirects=False)
+                response = requests.get(current_url, timeout=timeout, allow_redirects=False, headers=headers)
                 redirect_count += 1
 
             if response.is_redirect:

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -8,7 +8,7 @@ import ipaddress
 import logging
 import socket
 from pathlib import Path
-from typing import Callable
+from typing import BinaryIO, Callable, TextIO
 from urllib.parse import urljoin, urlparse
 
 import pandas as pd
@@ -172,3 +172,28 @@ class HttpURLHandler:
 
         logger.info("Successfully saved to %s (%d bytes)", dest, len(response.content))
         return dest
+
+
+_REMOTE_SCHEMES = {"http", "https", "gs", "s3", "r2"}
+
+
+class LocalFileHandler:
+    """Handles local filesystem paths and file:// URLs."""
+
+    def can_handle(self, url: str) -> bool:
+        parsed = urlparse(url)
+        return parsed.scheme in ("", "file") and parsed.scheme not in _REMOTE_SCHEMES
+
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        import builtins as _builtins
+
+        parsed = urlparse(url)
+        if parsed.scheme == "file":
+            path = Path(parsed.path)
+        else:
+            path = Path(url)
+
+        if "w" in mode:
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+        return _builtins.open(path, mode)  # type: ignore[return-value]

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -234,15 +234,11 @@ class LocalFileHandler:
     def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
     def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
         import builtins as _builtins
-        import sys
+        from urllib.request import url2pathname
 
         parsed = urlparse(url)
         if parsed.scheme == "file":
-            raw = parsed.path
-            # On Windows, file:///C:/path produces /C:/path — strip leading slash
-            if sys.platform == "win32" and len(raw) >= 3 and raw[0] == "/" and raw[2] == ":":
-                raw = raw[1:]
-            path = Path(raw)
+            path = Path(url2pathname(parsed.path))
         else:
             path = Path(url)
 

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -218,7 +218,11 @@ class LocalFileHandler:
 
     def can_handle(self, url: str) -> bool:
         parsed = urlparse(url)
-        return parsed.scheme in ("", "file") and parsed.scheme not in _REMOTE_SCHEMES
+        scheme = parsed.scheme
+        # On Windows, urlparse treats drive letters (C:) as schemes
+        if len(scheme) == 1 and scheme.isalpha():
+            return True
+        return scheme in ("", "file") and scheme not in _REMOTE_SCHEMES
 
     @overload
     def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
@@ -230,10 +234,15 @@ class LocalFileHandler:
     def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
     def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
         import builtins as _builtins
+        import sys
 
         parsed = urlparse(url)
         if parsed.scheme == "file":
-            path = Path(parsed.path)
+            raw = parsed.path
+            # On Windows, file:///C:/path produces /C:/path — strip leading slash
+            if sys.platform == "win32" and len(raw) >= 3 and raw[0] == "/" and raw[2] == ":":
+                raw = raw[1:]
+            path = Path(raw)
         else:
             path = Path(url)
 

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -4,10 +4,15 @@ Internal plugin implementations for built-in formats and HTTP fetching.
 
 from __future__ import annotations
 
+import ipaddress
+import logging
+import socket
 from pathlib import Path
 from typing import Callable
+from urllib.parse import urljoin, urlparse
 
 import pandas as pd
+import requests
 
 
 # Extension -> format string mapping
@@ -62,3 +67,108 @@ class BuiltinFormatHandler:
         fmt = self._resolve_format(path, None)
         writer = getattr(df, _WRITER_MAP[fmt])  # type: ignore[index]
         writer(path, **kwargs)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _is_public_url(url: str) -> bool:
+    """
+    Validate that a URL points to a public (non-private) resource.
+
+    Prevents SSRF attacks by blocking non-HTTP(S) schemes, private IPs,
+    localhost, loopback, and link-local addresses.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            logger.warning("URL scheme '%s' not allowed (only http/https permitted)", parsed.scheme)
+            return False
+        if not parsed.hostname:
+            logger.warning("URL has no hostname")
+            return False
+        addrinfos = socket.getaddrinfo(parsed.hostname, None)
+        for addrinfo in addrinfos:
+            sockaddr = addrinfo[4]
+            ip = sockaddr[0]
+            ip_obj = ipaddress.ip_address(ip)
+            if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+                logger.warning(
+                    "URL hostname '%s' resolves to restricted IP address: %s",
+                    parsed.hostname,
+                    ip,
+                )
+                return False
+        return True
+    except socket.gaierror:
+        logger.warning("Unable to resolve hostname: %s", parsed.hostname)
+        return False
+    except ValueError as e:
+        logger.warning("Error validating URL '%s': %s", url, e)
+        return False
+    except Exception as e:
+        logger.exception("Unexpected error validating URL '%s': %s", url, e)
+        raise
+
+
+class HttpURLHandler:
+    """Fetches datasets from HTTP/HTTPS URLs with SSRF protection."""
+
+    def __init__(self, timeout: int = 30, max_redirects: int = 10) -> None:
+        self.timeout = timeout
+        self.max_redirects = max_redirects
+        self.headers: dict[str, str] = {}
+
+    def can_handle(self, url: str) -> bool:
+        parsed = urlparse(url)
+        return parsed.scheme in ("http", "https")
+
+    def fetch(self, url: str, dest: Path) -> Path:
+        if not _is_public_url(url):
+            raise ValueError(
+                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to public internet addresses are permitted."
+            )
+
+        logger.info("Fetching dataset from URL: %s", url)
+
+        current_url = url
+        response = requests.get(current_url, timeout=self.timeout, allow_redirects=False, headers=self.headers)
+        redirect_count = 0
+
+        while response.is_redirect and redirect_count < self.max_redirects:
+            redirect_url = response.headers.get("Location")
+            if not redirect_url:
+                raise ValueError("Redirect response without Location header")
+
+            redirect_url = urljoin(current_url, redirect_url)
+
+            if not _is_public_url(redirect_url):
+                raise ValueError(
+                    f"Redirect URL '{redirect_url}' is not allowed. Only HTTP/HTTPS URLs "
+                    "pointing to public internet addresses are permitted."
+                )
+
+            # Strip auth headers on cross-origin redirects
+            redirect_parsed = urlparse(redirect_url)
+            original_parsed = urlparse(url)
+            if redirect_parsed.scheme != original_parsed.scheme or redirect_parsed.netloc != original_parsed.netloc:
+                redirect_headers = {k: v for k, v in self.headers.items() if k.lower() != "authorization"}
+            else:
+                redirect_headers = self.headers
+
+            logger.info("Following redirect to: %s", redirect_url)
+            current_url = redirect_url
+            response = requests.get(current_url, timeout=self.timeout, allow_redirects=False, headers=redirect_headers)
+            redirect_count += 1
+
+        if response.is_redirect:
+            raise ValueError(f"Too many redirects (max: {self.max_redirects})")
+
+        response.raise_for_status()
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(dest, "wb") as f:
+            f.write(response.content)
+
+        logger.info("Successfully saved to %s (%d bytes)", dest, len(response.content))
+        return dest

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -4,15 +4,17 @@ Internal plugin implementations for built-in formats and HTTP fetching.
 
 from __future__ import annotations
 
+import io
 import ipaddress
 import logging
 import socket
 from pathlib import Path, PurePosixPath
-from typing import BinaryIO, Callable, TextIO
+from typing import BinaryIO, Callable, Literal, TextIO, overload
+from urllib.error import HTTPError
 from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
 
 import pandas as pd
-import requests
 
 
 # Extension -> format string mapping
@@ -138,55 +140,72 @@ class HttpURLHandler:
         parsed = urlparse(url)
         return parsed.scheme in ("http", "https")
 
-    def fetch(self, url: str, dest: Path) -> Path:
+    @overload
+    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        if "w" in mode:
+            raise NotImplementedError(
+                "HTTP write is not supported. Use a cloud storage handler (gs://, s3://) for uploads."
+            )
+
         if not _is_public_url(url):
             raise ValueError(
-                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to public internet addresses are permitted."
+                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to "
+                "public internet addresses are permitted."
             )
 
         logger.info("Fetching dataset from URL: %s", url)
 
         current_url = url
-        response = requests.get(current_url, timeout=self.timeout, allow_redirects=False, headers=self.headers)
+        current_headers = dict(self.headers)
         redirect_count = 0
 
-        while response.is_redirect and redirect_count < self.max_redirects:
-            redirect_url = response.headers.get("Location")
-            if not redirect_url:
-                raise ValueError("Redirect response without Location header")
+        while redirect_count <= self.max_redirects:
+            request = Request(current_url, headers=current_headers)
+            try:
+                response = urlopen(request, timeout=self.timeout)  # noqa: S310
+                break
+            except HTTPError as e:
+                if e.status in (301, 302, 303, 307, 308):
+                    redirect_url = e.headers.get("Location")
+                    if not redirect_url:
+                        raise ValueError("Redirect response without Location header") from e
 
-            redirect_url = urljoin(current_url, redirect_url)
+                    redirect_url = urljoin(current_url, redirect_url)
 
-            if not _is_public_url(redirect_url):
-                raise ValueError(
-                    f"Redirect URL '{redirect_url}' is not allowed. Only HTTP/HTTPS URLs "
-                    "pointing to public internet addresses are permitted."
-                )
+                    if not _is_public_url(redirect_url):
+                        raise ValueError(f"Redirect URL '{redirect_url}' is not allowed.") from e
 
-            # Strip auth headers on cross-origin redirects
-            redirect_parsed = urlparse(redirect_url)
-            original_parsed = urlparse(url)
-            if redirect_parsed.scheme != original_parsed.scheme or redirect_parsed.netloc != original_parsed.netloc:
-                redirect_headers = {k: v for k, v in self.headers.items() if k.lower() != "authorization"}
-            else:
-                redirect_headers = self.headers
+                    # Strip auth headers on cross-origin redirects
+                    redirect_parsed = urlparse(redirect_url)
+                    original_parsed = urlparse(url)
+                    if (
+                        redirect_parsed.scheme != original_parsed.scheme
+                        or redirect_parsed.netloc != original_parsed.netloc
+                    ):
+                        current_headers = {k: v for k, v in current_headers.items() if k.lower() != "authorization"}
 
-            logger.info("Following redirect to: %s", redirect_url)
-            current_url = redirect_url
-            response = requests.get(current_url, timeout=self.timeout, allow_redirects=False, headers=redirect_headers)
-            redirect_count += 1
-
-        if response.is_redirect:
+                    logger.info("Following redirect to: %s", redirect_url)
+                    current_url = redirect_url
+                    redirect_count += 1
+                else:
+                    raise
+        else:
             raise ValueError(f"Too many redirects (max: {self.max_redirects})")
 
-        response.raise_for_status()
+        data = response.read()
+        logger.info("Fetched %d bytes from %s", len(data), current_url)
 
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        with open(dest, "wb") as f:
-            f.write(response.content)
-
-        logger.info("Successfully saved to %s (%d bytes)", dest, len(response.content))
-        return dest
+        if "b" in mode:
+            return io.BytesIO(data)
+        else:
+            return io.TextIOWrapper(io.BytesIO(data), encoding="utf-8")
 
 
 _REMOTE_SCHEMES = {"http", "https", "gs", "s3", "r2"}
@@ -199,6 +218,14 @@ class LocalFileHandler:
         parsed = urlparse(url)
         return parsed.scheme in ("", "file") and parsed.scheme not in _REMOTE_SCHEMES
 
+    @overload
+    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
     def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
         import builtins as _builtins
 

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -60,9 +60,12 @@ class BuiltinFormatHandler:
         fmt = self._resolve_format(path, format)
         return fmt is not None and fmt in _READER_MAP
 
-    def read(self, stream: BinaryIO, **kwargs: object) -> pd.DataFrame:
+    def read(self, stream: BinaryIO | Path, **kwargs: object) -> pd.DataFrame:
         fmt = kwargs.pop("format", None)
         path = kwargs.pop("path", None)
+        # If stream is actually a Path (pre-Task-7 call site), use it for format detection
+        if isinstance(stream, Path) and path is None:
+            path = stream
         if fmt is None and path is not None:
             fmt = self._resolve_format(str(path), None)
         if fmt is None:

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import ipaddress
 import logging
 import socket
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import BinaryIO, Callable, TextIO
 from urllib.parse import urljoin, urlparse
 
@@ -44,29 +44,44 @@ _WRITER_MAP: dict[str, str] = {
 class BuiltinFormatHandler:
     """Handles CSV, JSON, Excel, Parquet, and TSV formats using pandas."""
 
-    def _resolve_format(self, path: Path, format: str | None) -> str | None:
+    def _resolve_format(self, path: str, format: str | None) -> str | None:
         """Resolve a format string from explicit format or file extension."""
         if format is not None:
             return format if format in _READER_MAP or format in _WRITER_MAP else None
-        return _EXTENSION_MAP.get(path.suffix.lower())
+        # Extract extension from path or URL
+        parsed = urlparse(path)
+        file_path = parsed.path if parsed.scheme else path
+        suffix = PurePosixPath(file_path).suffix.lower()
+        return _EXTENSION_MAP.get(suffix)
 
-    def can_read(self, path: Path, format: str | None) -> bool:
+    def can_read(self, path: str, format: str | None) -> bool:
         fmt = self._resolve_format(path, format)
         return fmt is not None and fmt in _READER_MAP
 
-    def read(self, path: Path, **kwargs: object) -> pd.DataFrame:
-        fmt = self._resolve_format(path, None)
-        reader = _READER_MAP[fmt]  # type: ignore[index]
-        return reader(path, **kwargs)
+    def read(self, stream: BinaryIO, **kwargs: object) -> pd.DataFrame:
+        fmt = kwargs.pop("format", None)
+        path = kwargs.pop("path", None)
+        if fmt is None and path is not None:
+            fmt = self._resolve_format(str(path), None)
+        if fmt is None:
+            fmt = "csv"  # safe default
+        reader = _READER_MAP[str(fmt)]
+        return reader(stream, **kwargs)
 
-    def can_write(self, path: Path, format: str | None) -> bool:
+    def can_write(self, path: str, format: str | None) -> bool:
         fmt = self._resolve_format(path, format)
         return fmt is not None and fmt in _WRITER_MAP
 
-    def write(self, df: pd.DataFrame, path: Path, **kwargs: object) -> None:
-        fmt = self._resolve_format(path, None)
-        writer = getattr(df, _WRITER_MAP[fmt])  # type: ignore[index]
-        writer(path, **kwargs)
+    def write(self, df: pd.DataFrame, stream: BinaryIO, **kwargs: object) -> None:
+        fmt = kwargs.pop("format", None)
+        path = kwargs.pop("path", None)
+        if fmt is None and path is not None:
+            fmt = self._resolve_format(str(path), None)
+        if fmt is None:
+            fmt = "csv"
+        method_name = _WRITER_MAP[str(fmt)]
+        writer = getattr(df, method_name)
+        writer(stream, **kwargs)
 
 
 logger = logging.getLogger(__name__)

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -9,10 +9,10 @@ import ipaddress
 import logging
 import socket
 from pathlib import Path, PurePosixPath
-from typing import BinaryIO, Callable, Literal, TextIO, overload
-from urllib.error import HTTPError
+from typing import Any, BinaryIO, Callable, Literal, TextIO, overload
 from urllib.parse import urljoin, urlparse
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+from http.client import HTTPMessage
 
 import pandas as pd
 
@@ -92,6 +92,15 @@ class BuiltinFormatHandler:
 logger = logging.getLogger(__name__)
 
 
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Return redirect responses to the caller so they can be validated manually."""
+
+    def http_error_302(self, req: Request, fp: Any, code: int, msg: str, headers: HTTPMessage) -> Any:
+        return fp
+
+    http_error_301 = http_error_303 = http_error_307 = http_error_308 = http_error_302
+
+
 def _is_public_url(url: str) -> bool:
     """
     Validate that a URL points to a public (non-private) resource.
@@ -137,21 +146,20 @@ class HttpURLHandler:
     def __init__(self, timeout: int = 30, max_redirects: int = 10) -> None:
         self.timeout = timeout
         self.max_redirects = max_redirects
-        self.headers: dict[str, str] = {}
 
     def can_handle(self, url: str) -> bool:
         parsed = urlparse(url)
         return parsed.scheme in ("http", "https")
 
     @overload
-    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    def open(self, url: str, mode: Literal["r"], *, headers: dict[str, str] | None = ...) -> TextIO: ...
     @overload
-    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    def open(self, url: str, mode: Literal["rb"], *, headers: dict[str, str] | None = ...) -> BinaryIO: ...
     @overload
-    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    def open(self, url: str, mode: Literal["w"], *, headers: dict[str, str] | None = ...) -> TextIO: ...
     @overload
-    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
-    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+    def open(self, url: str, mode: Literal["wb"], *, headers: dict[str, str] | None = ...) -> BinaryIO: ...
+    def open(self, url: str, mode: str = "rb", *, headers: dict[str, str] | None = None) -> BinaryIO | TextIO:
         if "w" in mode:
             raise NotImplementedError(
                 "HTTP write is not supported. Use a cloud storage handler (gs://, s3://) for uploads."
@@ -165,44 +173,40 @@ class HttpURLHandler:
         logger.info("Fetching dataset from URL: %s", url)
 
         current_url = url
-        current_headers = dict(self.headers)
-        redirect_count = 0
+        current_headers = dict(headers or {})
+        opener = build_opener(_NoRedirectHandler())
 
-        while redirect_count <= self.max_redirects:
+        for redirect_count in range(self.max_redirects + 1):
             request = Request(current_url, headers=current_headers)
-            try:
-                response = urlopen(request, timeout=self.timeout)  # noqa: S310
+            response = opener.open(request, timeout=self.timeout)  # noqa: S310
+            status = getattr(response, "status", None)
+            if status is None and hasattr(response, "getcode"):
+                status = response.getcode()
+
+            if status not in (301, 302, 303, 307, 308):
+                data = response.read()
+                logger.info("Fetched %d bytes from %s", len(data), current_url)
                 break
-            except HTTPError as e:
-                if e.status in (301, 302, 303, 307, 308):
-                    redirect_url = e.headers.get("Location")
-                    if not redirect_url:
-                        raise ValueError("Redirect response without Location header") from e
 
-                    redirect_url = urljoin(current_url, redirect_url)
+            redirect_url = response.headers.get("Location")
+            response.close()
+            if not redirect_url:
+                raise ValueError("Redirect response without Location header")
 
-                    if not _is_public_url(redirect_url):
-                        raise ValueError(f"Redirect URL '{redirect_url}' is not allowed.") from e
+            redirect_url = urljoin(current_url, redirect_url)
 
-                    # Strip auth headers on cross-origin redirects
-                    redirect_parsed = urlparse(redirect_url)
-                    original_parsed = urlparse(url)
-                    if (
-                        redirect_parsed.scheme != original_parsed.scheme
-                        or redirect_parsed.netloc != original_parsed.netloc
-                    ):
-                        current_headers = {k: v for k, v in current_headers.items() if k.lower() != "authorization"}
+            if not _is_public_url(redirect_url):
+                raise ValueError(f"Redirect URL '{redirect_url}' is not allowed.")
 
-                    logger.info("Following redirect to: %s", redirect_url)
-                    current_url = redirect_url
-                    redirect_count += 1
-                else:
-                    raise
+            redirect_parsed = urlparse(redirect_url)
+            current_parsed = urlparse(current_url)
+            if redirect_parsed.scheme != current_parsed.scheme or redirect_parsed.netloc != current_parsed.netloc:
+                current_headers = {k: v for k, v in current_headers.items() if k.lower() != "authorization"}
+
+            logger.info("Following redirect to: %s", redirect_url)
+            current_url = redirect_url
         else:
             raise ValueError(f"Too many redirects (max: {self.max_redirects})")
-
-        data = response.read()
-        logger.info("Fetched %d bytes from %s", len(data), current_url)
 
         if "b" in mode:
             return io.BytesIO(data)

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -1,0 +1,64 @@
+"""
+Internal plugin implementations for built-in formats and HTTP fetching.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+
+
+# Extension -> format string mapping
+_EXTENSION_MAP: dict[str, str] = {
+    ".csv": "csv",
+    ".json": "json",
+    ".xlsx": "excel",
+    ".xls": "excel",
+    ".parquet": "parquet",
+    ".tsv": "tsv",
+    ".txt": "tsv",
+}
+
+# Format string -> pandas reader function
+_READER_MAP: dict[str, Callable[..., pd.DataFrame]] = {
+    "csv": pd.read_csv,
+    "json": pd.read_json,
+    "excel": pd.read_excel,
+    "parquet": pd.read_parquet,
+    "tsv": lambda path, **kw: pd.read_csv(path, sep="\t", **kw),
+}
+
+# Format string -> pandas writer method name on DataFrame
+_WRITER_MAP: dict[str, str] = {
+    "csv": "to_csv",
+}
+
+
+class BuiltinFormatHandler:
+    """Handles CSV, JSON, Excel, Parquet, and TSV formats using pandas."""
+
+    def _resolve_format(self, path: Path, format: str | None) -> str | None:
+        """Resolve a format string from explicit format or file extension."""
+        if format is not None:
+            return format if format in _READER_MAP or format in _WRITER_MAP else None
+        return _EXTENSION_MAP.get(path.suffix.lower())
+
+    def can_read(self, path: Path, format: str | None) -> bool:
+        fmt = self._resolve_format(path, format)
+        return fmt is not None and fmt in _READER_MAP
+
+    def read(self, path: Path, **kwargs: object) -> pd.DataFrame:
+        fmt = self._resolve_format(path, None)
+        reader = _READER_MAP[fmt]  # type: ignore[index]
+        return reader(path, **kwargs)
+
+    def can_write(self, path: Path, format: str | None) -> bool:
+        fmt = self._resolve_format(path, format)
+        return fmt is not None and fmt in _WRITER_MAP
+
+    def write(self, df: pd.DataFrame, path: Path, **kwargs: object) -> None:
+        fmt = self._resolve_format(path, None)
+        writer = getattr(df, _WRITER_MAP[fmt])  # type: ignore[index]
+        writer(path, **kwargs)

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -159,8 +159,7 @@ class HttpURLHandler:
 
         if not _is_public_url(url):
             raise ValueError(
-                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to "
-                "public internet addresses are permitted."
+                f"URL '{url}' is not allowed. Only HTTP/HTTPS URLs pointing to public internet addresses are permitted."
             )
 
         logger.info("Fetching dataset from URL: %s", url)

--- a/src/sunstone/handlers_gcs.py
+++ b/src/sunstone/handlers_gcs.py
@@ -1,0 +1,67 @@
+"""GCS URL handler. Requires google-cloud-storage (install with sunstone-py[gcs])."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import BinaryIO, Literal, TextIO, overload
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class _GcsWriteStream(io.BytesIO):
+    """A BytesIO that uploads to GCS on close()."""
+
+    def __init__(self, blob: object) -> None:
+        super().__init__()
+        self._blob = blob
+
+    def close(self) -> None:
+        if not self.closed:
+            self.seek(0)
+            self._blob.upload_from_file(self)  # type: ignore[attr-defined]
+        super().close()
+
+
+class GcsURLHandler:
+    """Handles gs:// URLs using google-cloud-storage."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        from google.cloud import storage  # type: ignore[import-untyped]
+
+        self._client = storage.Client()
+
+    def can_handle(self, url: str) -> bool:
+        return urlparse(url).scheme == "gs"
+
+    def _get_blob(self, url: str) -> object:
+        parsed = urlparse(url)
+        bucket = self._client.bucket(parsed.netloc)
+        blob_path = parsed.path.lstrip("/")
+        return bucket.blob(blob_path)
+
+    @overload
+    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        blob = self._get_blob(url)
+
+        if "w" in mode:
+            stream: BinaryIO = _GcsWriteStream(blob)
+            if "b" not in mode:
+                return io.TextIOWrapper(stream, encoding="utf-8")
+            return stream
+
+        data = blob.download_as_bytes()  # type: ignore[attr-defined]
+        logger.info("Downloaded %d bytes from %s", len(data), url)
+        binary_stream = io.BytesIO(data)
+
+        if "b" in mode:
+            return binary_stream
+        return io.TextIOWrapper(binary_stream, encoding="utf-8")

--- a/src/sunstone/handlers_s3.py
+++ b/src/sunstone/handlers_s3.py
@@ -30,7 +30,7 @@ class S3URLHandler:
     """Handles s3:// and r2:// URLs using boto3."""
 
     def __init__(self, config: dict | None = None) -> None:
-        import boto3  # type: ignore[import-untyped]
+        import boto3  # type: ignore[import-untyped,import-not-found]
 
         config = config or {}
         endpoint_url = config.get("endpoint_url")

--- a/src/sunstone/handlers_s3.py
+++ b/src/sunstone/handlers_s3.py
@@ -1,0 +1,72 @@
+"""S3/R2 URL handler. Requires boto3 (install with sunstone-py[s3])."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import BinaryIO, Literal, TextIO, overload
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class _S3WriteStream(io.BytesIO):
+    """A BytesIO that uploads to S3 on close()."""
+
+    def __init__(self, client: object, bucket: str, key: str) -> None:
+        super().__init__()
+        self._client = client
+        self._bucket = bucket
+        self._key = key
+
+    def close(self) -> None:
+        if not self.closed:
+            self.seek(0)
+            self._client.upload_fileobj(self, self._bucket, self._key)  # type: ignore[attr-defined]
+        super().close()
+
+
+class S3URLHandler:
+    """Handles s3:// and r2:// URLs using boto3."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        import boto3  # type: ignore[import-untyped]
+
+        config = config or {}
+        endpoint_url = config.get("endpoint_url")
+        self._client = boto3.client("s3", endpoint_url=endpoint_url)
+
+    def can_handle(self, url: str) -> bool:
+        return urlparse(url).scheme in ("s3", "r2")
+
+    def _parse_url(self, url: str) -> tuple[str, str]:
+        parsed = urlparse(url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        return bucket, key
+
+    @overload
+    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO:
+        bucket, key = self._parse_url(url)
+
+        if "w" in mode:
+            stream: BinaryIO = _S3WriteStream(self._client, bucket, key)
+            if "b" not in mode:
+                return io.TextIOWrapper(stream, encoding="utf-8")
+            return stream
+
+        response = self._client.get_object(Bucket=bucket, Key=key)
+        data = response["Body"].read()
+        logger.info("Downloaded %d bytes from %s", len(data), url)
+        binary_stream = io.BytesIO(data)
+
+        if "b" in mode:
+            return binary_stream
+        return io.TextIOWrapper(binary_stream, encoding="utf-8")

--- a/src/sunstone/packaging.py
+++ b/src/sunstone/packaging.py
@@ -1,0 +1,187 @@
+"""
+Reusable library for building and pushing data packages.
+
+This module extracts the core push logic from cli.py so it can be
+called from Python code without going through the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Optional
+from urllib.parse import urlparse
+
+from .datasets import DatasetsManager
+from .lineage import DatasetMetadata, PublishConfig
+from .plugins import PluginRegistry
+
+# Only the prefixes needed for the datapackage envelope.
+# The full STANDARD_RDF_PREFIXES dict lives in cli.py.
+_RDF_TYPE_URI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+_DCAT_DATASET_URI = "http://www.w3.org/ns/dcat#Dataset"
+
+
+def is_lfs_pointer(file_path: Path) -> bool:
+    """Check if a file is a Git LFS pointer file instead of actual content.
+
+    LFS pointer files are small text files with a specific format:
+        version https://git-lfs.github.com/spec/v1
+        oid sha256:<hash>
+        size <size>
+    """
+    try:
+        # LFS pointers are always small (< 200 bytes typically)
+        if file_path.stat().st_size > 1024:
+            return False
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        return content.startswith("version https://git-lfs.github.com/spec/v1\n")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def push_group(
+    dest_url: str,
+    datasets: list[DatasetMetadata],
+    manager: DatasetsManager,
+    project_slug: str,
+    publish_config: PublishConfig,
+    build_resource_dict_fn: Callable[
+        [DatasetMetadata, DatasetsManager, Optional[PublishConfig]], Optional[dict[str, Any]]
+    ],
+    package_metadata_fn: Callable[[], Optional[dict[str, Any]]],
+    rdf_prefixes: dict[str, str],
+    top_level_props: dict[str, Any],
+    methodology_files: list[tuple[Path, str]],
+) -> list[str]:
+    """Push a group of datasets to a remote destination via URLHandler plugins.
+
+    Args:
+        dest_url: The destination URL (gs://, s3://, r2://, etc.).
+        datasets: The datasets to include in this datapackage.
+        manager: The DatasetsManager instance.
+        project_slug: The project slug for the datapackage name.
+        publish_config: The effective publish config for this group.
+        build_resource_dict_fn: Callback to build a resource dict for a dataset.
+        package_metadata_fn: Callback returning package metadata dict (or None).
+        rdf_prefixes: Merged RDF prefix dict for property expansion.
+        top_level_props: Expanded top-level custom properties to merge into the datapackage.
+        methodology_files: List of (absolute_path, resolved_uri) tuples to upload.
+
+    Returns:
+        List of uploaded path strings (for the caller to report).
+
+    Raises:
+        ValueError: If any data files are Git LFS pointers, or no URL handler
+            is found for the destination.
+    """
+    # Resolve datapackage.json path and base directory
+    if not dest_url.endswith(".json"):
+        if not dest_url.endswith("/"):
+            dest_url += "/"
+        datapackage_url = dest_url + "datapackage.json"
+    else:
+        datapackage_url = dest_url
+
+    parsed = urlparse(datapackage_url)
+    datapackage_path = parsed.path.lstrip("/")
+    if parsed.netloc:
+        datapackage_path = parsed.netloc + "/" + datapackage_path if datapackage_path else parsed.netloc
+
+    # For GCS-style URLs, the path is just the blob path (after bucket)
+    datapackage_path = parsed.path.lstrip("/")
+
+    base_dir = str(PurePosixPath(datapackage_path).parent)
+    if base_dir and base_dir != ".":
+        base_dir = base_dir + "/"
+    else:
+        base_dir = ""
+
+    resources = []
+    data_files: list[tuple[Path, str, str]] = []
+
+    for ds in datasets:
+        resource_dict = build_resource_dict_fn(ds, manager, publish_config)
+        if not resource_dict:
+            continue
+
+        data_path = manager.get_absolute_path(ds.location)
+        if publish_config.flatten:
+            remote_path = base_dir + data_path.name
+            resource_path = data_path.name
+        else:
+            remote_path = base_dir + ds.location
+            resource_path = ds.location
+
+        resources.append(resource_dict)
+        data_files.append((data_path, remote_path, resource_path))
+
+    if not resources:
+        return []
+
+    # Guard: check for LFS pointer files before uploading
+    lfs_pointers = [resource_path for local_path, _, resource_path in data_files if is_lfs_pointer(local_path)]
+    if lfs_pointers:
+        raise ValueError(
+            "The following files are Git LFS pointers, not actual content: "
+            + ", ".join(lfs_pointers)
+            + ". Run 'git lfs pull' to download the actual files before pushing."
+        )
+
+    datapackage: dict[str, Any] = {
+        "name": project_slug,
+        f"{_RDF_TYPE_URI}": _DCAT_DATASET_URI,
+        "resources": resources,
+    }
+
+    # Add standard package metadata
+    pkg_meta = package_metadata_fn()
+    if pkg_meta:
+        datapackage.update(pkg_meta)
+
+    # Add top-level custom properties
+    if top_level_props:
+        datapackage.update(top_level_props)
+
+    # Find a URL handler for the destination
+    registry = PluginRegistry.get()
+    handler = registry.find_url_handler(datapackage_url)
+    if handler is None:
+        raise ValueError(f"No URL handler found for: {datapackage_url}")
+
+    uploaded: list[str] = []
+
+    # Upload datapackage.json
+    with handler.open(datapackage_url, "w") as f:
+        f.write(json.dumps(datapackage, indent=2))
+    uploaded.append(datapackage_path)
+
+    # Upload data files
+    for local_path, remote_path, resource_path in data_files:
+        # Build the full URL for this file
+        file_url = f"{parsed.scheme}://{parsed.netloc}/{remote_path}"
+        with open(local_path, "rb") as src, handler.open(file_url, "wb") as dst:
+            while True:
+                chunk = src.read(8192)
+                if not chunk:
+                    break
+                dst.write(chunk)
+        uploaded.append(resource_path)
+
+    # Upload methodology files
+    for abs_path, _resolved_uri in methodology_files:
+        if publish_config.flatten:
+            methodology_remote = base_dir + abs_path.name
+        else:
+            methodology_remote = base_dir + abs_path.relative_to(manager.project_path).as_posix()
+        methodology_url = f"{parsed.scheme}://{parsed.netloc}/{methodology_remote}"
+        with open(abs_path, "rb") as src, handler.open(methodology_url, "wb") as dst:
+            while True:
+                chunk = src.read(8192)
+                if not chunk:
+                    break
+                dst.write(chunk)
+        uploaded.append(methodology_remote)
+
+    return uploaded

--- a/src/sunstone/packaging.py
+++ b/src/sunstone/packaging.py
@@ -145,7 +145,7 @@ def push_group(
         datapackage.update(top_level_props)
 
     # Find a URL handler for the destination
-    registry = PluginRegistry.get()
+    registry = PluginRegistry.get(manager.project_path)
     handler = registry.find_url_handler(datapackage_url)
     if handler is None:
         raise ValueError(f"No URL handler found for: {datapackage_url}")

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -156,8 +156,8 @@ class PluginRegistry:
         from .handlers import BuiltinFormatHandler, HttpURLHandler, LocalFileHandler
 
         self._format_handlers.append(BuiltinFormatHandler())
-        self._url_handlers.append(HttpURLHandler())  # type: ignore[arg-type]  # TODO: update in Task 5
-        self._url_handlers.append(LocalFileHandler())  # type: ignore[arg-type]  # last fallback
+        self._url_handlers.append(HttpURLHandler())
+        self._url_handlers.append(LocalFileHandler())
 
     def _register(self, name: str, plugin: object) -> None:
         """Classify plugin by protocol conformance."""

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -51,22 +51,22 @@ class URLHandler(Protocol):
 
 @runtime_checkable
 class FormatHandler(Protocol):
-    """Reads and writes data formats not built into sunstone."""
+    """Reads and writes data formats."""
 
-    def can_read(self, path: Path, format: str | None) -> bool:
-        """Return True if this handler can read the given file/format."""
+    def can_read(self, path: str, format: str | None) -> bool:
+        """Return True if this handler can read the given format. path is used for extension detection."""
         ...
 
-    def read(self, path: Path, **kwargs: object) -> pd.DataFrame:
-        """Read file into a pandas DataFrame."""
+    def read(self, stream: BinaryIO, **kwargs: object) -> pd.DataFrame:
+        """Read stream into a pandas DataFrame."""
         ...
 
-    def can_write(self, path: Path, format: str | None) -> bool:
-        """Return True if this handler can write the given file/format."""
+    def can_write(self, path: str, format: str | None) -> bool:
+        """Return True if this handler can write the given format. path is used for extension detection."""
         ...
 
-    def write(self, df: pd.DataFrame, path: Path, **kwargs: object) -> None:
-        """Write DataFrame to file."""
+    def write(self, df: pd.DataFrame, stream: BinaryIO, **kwargs: object) -> None:
+        """Write DataFrame to stream."""
         ...
 
 
@@ -155,7 +155,7 @@ class PluginRegistry:
         # Internal handlers last (fallback)
         from .handlers import BuiltinFormatHandler, HttpURLHandler
 
-        self._format_handlers.append(BuiltinFormatHandler())
+        self._format_handlers.append(BuiltinFormatHandler())  # type: ignore[arg-type]  # TODO: update in Task 4
         self._url_handlers.append(HttpURLHandler())  # type: ignore[arg-type]  # TODO: update in Task 5
 
     def _register(self, name: str, plugin: object) -> None:
@@ -192,17 +192,19 @@ class PluginRegistry:
                 return handler
         return None
 
-    def find_format_reader(self, path: Path, format: str | None) -> FormatHandler | None:
+    def find_format_reader(self, path: Path | str, format: str | None) -> FormatHandler | None:
         """Find the first format handler that can read the given file."""
+        path_str = str(path)
         for handler in self._format_handlers:
-            if handler.can_read(path, format):
+            if handler.can_read(path_str, format):
                 return handler
         return None
 
-    def find_format_writer(self, path: Path, format: str | None) -> FormatHandler | None:
+    def find_format_writer(self, path: Path | str, format: str | None) -> FormatHandler | None:
         """Find the first format handler that can write the given file."""
+        path_str = str(path)
         for handler in self._format_handlers:
-            if handler.can_write(path, format):
+            if handler.can_write(path_str, format):
                 return handler
         return None
 

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -6,12 +6,17 @@ from __future__ import annotations
 
 import importlib.metadata
 import logging
+import os
+import tomllib
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 import pandas as pd
+from ruamel.yaml import YAML
 
 from .lineage import DatasetMetadata
+
+_config_yaml = YAML()
 
 
 @runtime_checkable
@@ -65,9 +70,48 @@ def _get_entry_points() -> list:
     return list(importlib.metadata.entry_points(group="sunstone.plugins"))
 
 
+def _load_cascading_config(name: str, project_path: Path) -> dict | None:
+    """
+    Load plugin config with cascading precedence:
+    1. pyproject.toml [tool.sunstone.plugins.<name>]
+    2. datasets.yaml plugins.<name>
+    3. Environment variables SUNSTONE_PLUGIN_<NAME>_<KEY>
+
+    Later sources override earlier ones. Returns None if no config found.
+    """
+    config: dict = {}
+
+    # Source 1: datasets.yaml
+    datasets_path = project_path / "datasets.yaml"
+    if datasets_path.exists():
+        with open(datasets_path) as f:
+            data = _config_yaml.load(f) or {}
+        plugins_section = data.get("plugins", {})
+        if name in plugins_section and plugins_section[name]:
+            config.update(plugins_section[name])
+
+    # Source 2: pyproject.toml (overrides datasets.yaml)
+    pyproject_path = project_path / "pyproject.toml"
+    if pyproject_path.exists():
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+        plugin_config = pyproject.get("tool", {}).get("sunstone", {}).get("plugins", {}).get(name)
+        if plugin_config:
+            config.update(plugin_config)
+
+    # Source 3: environment variables (override everything)
+    env_prefix = f"SUNSTONE_PLUGIN_{name.upper().replace('-', '_')}_"
+    for key, value in os.environ.items():
+        if key.startswith(env_prefix):
+            config_key = key[len(env_prefix) :].lower()
+            config[config_key] = value
+
+    return config if config else None
+
+
 def _load_plugin_config(name: str) -> dict | None:
-    """Load config for a plugin. Separated for testability. Full implementation in Task 3."""
-    return None
+    """Load config for a plugin using cascading lookup from cwd."""
+    return _load_cascading_config(name, Path.cwd())
 
 
 class PluginRegistry:

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -117,17 +117,19 @@ def _load_cascading_config(name: str, project_path: Path) -> dict | None:
     return config if config else None
 
 
-def _load_plugin_config(name: str) -> dict | None:
-    """Load config for a plugin using cascading lookup from cwd."""
-    return _load_cascading_config(name, Path.cwd())
+def _load_plugin_config(name: str, project_path: Path | None = None) -> dict | None:
+    """Load config for a plugin using cascading lookup from the target project."""
+    return _load_cascading_config(name, (project_path or Path.cwd()).resolve())
 
 
 class PluginRegistry:
     """Discovers and manages plugins."""
 
     _instance: PluginRegistry | None = None
+    _instances: dict[Path, "PluginRegistry"] = {}
 
-    def __init__(self) -> None:
+    def __init__(self, project_path: Path | None = None) -> None:
+        self.project_path = project_path.resolve() if project_path is not None else None
         self._auth_providers: list[AuthProvider] = []
         from .handlers import LocalFileHandler
 
@@ -135,12 +137,21 @@ class PluginRegistry:
         self._format_handlers: list[FormatHandler] = []
 
     @classmethod
-    def get(cls) -> PluginRegistry:
-        """Singleton - lazy-loads plugins on first access."""
-        if cls._instance is None:
-            cls._instance = cls()
-            cls._instance._discover()
-        return cls._instance
+    def get(cls, project_path: Path | str | None = None) -> PluginRegistry:
+        """Return a cached registry instance, scoped to the target project when provided."""
+        if project_path is None:
+            if cls._instance is None:
+                cls._instance = cls()
+                cls._instance._discover()
+            return cls._instance
+
+        project_key = Path(project_path).resolve()
+        registry = cls._instances.get(project_key)
+        if registry is None:
+            registry = cls(project_key)
+            registry._discover()
+            cls._instances[project_key] = registry
+        return registry
 
     def _discover(self) -> None:
         """Load plugins from entry points, then register internal handlers."""
@@ -148,7 +159,7 @@ class PluginRegistry:
         for ep in _get_entry_points():
             try:
                 plugin_cls = ep.load()
-                config = _load_plugin_config(ep.name)
+                config = _load_plugin_config(ep.name, self.project_path)
                 plugin = plugin_cls(config) if config else plugin_cls()
                 self._register(ep.name, plugin)
             except Exception:
@@ -165,7 +176,7 @@ class PluginRegistry:
         try:
             from .handlers_s3 import S3URLHandler
 
-            s3_config = _load_plugin_config("s3")
+            s3_config = _load_plugin_config("s3", self.project_path)
             self._url_handlers.append(S3URLHandler(config=s3_config))
         except ImportError:
             pass  # boto3 not installed

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -4,12 +4,14 @@ Plugin system for extending sunstone with custom auth, URL handlers, and format 
 
 from __future__ import annotations
 
+import builtins
 import importlib.metadata
 import logging
 import os
+import shutil
 import tomllib
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import BinaryIO, Literal, Protocol, TextIO, overload, runtime_checkable
 
 import pandas as pd
 from ruamel.yaml import YAML
@@ -30,15 +32,21 @@ class AuthProvider(Protocol):
 
 @runtime_checkable
 class URLHandler(Protocol):
-    """Resolves custom URL schemes to local file paths."""
+    """Resolves URLs to readable/writable streams."""
 
     def can_handle(self, url: str) -> bool:
         """Return True if this handler can resolve the given URL."""
         ...
 
-    def fetch(self, url: str, dest: Path) -> Path:
-        """Download/resolve URL to a local file. Return path to the file."""
-        ...
+    @overload
+    def open(self, url: str, mode: Literal["r"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["rb"]) -> BinaryIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["w"]) -> TextIO: ...
+    @overload
+    def open(self, url: str, mode: Literal["wb"]) -> BinaryIO: ...
+    def open(self, url: str, mode: str = "rb") -> BinaryIO | TextIO: ...
 
 
 @runtime_checkable
@@ -148,7 +156,7 @@ class PluginRegistry:
         from .handlers import BuiltinFormatHandler, HttpURLHandler
 
         self._format_handlers.append(BuiltinFormatHandler())
-        self._url_handlers.append(HttpURLHandler())
+        self._url_handlers.append(HttpURLHandler())  # type: ignore[arg-type]  # TODO: update in Task 5
 
     def _register(self, name: str, plugin: object) -> None:
         """Classify plugin by protocol conformance."""
@@ -197,3 +205,12 @@ class PluginRegistry:
             if handler.can_write(path, format):
                 return handler
         return None
+
+    def fetch(self, url: str, dest: Path) -> Path:
+        """Convenience: download url to local file via open()."""
+        handler = self.find_url_handler(url)
+        if handler is None:
+            raise ValueError(f"No URL handler found for: {url}")
+        with handler.open(url, "rb") as src, builtins.open(dest, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        return dest

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -86,7 +86,7 @@ def _load_cascading_config(name: str, project_path: Path) -> dict | None:
     if datasets_path.exists():
         with open(datasets_path) as f:
             data = _config_yaml.load(f) or {}
-        plugins_section = data.get("plugins", {})
+        plugins_section = data.get("plugins") or {}
         if name in plugins_section and plugins_section[name]:
             config.update(plugins_section[name])
 

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -4,6 +4,8 @@ Plugin system for extending sunstone with custom auth, URL handlers, and format 
 
 from __future__ import annotations
 
+import importlib.metadata
+import logging
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -53,3 +55,94 @@ class FormatHandler(Protocol):
     def write(self, df: pd.DataFrame, path: Path, **kwargs: object) -> None:
         """Write DataFrame to file."""
         ...
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_entry_points() -> list:
+    """Get entry points for sunstone plugins. Separated for testability."""
+    return list(importlib.metadata.entry_points(group="sunstone.plugins"))
+
+
+def _load_plugin_config(name: str) -> dict | None:
+    """Load config for a plugin. Separated for testability. Full implementation in Task 3."""
+    return None
+
+
+class PluginRegistry:
+    """Discovers and manages plugins."""
+
+    _instance: PluginRegistry | None = None
+
+    def __init__(self) -> None:
+        self._auth_providers: list[AuthProvider] = []
+        self._url_handlers: list[URLHandler] = []
+        self._format_handlers: list[FormatHandler] = []
+
+    @classmethod
+    def get(cls) -> PluginRegistry:
+        """Singleton - lazy-loads plugins on first access."""
+        if cls._instance is None:
+            cls._instance = cls()
+            cls._instance._discover()
+        return cls._instance
+
+    def _discover(self) -> None:
+        """Load plugins from entry points."""
+        for ep in _get_entry_points():
+            try:
+                plugin_cls = ep.load()
+                config = _load_plugin_config(ep.name)
+                plugin = plugin_cls(config) if config else plugin_cls()
+                self._register(ep.name, plugin)
+            except Exception:
+                logger.exception("Failed to load plugin '%s'", ep.name)
+
+    def _register(self, name: str, plugin: object) -> None:
+        """Classify plugin by protocol conformance."""
+        registered = False
+        if isinstance(plugin, AuthProvider):
+            self._auth_providers.append(plugin)
+            registered = True
+        if isinstance(plugin, URLHandler):
+            self._url_handlers.append(plugin)
+            registered = True
+        if isinstance(plugin, FormatHandler):
+            self._format_handlers.append(plugin)
+            registered = True
+        if not registered:
+            logger.warning("Plugin '%s' does not implement any known plugin protocol", name)
+
+    def get_auth_providers(self) -> list[AuthProvider]:
+        """Return all registered auth providers."""
+        return self._auth_providers
+
+    def get_url_handlers(self) -> list[URLHandler]:
+        """Return all registered URL handlers."""
+        return self._url_handlers
+
+    def get_format_handlers(self) -> list[FormatHandler]:
+        """Return all registered format handlers."""
+        return self._format_handlers
+
+    def find_url_handler(self, url: str) -> URLHandler | None:
+        """Find the first URL handler that can handle the given URL."""
+        for handler in self._url_handlers:
+            if handler.can_handle(url):
+                return handler
+        return None
+
+    def find_format_reader(self, path: Path, format: str | None) -> FormatHandler | None:
+        """Find the first format handler that can read the given file."""
+        for handler in self._format_handlers:
+            if handler.can_read(path, format):
+                return handler
+        return None
+
+    def find_format_writer(self, path: Path, format: str | None) -> FormatHandler | None:
+        """Find the first format handler that can write the given file."""
+        for handler in self._format_handlers:
+            if handler.can_write(path, format):
+                return handler
+        return None

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -129,7 +129,9 @@ class PluginRegistry:
 
     def __init__(self) -> None:
         self._auth_providers: list[AuthProvider] = []
-        self._url_handlers: list[URLHandler] = []
+        from .handlers import LocalFileHandler
+
+        self._url_handlers: list[URLHandler] = [LocalFileHandler()]
         self._format_handlers: list[FormatHandler] = []
 
     @classmethod
@@ -153,11 +155,11 @@ class PluginRegistry:
                 logger.exception("Failed to load plugin '%s'", ep.name)
 
         # Internal handlers last (fallback)
-        from .handlers import BuiltinFormatHandler, HttpURLHandler, LocalFileHandler
+        from .handlers import BuiltinFormatHandler, HttpURLHandler
 
         self._format_handlers.append(BuiltinFormatHandler())
         self._url_handlers.append(HttpURLHandler())
-        self._url_handlers.append(LocalFileHandler())
+        # LocalFileHandler is always present (registered in __init__)
 
     def _register(self, name: str, plugin: object) -> None:
         """Classify plugin by protocol conformance."""

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -133,7 +133,8 @@ class PluginRegistry:
         return cls._instance
 
     def _discover(self) -> None:
-        """Load plugins from entry points."""
+        """Load plugins from entry points, then register internal handlers."""
+        # External plugins first (they take priority)
         for ep in _get_entry_points():
             try:
                 plugin_cls = ep.load()
@@ -142,6 +143,12 @@ class PluginRegistry:
                 self._register(ep.name, plugin)
             except Exception:
                 logger.exception("Failed to load plugin '%s'", ep.name)
+
+        # Internal handlers last (fallback)
+        from .handlers import BuiltinFormatHandler, HttpURLHandler
+
+        self._format_handlers.append(BuiltinFormatHandler())
+        self._url_handlers.append(HttpURLHandler())
 
     def _register(self, name: str, plugin: object) -> None:
         """Classify plugin by protocol conformance."""

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -154,6 +154,22 @@ class PluginRegistry:
             except Exception:
                 logger.exception("Failed to load plugin '%s'", ep.name)
 
+        # Optional cloud handlers
+        try:
+            from .handlers_gcs import GcsURLHandler
+
+            self._url_handlers.append(GcsURLHandler())
+        except ImportError:
+            pass  # google-cloud-storage not installed
+
+        try:
+            from .handlers_s3 import S3URLHandler
+
+            s3_config = _load_plugin_config("s3")
+            self._url_handlers.append(S3URLHandler(config=s3_config))
+        except ImportError:
+            pass  # boto3 not installed
+
         # Internal handlers last (fallback)
         from .handlers import BuiltinFormatHandler, HttpURLHandler
 

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -1,0 +1,55 @@
+"""
+Plugin system for extending sunstone with custom auth, URL handlers, and format handlers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import pandas as pd
+
+from .lineage import DatasetMetadata
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Provides authentication for HTTP requests."""
+
+    def authenticate(self, url: str, headers: dict[str, str], dataset: DatasetMetadata) -> dict[str, str]:
+        """Return modified headers dict. Called before every HTTP fetch."""
+        ...
+
+
+@runtime_checkable
+class URLHandler(Protocol):
+    """Resolves custom URL schemes to local file paths."""
+
+    def can_handle(self, url: str) -> bool:
+        """Return True if this handler can resolve the given URL."""
+        ...
+
+    def fetch(self, url: str, dest: Path) -> Path:
+        """Download/resolve URL to a local file. Return path to the file."""
+        ...
+
+
+@runtime_checkable
+class FormatHandler(Protocol):
+    """Reads and writes data formats not built into sunstone."""
+
+    def can_read(self, path: Path, format: str | None) -> bool:
+        """Return True if this handler can read the given file/format."""
+        ...
+
+    def read(self, path: Path, **kwargs: object) -> pd.DataFrame:
+        """Read file into a pandas DataFrame."""
+        ...
+
+    def can_write(self, path: Path, format: str | None) -> bool:
+        """Return True if this handler can write the given file/format."""
+        ...
+
+    def write(self, df: pd.DataFrame, path: Path, **kwargs: object) -> None:
+        """Write DataFrame to file."""
+        ...

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -153,10 +153,11 @@ class PluginRegistry:
                 logger.exception("Failed to load plugin '%s'", ep.name)
 
         # Internal handlers last (fallback)
-        from .handlers import BuiltinFormatHandler, HttpURLHandler
+        from .handlers import BuiltinFormatHandler, HttpURLHandler, LocalFileHandler
 
         self._format_handlers.append(BuiltinFormatHandler())  # type: ignore[arg-type]  # TODO: update in Task 4
         self._url_handlers.append(HttpURLHandler())  # type: ignore[arg-type]  # TODO: update in Task 5
+        self._url_handlers.append(LocalFileHandler())  # type: ignore[arg-type]  # last fallback
 
     def _register(self, name: str, plugin: object) -> None:
         """Classify plugin by protocol conformance."""

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -155,7 +155,7 @@ class PluginRegistry:
         # Internal handlers last (fallback)
         from .handlers import BuiltinFormatHandler, HttpURLHandler, LocalFileHandler
 
-        self._format_handlers.append(BuiltinFormatHandler())  # type: ignore[arg-type]  # TODO: update in Task 4
+        self._format_handlers.append(BuiltinFormatHandler())
         self._url_handlers.append(HttpURLHandler())  # type: ignore[arg-type]  # TODO: update in Task 5
         self._url_handlers.append(LocalFileHandler())  # type: ignore[arg-type]  # last fallback
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,80 @@ from sunstone.cli import _contributor_to_dict, _package_metadata_to_dict, app, e
 from sunstone.lineage import Contributor, PackageMetadata
 
 
+import contextlib
+import io
+
+
+class _MockURLHandler:
+    """A mock URL handler that captures all writes for test assertions.
+
+    Usage::
+
+        handler = _MockURLHandler()
+        with handler.patch():
+            # run CLI commands that call push_group
+            ...
+        # inspect handler.uploaded_text, handler.uploaded_bytes, handler.uploaded_blobs
+    """
+
+    def __init__(self) -> None:
+        self.uploaded_text: dict[str, str] = {}
+        self.uploaded_bytes: dict[str, bytes] = {}
+        self.uploaded_blobs: list[str] = []
+
+    def can_handle(self, url: str) -> bool:
+        return True
+
+    def open(self, url: str, mode: str = "rb") -> io.IOBase:
+        if mode == "w":
+            return self._TextCapture(self, url)
+        elif mode == "wb":
+            return self._BytesCapture(self, url)
+        raise NotImplementedError(f"Mode {mode!r} not supported by _MockURLHandler")
+
+    class _TextCapture(io.StringIO):
+        def __init__(self, handler: "_MockURLHandler", url: str) -> None:
+            super().__init__()
+            self._handler = handler
+            self._url = url
+
+        def close(self) -> None:
+            content = self.getvalue()
+            # Extract blob path from URL
+            from urllib.parse import urlparse
+
+            parsed = urlparse(self._url)
+            blob_path = parsed.path.lstrip("/")
+            self._handler.uploaded_text[blob_path] = content
+            self._handler.uploaded_blobs.append(blob_path)
+            super().close()
+
+    class _BytesCapture(io.BytesIO):
+        def __init__(self, handler: "_MockURLHandler", url: str) -> None:
+            super().__init__()
+            self._handler = handler
+            self._url = url
+
+        def close(self) -> None:
+            content = self.getvalue()
+            from urllib.parse import urlparse
+
+            parsed = urlparse(self._url)
+            blob_path = parsed.path.lstrip("/")
+            self._handler.uploaded_bytes[blob_path] = content
+            self._handler.uploaded_blobs.append(blob_path)
+            super().close()
+
+    @contextlib.contextmanager
+    def patch(self):
+        """Context manager that patches PluginRegistry to return this handler."""
+        mock_registry = MagicMock()
+        mock_registry.find_url_handler.return_value = self
+        with patch("sunstone.packaging.PluginRegistry") as MockPR:
+            MockPR.get.return_value = mock_registry
+            yield self
+
+
 @pytest.fixture
 def runner() -> CliRunner:
     """Create a Click CLI test runner."""
@@ -657,14 +731,8 @@ class TestPackagePushCommand:
         output_dir.mkdir(exist_ok=True)
         (output_dir / "current_un_member_states.csv").write_text("Country,Code\nTest,TST")
 
-        # Mock GCS client
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(test_project / "datasets.yaml")])
             assert result.exit_code == 0
             assert "datapackage.json" in result.output
@@ -677,22 +745,17 @@ class TestPackagePushCommand:
         output_dir.mkdir(exist_ok=True)
         (output_dir / "current_un_member_states.csv").write_text("Country,Code\nTest,TST")
 
-        # Mock GCS client
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(
                 app, ["package", "push", "-f", str(test_project / "datasets.yaml"), "-d", "gs://my-bucket/custom/"]
             )
             assert result.exit_code == 0
-            mock_client.bucket.assert_called_with("my-bucket")
+            # Verify uploads went to the custom bucket path
+            assert any("custom/datapackage.json" in b for b in handler.uploaded_blobs)
 
     def test_push_invalid_destination_scheme(self, runner: CliRunner, test_project: Path) -> None:
-        """Test push with non-gs:// destination fails."""
+        """Test push with a destination that doesn't support writes fails."""
         # Create the output file
         output_dir = test_project / "outputs"
         output_dir.mkdir(exist_ok=True)
@@ -702,10 +765,9 @@ class TestPackagePushCommand:
             app, ["package", "push", "-f", str(test_project / "datasets.yaml"), "-d", "https://example.com/"]
         )
         assert result.exit_code != 0
-        assert "gs://" in result.output
 
     def test_push_with_as_url(self, runner: CliRunner, test_project: Path) -> None:
-        """Test that as_url produces public URLs in datapackage.json while uploads go to GCS."""
+        """Test that as_url produces public URLs in datapackage.json while uploads go to destination."""
         import json
 
         # Create the output file
@@ -722,30 +784,19 @@ class TestPackagePushCommand:
         )
         yaml_path.write_text(content)
 
-        # Mock GCS client and capture uploaded datapackage content
-        uploaded_content = {}
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-
-        def capture_upload(content: str, content_type: str | None = None) -> None:
-            uploaded_content["datapackage"] = content
-
-        mock_blob.upload_from_string.side_effect = capture_upload
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(yaml_path)])
             assert result.exit_code == 0
 
             # Verify datapackage.json has public URLs
-            datapackage = json.loads(uploaded_content["datapackage"])
+            dp_path = [k for k in handler.uploaded_text if "datapackage.json" in k][0]
+            datapackage = json.loads(handler.uploaded_text[dp_path])
             resource_path = datapackage["resources"][0]["path"]
             assert resource_path == "https://data.example.com/un-members/outputs/current_un_member_states.csv"
 
-            # Verify uploads went to GCS
-            mock_client.bucket.assert_called_with("example-bucket")
+            # Verify uploads went to GCS bucket path
+            assert any("datasets/un-members/" in b for b in handler.uploaded_blobs)
 
     def test_push_uploads_methodology_file(self, runner: CliRunner, test_project: Path) -> None:
         """Test that push uploads the methodology file referenced by si:methodology."""
@@ -769,42 +820,19 @@ class TestPackagePushCommand:
         )
         yaml_path.write_text(content)
 
-        # Mock GCS client and track blob paths
-        uploaded_blobs: list[str] = []
-        uploaded_content: dict[str, str] = {}
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-
-        def make_blob(path: str) -> MagicMock:
-            blob = MagicMock()
-            blob.name = path
-
-            def capture_string(content: str, content_type: str | None = None) -> None:
-                uploaded_blobs.append(path)
-                uploaded_content[path] = content
-
-            def capture_file(filename: str) -> None:
-                uploaded_blobs.append(path)
-
-            blob.upload_from_string.side_effect = capture_string
-            blob.upload_from_filename.side_effect = capture_file
-            return blob
-
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.side_effect = make_blob
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(yaml_path)])
             assert result.exit_code == 0
 
             # Verify methodology file was uploaded
             assert any(
-                "DATA_METHODOLOGY.md" in b for b in uploaded_blobs
-            ), f"Methodology file not uploaded. Uploaded blobs: {uploaded_blobs}"
+                "DATA_METHODOLOGY.md" in b for b in handler.uploaded_blobs
+            ), f"Methodology file not uploaded. Uploaded blobs: {handler.uploaded_blobs}"
 
             # Verify datapackage.json contains expanded methodology key
-            dp_path = [b for b in uploaded_blobs if "datapackage.json" in b][0]
-            datapackage = json.loads(uploaded_content[dp_path])
+            dp_path = [b for b in handler.uploaded_text if "datapackage.json" in b][0]
+            datapackage = json.loads(handler.uploaded_text[dp_path])
             methodology_key = "https://sunstone.institute/rdf/vocab#methodology"
             assert methodology_key in datapackage
 
@@ -832,28 +860,13 @@ class TestPackagePushCommand:
         )
         yaml_path.write_text(content)
 
-        uploaded_content: dict[str, str] = {}
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-
-        def make_blob(path: str) -> MagicMock:
-            blob = MagicMock()
-
-            def capture_string(content: str, content_type: str | None = None) -> None:
-                uploaded_content[path] = content
-
-            blob.upload_from_string.side_effect = capture_string
-            return blob
-
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.side_effect = make_blob
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(yaml_path)])
             assert result.exit_code == 0
 
-            dp_path = [k for k in uploaded_content if "datapackage.json" in k][0]
-            datapackage = json.loads(uploaded_content[dp_path])
+            dp_path = [k for k in handler.uploaded_text if "datapackage.json" in k][0]
+            datapackage = json.loads(handler.uploaded_text[dp_path])
             methodology_key = "https://sunstone.institute/rdf/vocab#methodology"
             assert methodology_key in datapackage
             assert datapackage[methodology_key] == "https://data.example.com/un-members/report/DATA_METHODOLOGY.md"
@@ -882,41 +895,20 @@ class TestPackagePushCommand:
         )
         yaml_path.write_text(content)
 
-        uploaded_blobs: list[str] = []
-        uploaded_content: dict[str, str] = {}
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-
-        def make_blob(path: str) -> MagicMock:
-            blob = MagicMock()
-
-            def capture_string(content: str, content_type: str | None = None) -> None:
-                uploaded_blobs.append(path)
-                uploaded_content[path] = content
-
-            def capture_file(filename: str) -> None:
-                uploaded_blobs.append(path)
-
-            blob.upload_from_string.side_effect = capture_string
-            blob.upload_from_filename.side_effect = capture_file
-            return blob
-
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.side_effect = make_blob
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(yaml_path)])
             assert result.exit_code == 0, result.output
 
             # Methodology file should be uploaded with flattened path (just filename)
-            methodology_blobs = [b for b in uploaded_blobs if "DATA_METHODOLOGY.md" in b]
+            methodology_blobs = [b for b in handler.uploaded_blobs if "DATA_METHODOLOGY.md" in b]
             assert len(methodology_blobs) == 1
             # Should be "datasets/un-members/DATA_METHODOLOGY.md", not "datasets/un-members/report/DATA_METHODOLOGY.md"
             assert methodology_blobs[0] == "datasets/un-members/DATA_METHODOLOGY.md"
 
             # datapackage.json should have flattened methodology URL
-            dp_path = [k for k in uploaded_content if "datapackage.json" in k][0]
-            datapackage = json.loads(uploaded_content[dp_path])
+            dp_path = [k for k in handler.uploaded_text if "datapackage.json" in k][0]
+            datapackage = json.loads(handler.uploaded_text[dp_path])
             methodology_key = "https://sunstone.institute/rdf/vocab#methodology"
             assert methodology_key in datapackage
             assert datapackage[methodology_key] == "https://data.example.com/un-members/DATA_METHODOLOGY.md"
@@ -967,20 +959,14 @@ class TestIsLfsPointer:
             "size 12345\n"
         )
 
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(test_project / "datasets.yaml")])
             assert result.exit_code != 0
-            assert "Git LFS pointers" in result.output
+            assert "LFS pointers" in result.output
             assert "git lfs pull" in result.output
             # Verify no uploads happened
-            mock_blob.upload_from_string.assert_not_called()
-            mock_blob.upload_from_filename.assert_not_called()
+            assert len(handler.uploaded_blobs) == 0
 
 
 class TestPublishConfigParsing:
@@ -1272,21 +1258,15 @@ class TestPerDatasetPublish:
         (tmp_path / "a.csv").write_text("col\nval")
         (tmp_path / "b.csv").write_text("col\nval")
 
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(yaml_file)])
             assert result.exit_code == 0
             assert "Pushed to 2 destination(s)" in result.output
 
             # Verify both datapackage.json paths were uploaded
-            blob_calls = [call[0][0] for call in mock_bucket.blob.call_args_list]
-            assert "a/datapackage.json" in blob_calls
-            assert "b/datapackage.json" in blob_calls
+            assert any("a/datapackage.json" in b for b in handler.uploaded_blobs)
+            assert any("b/datapackage.json" in b for b in handler.uploaded_blobs)
 
     def test_publish_not_in_custom_properties(self, runner: CliRunner, tmp_path: Path) -> None:
         """Test that per-dataset publish config doesn't leak into custom_properties."""
@@ -1458,23 +1438,13 @@ class TestBuildDatapackageWithPackageMetadata:
         output_dir.mkdir(exist_ok=True)
         (output_dir / "current_un_member_states.csv").write_text("Country,Code\nTest,TST")
 
-        uploaded_content: dict[str, str] = {}
-        mock_client = MagicMock()
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-
-        def capture_upload(content: str, content_type: str | None = None) -> None:
-            uploaded_content["datapackage"] = content
-
-        mock_blob.upload_from_string.side_effect = capture_upload
-
-        with patch("google.cloud.storage.Client", return_value=mock_client):
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(app, ["package", "push", "-f", str(test_project / "datasets.yaml")])
             assert result.exit_code == 0
 
-            dp = json.loads(uploaded_content["datapackage"])
+            dp_path = [k for k in handler.uploaded_text if "datapackage.json" in k][0]
+            dp = json.loads(handler.uploaded_text[dp_path])
             assert dp["title"] == "UN Member States Dataset"
             assert dp["version"] == "1.0.0"
             assert dp["license"] == "CC-BY-4.0"
@@ -1711,27 +1681,17 @@ class TestParquetResourceSupport:
 
     def test_package_push_parquet_uploads_file(self, runner: CliRunner, parquet_project: Path) -> None:
         """package push uploads Parquet files when publish is configured."""
-        from unittest.mock import MagicMock, patch
-
-        mock_bucket = MagicMock()
-        mock_blob = MagicMock()
-        mock_bucket.blob.return_value = mock_blob
-
-        with patch("google.cloud.storage.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client_cls.return_value = mock_client
-            mock_client.bucket.return_value = mock_bucket
-
+        handler = _MockURLHandler()
+        with handler.patch():
             result = runner.invoke(
                 app,
                 ["package", "push", "-f", str(parquet_project / "datasets.yaml")],
             )
 
         assert result.exit_code == 0, f"Command failed: {result.output}"
-        # Verify upload_from_filename was called for the Parquet file
-        upload_calls = mock_blob.upload_from_filename.call_args_list
-        parquet_calls = [c for c in upload_calls if str(c.args[0]).endswith(".parquet")]
-        assert len(parquet_calls) >= 1, f"Expected at least one Parquet upload, got: {upload_calls}"
+        # Verify a Parquet file was uploaded
+        parquet_blobs = [b for b in handler.uploaded_blobs if b.endswith(".parquet")]
+        assert len(parquet_blobs) >= 1, f"Expected at least one Parquet upload, got: {handler.uploaded_blobs}"
 
     def test_parquet_resource_has_rdf_type(self, parquet_project: Path) -> None:
         """Parquet resource dict includes the DCAT Distribution RDF type."""

--- a/tests/test_dataframe_coverage.py
+++ b/tests/test_dataframe_coverage.py
@@ -180,7 +180,7 @@ class TestReadDatasetFormatDetection:
 
     def test_unsupported_format_raises_value_error(self, project_copy: Path) -> None:
         """Line 192: Unsupported explicit format raises ValueError."""
-        with pytest.raises(ValueError, match="Unsupported format"):
+        with pytest.raises(ValueError, match="No format handler found"):
             DataFrame.read_dataset(
                 "official-un-member-states",
                 project_path=project_copy,
@@ -200,7 +200,7 @@ class TestReadDatasetFormatDetection:
             location="inputs/test_data.xyz",
         )
 
-        with pytest.raises(ValueError, match="Cannot auto-detect format"):
+        with pytest.raises(ValueError, match="No format handler found"):
             DataFrame.read_dataset(
                 "test-weird",
                 project_path=project_copy,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 import sunstone
-from sunstone.datasets import _is_public_url
+from sunstone.handlers import _is_public_url
 
 
 def mock_getaddrinfo(ip: str) -> list[tuple[Any, ...]]:
@@ -230,13 +230,13 @@ class TestURLSafety:
 
     def test_valid_https_url(self) -> None:
         """Test that valid HTTPS URLs to public addresses are allowed."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("93.184.216.34")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("93.184.216.34")):
             assert _is_public_url("https://example.com/data.csv") is True
             assert _is_public_url("https://www.google.com/file.json") is True
 
     def test_valid_http_url(self) -> None:
         """Test that valid HTTP URLs to public addresses are allowed."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("93.184.216.34")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("93.184.216.34")):
             assert _is_public_url("http://example.com/data.csv") is True
 
     def test_file_scheme_blocked(self) -> None:
@@ -250,77 +250,77 @@ class TestURLSafety:
 
     def test_localhost_blocked(self) -> None:
         """Test that localhost URLs are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
             assert _is_public_url("http://localhost/api") is False
             assert _is_public_url("http://localhost:8080/data") is False
 
     def test_loopback_ip_blocked(self) -> None:
         """Test that loopback IP addresses are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
             assert _is_public_url("http://127.0.0.1/api") is False
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.2")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.2")):
             assert _is_public_url("http://127.0.0.2:8080/data") is False
 
     def test_private_ip_10_blocked(self) -> None:
         """Test that private IP addresses (10.x.x.x) are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("10.0.0.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("10.0.0.1")):
             assert _is_public_url("http://internal.example.com/api") is False
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("10.255.255.254")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("10.255.255.254")):
             assert _is_public_url("http://10.255.255.254/data") is False
 
     def test_private_ip_192_168_blocked(self) -> None:
         """Test that private IP addresses (192.168.x.x) are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.1.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.1.1")):
             assert _is_public_url("http://router.local/config") is False
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.100.50")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.100.50")):
             assert _is_public_url("http://192.168.100.50/api") is False
 
     def test_private_ip_172_16_blocked(self) -> None:
         """Test that private IP addresses (172.16-31.x.x) are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("172.16.0.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("172.16.0.1")):
             assert _is_public_url("http://internal-app.local/data") is False
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("172.31.255.255")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("172.31.255.255")):
             assert _is_public_url("http://172.31.255.255/api") is False
 
     def test_link_local_blocked(self) -> None:
         """Test that link-local addresses (169.254.x.x) are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
             assert _is_public_url("http://169.254.169.254/metadata") is False
 
     def test_cloud_metadata_endpoint_blocked(self) -> None:
         """Test that AWS/GCP cloud metadata endpoints are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
             assert _is_public_url("http://169.254.169.254/latest/meta-data/") is False
 
     def test_ipv6_loopback_blocked(self) -> None:
         """Test that IPv6 loopback address (::1) is blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("::1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("::1")):
             assert _is_public_url("http://localhost/api") is False
             assert _is_public_url("http://[::1]/api") is False
             assert _is_public_url("http://[::1]:8080/data") is False
 
     def test_ipv6_link_local_blocked(self) -> None:
         """Test that IPv6 link-local addresses (fe80::) are blocked."""
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("fe80::1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("fe80::1")):
             assert _is_public_url("http://ipv6-link-local.example.com/data") is False
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("fe80::1234:5678:abcd:ef01")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("fe80::1234:5678:abcd:ef01")):
             assert _is_public_url("http://[fe80::1234:5678:abcd:ef01]/api") is False
 
     def test_ipv6_unique_local_blocked(self) -> None:
         """Test that IPv6 unique local addresses (fc00::/7, including fd00::) are blocked."""
         # fc00:: prefix (unique local, not yet assigned)
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("fc00::1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("fc00::1")):
             assert _is_public_url("http://internal-ipv6.example.com/data") is False
         # fd00:: prefix (unique local, commonly used for private networks)
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("fd00::1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("fd00::1")):
             assert _is_public_url("http://private-ipv6.example.com/api") is False
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("fd12:3456:789a::1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("fd12:3456:789a::1")):
             assert _is_public_url("http://[fd12:3456:789a::1]:8080/data") is False
 
     def test_dns_resolution_failure(self) -> None:
         """Test that URLs with unresolvable hostnames are blocked."""
         with patch(
-            "sunstone.datasets.socket.getaddrinfo",
+            "sunstone.handlers.socket.getaddrinfo",
             side_effect=socket.gaierror("DNS lookup failed"),
         ):
             assert _is_public_url("http://nonexistent-domain-xyz123.com/data") is False
@@ -333,15 +333,15 @@ class TestURLSafety:
         """
         # 2130706433 is the decimal representation of 127.0.0.1
         # getaddrinfo resolves this to the actual IP, which should be blocked
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
             assert _is_public_url("http://2130706433/api") is False
 
         # 3232235777 is the decimal representation of 192.168.1.1
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.1.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.1.1")):
             assert _is_public_url("http://3232235777/data") is False
 
         # 2851995649 is the decimal representation of 169.254.169.254 (cloud metadata)
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
             assert _is_public_url("http://2851995649/latest/meta-data/") is False
 
     def test_hex_ip_representation_blocked(self) -> None:
@@ -351,15 +351,15 @@ class TestURLSafety:
         socket.getaddrinfo() correctly resolves these to the actual IP address.
         """
         # 0x7f000001 is the hex representation of 127.0.0.1
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
             assert _is_public_url("http://0x7f000001/api") is False
 
         # 0xc0a80101 is the hex representation of 192.168.1.1
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.1.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("192.168.1.1")):
             assert _is_public_url("http://0xc0a80101/data") is False
 
         # 0xa9fea9fe is the hex representation of 169.254.169.254
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
             assert _is_public_url("http://0xa9fea9fe/metadata") is False
 
     def test_mixed_notation_ip_blocked(self) -> None:
@@ -369,7 +369,7 @@ class TestURLSafety:
         represented as 0x7f.0.0.1 or similar variations.
         """
         # Various representations that resolve to loopback
-        with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
+        with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("127.0.0.1")):
             assert _is_public_url("http://0x7f.0.0.1/api") is False
             assert _is_public_url("http://127.0x0.0.1/data") is False
 
@@ -387,7 +387,7 @@ class TestURLSafety:
             dataset.source.location.data = "http://169.254.169.254/metadata"
 
             # Mock DNS resolution to return the link-local IP
-            with patch("sunstone.datasets.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
+            with patch("sunstone.handlers.socket.getaddrinfo", return_value=mock_getaddrinfo("169.254.169.254")):
                 with pytest.raises(ValueError, match="not allowed"):
                     manager.fetch_from_url(dataset, force=True)
 
@@ -400,7 +400,7 @@ class TestURLSafety:
             # Mock the source URL to use file:// scheme
             dataset.source.location.data = "file:///etc/passwd"
 
-            with pytest.raises(ValueError, match="not allowed"):
+            with pytest.raises(ValueError, match="No URL handler found"):
                 manager.fetch_from_url(dataset, force=True)
 
 
@@ -429,8 +429,8 @@ class TestRedirectSSRFProtection:
             mock_redirect_response.is_redirect = True
             mock_redirect_response.headers = {"Location": "http://evil-internal.local/metadata"}
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.datasets.requests.get", return_value=mock_redirect_response):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
+                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -453,8 +453,8 @@ class TestRedirectSSRFProtection:
             mock_redirect_response.is_redirect = True
             mock_redirect_response.headers = {"Location": "http://localhost/admin"}
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.datasets.requests.get", return_value=mock_redirect_response):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
+                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -477,8 +477,8 @@ class TestRedirectSSRFProtection:
             mock_redirect_response.is_redirect = True
             mock_redirect_response.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.datasets.requests.get", return_value=mock_redirect_response):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
+                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -505,9 +505,9 @@ class TestRedirectSSRFProtection:
             mock_final_response.content = b"test data"
             mock_final_response.raise_for_status = unittest.mock.Mock()
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
                 with patch(
-                    "sunstone.datasets.requests.get",
+                    "sunstone.handlers.requests.get",
                     side_effect=[mock_redirect_response, mock_final_response],
                 ):
                     # Mock file writing to avoid modifying test input files
@@ -532,8 +532,8 @@ class TestRedirectSSRFProtection:
             mock_redirect_response.is_redirect = True
             mock_redirect_response.headers = {"Location": "https://example.com/redirect-loop"}
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.datasets.requests.get", return_value=mock_redirect_response):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
+                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
                     with pytest.raises(ValueError, match="Too many redirects"):
                         manager.fetch_from_url(dataset, force=True, max_redirects=5)
 
@@ -552,8 +552,8 @@ class TestRedirectSSRFProtection:
             mock_redirect_response.is_redirect = True
             mock_redirect_response.headers = {}  # No Location header
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.datasets.requests.get", return_value=mock_redirect_response):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
+                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
                     with pytest.raises(ValueError, match="Location header"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -572,8 +572,8 @@ class TestRedirectSSRFProtection:
             mock_redirect_response.is_redirect = True
             mock_redirect_response.headers = {"Location": "file:///etc/passwd"}
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.datasets.requests.get", return_value=mock_redirect_response):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
+                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -599,9 +599,9 @@ class TestRedirectSSRFProtection:
             mock_final_response.content = b"test data"
             mock_final_response.raise_for_status = unittest.mock.Mock()
 
-            with patch("sunstone.datasets.socket.getaddrinfo", side_effect=dns_side_effect):
+            with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
                 with patch(
-                    "sunstone.datasets.requests.get",
+                    "sunstone.handlers.requests.get",
                     side_effect=[mock_redirect_response, mock_final_response],
                 ) as mock_get:
                     # Mock file writing to avoid modifying test input files

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -7,11 +7,27 @@ import unittest.mock
 from pathlib import Path
 from unittest.mock import patch
 from typing import Any
+from urllib.error import HTTPError
 
 
 import pytest
 import sunstone
 from sunstone.handlers import _is_public_url
+
+
+def _make_redirect_error(url: str, status: int, location: str | None) -> HTTPError:
+    """Create an HTTPError that simulates an HTTP redirect response."""
+    headers: dict[str, str] = {}
+    if location is not None:
+        headers["Location"] = location
+    return HTTPError(url, status, "Redirect", headers, None)  # type: ignore[arg-type]
+
+
+def _make_ok_response(content: bytes = b"test data") -> unittest.mock.Mock:
+    """Create a mock urlopen response for a successful (200) request."""
+    mock_resp = unittest.mock.Mock()
+    mock_resp.read.return_value = content
+    return mock_resp
 
 
 def mock_getaddrinfo(ip: str) -> list[tuple[Any, ...]]:
@@ -424,13 +440,12 @@ class TestRedirectSSRFProtection:
                     return mock_getaddrinfo("192.168.1.1")  # Private IP
                 raise socket.gaierror("Unknown host")
 
-            # Mock HTTP response with redirect to private IP
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {"Location": "http://evil-internal.local/metadata"}
+            redirect_error = _make_redirect_error(
+                "https://example.com/data.csv", 302, "http://evil-internal.local/metadata"
+            )
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
+                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -449,12 +464,10 @@ class TestRedirectSSRFProtection:
                     return mock_getaddrinfo("127.0.0.1")
                 raise socket.gaierror("Unknown host")
 
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {"Location": "http://localhost/admin"}
+            redirect_error = _make_redirect_error("https://example.com/data.csv", 302, "http://localhost/admin")
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
+                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -473,12 +486,12 @@ class TestRedirectSSRFProtection:
                     return mock_getaddrinfo("169.254.169.254")
                 raise socket.gaierror("Unknown host")
 
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+            redirect_error = _make_redirect_error(
+                "https://example.com/data.csv", 302, "http://169.254.169.254/latest/meta-data/"
+            )
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
+                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -494,21 +507,13 @@ class TestRedirectSSRFProtection:
                 # Both URLs resolve to public IPs
                 return mock_getaddrinfo("93.184.216.34")
 
-            # First call returns redirect, second call returns content
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {"Location": "https://example.com/new-path"}
-
-            mock_final_response = unittest.mock.Mock()
-            mock_final_response.is_redirect = False
-            mock_final_response.status_code = 200
-            mock_final_response.content = b"test data"
-            mock_final_response.raise_for_status = unittest.mock.Mock()
+            redirect_error = _make_redirect_error("https://example.com/old-path", 302, "https://example.com/new-path")
+            ok_response = _make_ok_response(b"test data")
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
                 with patch(
-                    "sunstone.handlers.requests.get",
-                    side_effect=[mock_redirect_response, mock_final_response],
+                    "sunstone.handlers.urlopen",
+                    side_effect=[redirect_error, ok_response],
                 ):
                     # Mock file writing to avoid modifying test input files
                     with patch("builtins.open", unittest.mock.mock_open()):
@@ -527,15 +532,16 @@ class TestRedirectSSRFProtection:
             def dns_side_effect(hostname: str, port: Any) -> list[tuple[Any, ...]]:
                 return mock_getaddrinfo("93.184.216.34")  # All public IPs
 
-            # Always return redirect
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {"Location": "https://example.com/redirect-loop"}
+            # HttpURLHandler.max_redirects defaults to 10; loop exits after 11 redirects
+            redirect_errors = [
+                _make_redirect_error("https://example.com/redirect-loop", 302, "https://example.com/redirect-loop")
+                for _ in range(12)
+            ]
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
+                with patch("sunstone.handlers.urlopen", side_effect=redirect_errors):
                     with pytest.raises(ValueError, match="Too many redirects"):
-                        manager.fetch_from_url(dataset, force=True, max_redirects=5)
+                        manager.fetch_from_url(dataset, force=True)
 
     def test_redirect_without_location_header_blocked(self, project_path: Path) -> None:
         """Test that redirects without Location header are blocked."""
@@ -548,12 +554,11 @@ class TestRedirectSSRFProtection:
             def dns_side_effect(hostname: str, port: Any) -> list[tuple[Any, ...]]:
                 return mock_getaddrinfo("93.184.216.34")
 
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {}  # No Location header
+            # Redirect with no Location header
+            redirect_error = _make_redirect_error("https://example.com/data.csv", 302, None)
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
+                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
                     with pytest.raises(ValueError, match="Location header"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -568,12 +573,10 @@ class TestRedirectSSRFProtection:
             def dns_side_effect(hostname: str, port: Any) -> list[tuple[Any, ...]]:
                 return mock_getaddrinfo("93.184.216.34")
 
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {"Location": "file:///etc/passwd"}
+            redirect_error = _make_redirect_error("https://example.com/data.csv", 302, "file:///etc/passwd")
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.requests.get", return_value=mock_redirect_response):
+                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -588,28 +591,20 @@ class TestRedirectSSRFProtection:
             def dns_side_effect(hostname: str, port: Any) -> list[tuple[Any, ...]]:
                 return mock_getaddrinfo("93.184.216.34")  # Public IP
 
-            # First call returns redirect with relative URL, second call returns content
-            mock_redirect_response = unittest.mock.Mock()
-            mock_redirect_response.is_redirect = True
-            mock_redirect_response.headers = {"Location": "../new/data.csv"}  # Relative URL
-
-            mock_final_response = unittest.mock.Mock()
-            mock_final_response.is_redirect = False
-            mock_final_response.status_code = 200
-            mock_final_response.content = b"test data"
-            mock_final_response.raise_for_status = unittest.mock.Mock()
+            redirect_error = _make_redirect_error("https://example.com/old/data.csv", 302, "../new/data.csv")
+            ok_response = _make_ok_response(b"test data")
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
                 with patch(
-                    "sunstone.handlers.requests.get",
-                    side_effect=[mock_redirect_response, mock_final_response],
-                ) as mock_get:
+                    "sunstone.handlers.urlopen",
+                    side_effect=[redirect_error, ok_response],
+                ) as mock_urlopen:
                     # Mock file writing to avoid modifying test input files
                     with patch("builtins.open", unittest.mock.mock_open()):
                         result = manager.fetch_from_url(dataset, force=True)
                         assert result is not None
                         # Verify the relative URL was resolved to the correct absolute URL
                         # The second call should be to the resolved URL: https://example.com/new/data.csv
-                        assert mock_get.call_count == 2
-                        second_call_url = mock_get.call_args_list[1][0][0]
-                        assert second_call_url == "https://example.com/new/data.csv"
+                        assert mock_urlopen.call_count == 2
+                        second_call_request = mock_urlopen.call_args_list[1][0][0]
+                        assert second_call_request.full_url == "https://example.com/new/data.csv"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,9 +5,8 @@ Tests for Sunstone DatasetsManager functionality.
 import socket
 import unittest.mock
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from typing import Any
-from urllib.error import HTTPError
 
 
 import pytest
@@ -15,19 +14,20 @@ import sunstone
 from sunstone.handlers import _is_public_url
 
 
-def _make_redirect_error(url: str, status: int, location: str | None) -> HTTPError:
-    """Create an HTTPError that simulates an HTTP redirect response."""
-    headers: dict[str, str] = {}
+def _make_response(status: int, location: str | None = None, content: bytes = b"test data") -> MagicMock:
+    """Create a mock urllib response object."""
+    mock_resp = MagicMock()
+    mock_resp.status = status
+    mock_resp.headers = {}
     if location is not None:
-        headers["Location"] = location
-    return HTTPError(url, status, "Redirect", headers, None)  # type: ignore[arg-type]
+        mock_resp.headers["Location"] = location
+    mock_resp.read.return_value = content
+    return mock_resp
 
 
 def _make_ok_response(content: bytes = b"test data") -> unittest.mock.Mock:
     """Create a mock urlopen response for a successful (200) request."""
-    mock_resp = unittest.mock.Mock()
-    mock_resp.read.return_value = content
-    return mock_resp
+    return _make_response(200, content=content)
 
 
 def mock_getaddrinfo(ip: str) -> list[tuple[Any, ...]]:
@@ -440,12 +440,12 @@ class TestRedirectSSRFProtection:
                     return mock_getaddrinfo("192.168.1.1")  # Private IP
                 raise socket.gaierror("Unknown host")
 
-            redirect_error = _make_redirect_error(
-                "https://example.com/data.csv", 302, "http://evil-internal.local/metadata"
-            )
+            redirect_response = _make_response(302, "http://evil-internal.local/metadata")
+            mock_opener = MagicMock()
+            mock_opener.open.return_value = redirect_response
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -464,10 +464,12 @@ class TestRedirectSSRFProtection:
                     return mock_getaddrinfo("127.0.0.1")
                 raise socket.gaierror("Unknown host")
 
-            redirect_error = _make_redirect_error("https://example.com/data.csv", 302, "http://localhost/admin")
+            redirect_response = _make_response(302, "http://localhost/admin")
+            mock_opener = MagicMock()
+            mock_opener.open.return_value = redirect_response
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -486,12 +488,12 @@ class TestRedirectSSRFProtection:
                     return mock_getaddrinfo("169.254.169.254")
                 raise socket.gaierror("Unknown host")
 
-            redirect_error = _make_redirect_error(
-                "https://example.com/data.csv", 302, "http://169.254.169.254/latest/meta-data/"
-            )
+            redirect_response = _make_response(302, "http://169.254.169.254/latest/meta-data/")
+            mock_opener = MagicMock()
+            mock_opener.open.return_value = redirect_response
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -507,14 +509,13 @@ class TestRedirectSSRFProtection:
                 # Both URLs resolve to public IPs
                 return mock_getaddrinfo("93.184.216.34")
 
-            redirect_error = _make_redirect_error("https://example.com/old-path", 302, "https://example.com/new-path")
+            redirect_response = _make_response(302, "https://example.com/new-path")
             ok_response = _make_ok_response(b"test data")
+            mock_opener = MagicMock()
+            mock_opener.open.side_effect = [redirect_response, ok_response]
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch(
-                    "sunstone.handlers.urlopen",
-                    side_effect=[redirect_error, ok_response],
-                ):
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     # Mock file writing to avoid modifying test input files
                     with patch("builtins.open", unittest.mock.mock_open()):
                         # Should succeed without raising an error
@@ -533,13 +534,12 @@ class TestRedirectSSRFProtection:
                 return mock_getaddrinfo("93.184.216.34")  # All public IPs
 
             # HttpURLHandler.max_redirects defaults to 10; loop exits after 11 redirects
-            redirect_errors = [
-                _make_redirect_error("https://example.com/redirect-loop", 302, "https://example.com/redirect-loop")
-                for _ in range(12)
-            ]
+            redirect_responses = [_make_response(302, "https://example.com/redirect-loop") for _ in range(12)]
+            mock_opener = MagicMock()
+            mock_opener.open.side_effect = redirect_responses
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.urlopen", side_effect=redirect_errors):
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     with pytest.raises(ValueError, match="Too many redirects"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -555,10 +555,12 @@ class TestRedirectSSRFProtection:
                 return mock_getaddrinfo("93.184.216.34")
 
             # Redirect with no Location header
-            redirect_error = _make_redirect_error("https://example.com/data.csv", 302, None)
+            redirect_response = _make_response(302, None)
+            mock_opener = MagicMock()
+            mock_opener.open.return_value = redirect_response
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     with pytest.raises(ValueError, match="Location header"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -573,10 +575,12 @@ class TestRedirectSSRFProtection:
             def dns_side_effect(hostname: str, port: Any) -> list[tuple[Any, ...]]:
                 return mock_getaddrinfo("93.184.216.34")
 
-            redirect_error = _make_redirect_error("https://example.com/data.csv", 302, "file:///etc/passwd")
+            redirect_response = _make_response(302, "file:///etc/passwd")
+            mock_opener = MagicMock()
+            mock_opener.open.return_value = redirect_response
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch("sunstone.handlers.urlopen", side_effect=redirect_error):
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     with pytest.raises(ValueError, match="not allowed"):
                         manager.fetch_from_url(dataset, force=True)
 
@@ -591,20 +595,19 @@ class TestRedirectSSRFProtection:
             def dns_side_effect(hostname: str, port: Any) -> list[tuple[Any, ...]]:
                 return mock_getaddrinfo("93.184.216.34")  # Public IP
 
-            redirect_error = _make_redirect_error("https://example.com/old/data.csv", 302, "../new/data.csv")
+            redirect_response = _make_response(302, "../new/data.csv")
             ok_response = _make_ok_response(b"test data")
+            mock_opener = MagicMock()
+            mock_opener.open.side_effect = [redirect_response, ok_response]
 
             with patch("sunstone.handlers.socket.getaddrinfo", side_effect=dns_side_effect):
-                with patch(
-                    "sunstone.handlers.urlopen",
-                    side_effect=[redirect_error, ok_response],
-                ) as mock_urlopen:
+                with patch("sunstone.handlers.build_opener", return_value=mock_opener):
                     # Mock file writing to avoid modifying test input files
                     with patch("builtins.open", unittest.mock.mock_open()):
                         result = manager.fetch_from_url(dataset, force=True)
                         assert result is not None
                         # Verify the relative URL was resolved to the correct absolute URL
                         # The second call should be to the resolved URL: https://example.com/new/data.csv
-                        assert mock_urlopen.call_count == 2
-                        second_call_request = mock_urlopen.call_args_list[1][0][0]
+                        assert mock_opener.open.call_count == 2
+                        second_call_request = mock_opener.open.call_args_list[1][0][0]
                         assert second_call_request.full_url == "https://example.com/new/data.csv"

--- a/tests/test_datasets_coverage.py
+++ b/tests/test_datasets_coverage.py
@@ -6,11 +6,12 @@ add/update operations, lineage strict mode, and fetch_from_url.
 """
 
 import socket
+import urllib.error
+import urllib.request
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import requests
 from ruamel.yaml import YAML
 
 from sunstone.datasets import DatasetsManager
@@ -392,8 +393,8 @@ class TestFetchFromUrl:
         mgr = DatasetsManager(project_copy)
         dataset = self._make_dataset_with_source(url="https://example.com/data.csv")
         with patch("sunstone.handlers._is_public_url", return_value=True):
-            with patch("sunstone.handlers.requests.get", side_effect=requests.Timeout("timed out")):
-                with pytest.raises(requests.Timeout):
+            with patch("sunstone.handlers.urlopen", side_effect=socket.timeout("timed out")):
+                with pytest.raises(socket.timeout):
                     mgr.fetch_from_url(dataset, force=True)
 
     def test_request_exception_propagates(self, project_copy: Path) -> None:
@@ -402,8 +403,8 @@ class TestFetchFromUrl:
         dataset = self._make_dataset_with_source(url="https://example.com/data.csv")
         with patch("sunstone.handlers._is_public_url", return_value=True):
             with patch(
-                "sunstone.handlers.requests.get",
-                side_effect=requests.ConnectionError("connection failed"),
+                "sunstone.handlers.urlopen",
+                side_effect=urllib.error.URLError("connection failed"),
             ):
-                with pytest.raises(requests.ConnectionError):
+                with pytest.raises(urllib.error.URLError):
                     mgr.fetch_from_url(dataset, force=True)

--- a/tests/test_datasets_coverage.py
+++ b/tests/test_datasets_coverage.py
@@ -13,7 +13,8 @@ import pytest
 import requests
 from ruamel.yaml import YAML
 
-from sunstone.datasets import DatasetsManager, _is_public_url
+from sunstone.datasets import DatasetsManager
+from sunstone.handlers import _is_public_url
 from sunstone.exceptions import DatasetNotFoundError, DatasetValidationError
 from sunstone.lineage import (
     DatasetMetadata,
@@ -46,21 +47,21 @@ class TestIsPublicUrlErrorPaths:
     """Tests for _is_public_url error handling (lines 102-110)."""
 
     def test_gaierror_returns_false(self) -> None:
-        with patch("sunstone.datasets.socket.getaddrinfo", side_effect=socket.gaierror("DNS failure")):
+        with patch("sunstone.handlers.socket.getaddrinfo", side_effect=socket.gaierror("DNS failure")):
             assert _is_public_url("https://nonexistent.invalid/data.csv") is False
 
     def test_value_error_returns_false(self) -> None:
         # Trigger ValueError by making ip_address raise on a bad address
         with patch(
-            "sunstone.datasets.socket.getaddrinfo",
+            "sunstone.handlers.socket.getaddrinfo",
             return_value=[(None, None, None, None, ("not-an-ip",))],
         ):
-            with patch("sunstone.datasets.ipaddress.ip_address", side_effect=ValueError("bad IP")):
+            with patch("sunstone.handlers.ipaddress.ip_address", side_effect=ValueError("bad IP")):
                 assert _is_public_url("https://example.com/data.csv") is False
 
     def test_unexpected_exception_is_reraised(self) -> None:
         with patch(
-            "sunstone.datasets.socket.getaddrinfo",
+            "sunstone.handlers.socket.getaddrinfo",
             side_effect=RuntimeError("unexpected"),
         ):
             with pytest.raises(RuntimeError, match="unexpected"):
@@ -387,21 +388,21 @@ class TestFetchFromUrl:
         assert target.read_text() == "existing data"
 
     def test_timeout_exception_propagates(self, project_copy: Path) -> None:
-        """Lines 801-802: Timeout handling."""
+        """Timeout handling."""
         mgr = DatasetsManager(project_copy)
         dataset = self._make_dataset_with_source(url="https://example.com/data.csv")
-        with patch("sunstone.datasets._is_public_url", return_value=True):
-            with patch("sunstone.datasets.requests.get", side_effect=requests.Timeout("timed out")):
+        with patch("sunstone.handlers._is_public_url", return_value=True):
+            with patch("sunstone.handlers.requests.get", side_effect=requests.Timeout("timed out")):
                 with pytest.raises(requests.Timeout):
                     mgr.fetch_from_url(dataset, force=True)
 
     def test_request_exception_propagates(self, project_copy: Path) -> None:
-        """Lines 804-805: RequestException handling."""
+        """RequestException handling."""
         mgr = DatasetsManager(project_copy)
         dataset = self._make_dataset_with_source(url="https://example.com/data.csv")
-        with patch("sunstone.datasets._is_public_url", return_value=True):
+        with patch("sunstone.handlers._is_public_url", return_value=True):
             with patch(
-                "sunstone.datasets.requests.get",
+                "sunstone.handlers.requests.get",
                 side_effect=requests.ConnectionError("connection failed"),
             ):
                 with pytest.raises(requests.ConnectionError):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -210,3 +210,53 @@ class TestHttpURLHandlerFetch:
         ):
             with pytest.raises(ValueError, match="Too many redirects"):
                 http_handler.fetch("https://example.com/data.csv", dest)
+
+
+def test_fetch_from_url_delegates_auth_to_http_handler(tmp_path):
+    """Auth providers set headers on the HttpURLHandler before fetch."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Test Dataset\n"
+        "    slug: test-dataset\n"
+        "    location: inputs/test.csv\n"
+        "    source:\n"
+        "      name: Test Source\n"
+        "      location:\n"
+        "        data: https://example.com/test.csv\n"
+        "      attributedTo: Test Org\n"
+        "      acquiredAt: '2026-01-01'\n"
+        "      acquisitionMethod: manual-download\n"
+        "      license: CC-BY-4.0\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+
+    from sunstone.datasets import DatasetsManager
+    from sunstone.plugins import PluginRegistry
+
+    manager = DatasetsManager(tmp_path)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    class TestAuth:
+        def authenticate(self, url, headers, dataset):
+            headers["Authorization"] = "Bearer test-token"
+            return headers
+
+    registry = PluginRegistry()
+    registry._auth_providers.append(TestAuth())
+    registry._url_handlers.append(HttpURLHandler())
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,6 +1,6 @@
 """Tests for internal plugin handlers."""
 
-from pathlib import Path
+import io
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -16,93 +16,101 @@ def handler():
 
 class TestBuiltinFormatHandlerCanRead:
     def test_csv(self, handler):
-        assert handler.can_read(Path("data.csv"), None)
+        assert handler.can_read("data.csv", None)
 
     def test_csv_with_format(self, handler):
-        assert handler.can_read(Path("data.whatever"), "csv")
+        assert handler.can_read("data.whatever", "csv")
 
     def test_json(self, handler):
-        assert handler.can_read(Path("data.json"), None)
+        assert handler.can_read("data.json", None)
 
     def test_excel_xlsx(self, handler):
-        assert handler.can_read(Path("data.xlsx"), None)
+        assert handler.can_read("data.xlsx", None)
 
     def test_excel_xls(self, handler):
-        assert handler.can_read(Path("data.xls"), None)
+        assert handler.can_read("data.xls", None)
 
     def test_parquet(self, handler):
-        assert handler.can_read(Path("data.parquet"), None)
+        assert handler.can_read("data.parquet", None)
 
     def test_tsv(self, handler):
-        assert handler.can_read(Path("data.tsv"), None)
+        assert handler.can_read("data.tsv", None)
 
     def test_txt_as_tsv(self, handler):
-        assert handler.can_read(Path("data.txt"), None)
+        assert handler.can_read("data.txt", None)
 
     def test_unknown_extension(self, handler):
-        assert not handler.can_read(Path("data.hdf5"), None)
+        assert not handler.can_read("data.hdf5", None)
 
     def test_unknown_format_string(self, handler):
-        assert not handler.can_read(Path("data.whatever"), "hdf5")
+        assert not handler.can_read("data.whatever", "hdf5")
+
+    def test_url_path(self, handler):
+        assert handler.can_read("gs://bucket/data.csv", None)
+
+    def test_url_path_with_format(self, handler):
+        assert handler.can_read("gs://bucket/data.whatever", "csv")
 
 
 class TestBuiltinFormatHandlerCanWrite:
     def test_csv(self, handler):
-        assert handler.can_write(Path("data.csv"), None)
+        assert handler.can_write("data.csv", None)
 
     def test_csv_with_format(self, handler):
-        assert handler.can_write(Path("data.whatever"), "csv")
+        assert handler.can_write("data.whatever", "csv")
 
     def test_unknown(self, handler):
-        assert not handler.can_write(Path("data.hdf5"), None)
+        assert not handler.can_write("data.hdf5", None)
 
 
 class TestBuiltinFormatHandlerRead:
-    def test_read_csv(self, handler, tmp_path):
-        f = tmp_path / "data.csv"
-        f.write_text("a,b\n1,2\n3,4\n")
-        df = handler.read(f)
+    def test_read_csv(self, handler):
+        stream = io.BytesIO(b"a,b\n1,2\n3,4\n")
+        df = handler.read(stream)
         assert list(df.columns) == ["a", "b"]
         assert len(df) == 2
 
-    def test_read_tsv(self, handler, tmp_path):
-        f = tmp_path / "data.tsv"
-        f.write_text("a\tb\n1\t2\n3\t4\n")
-        df = handler.read(f)
+    def test_read_csv_with_format(self, handler):
+        stream = io.BytesIO(b"a,b\n1,2\n3,4\n")
+        df = handler.read(stream, format="csv")
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_tsv_with_format(self, handler):
+        stream = io.BytesIO(b"a\tb\n1\t2\n3\t4\n")
+        df = handler.read(stream, format="tsv")
         assert list(df.columns) == ["a", "b"]
         assert len(df) == 2
 
-    def test_read_txt_as_tsv(self, handler, tmp_path):
-        f = tmp_path / "data.txt"
-        f.write_text("a\tb\n1\t2\n")
-        df = handler.read(f)
-        assert list(df.columns) == ["a", "b"]
-
-    def test_read_json(self, handler, tmp_path):
-        f = tmp_path / "data.json"
-        f.write_text('[{"a": 1, "b": 2}]')
-        df = handler.read(f)
+    def test_read_json(self, handler):
+        stream = io.BytesIO(b'[{"a": 1, "b": 2}]')
+        df = handler.read(stream, format="json")
         assert list(df.columns) == ["a", "b"]
 
     def test_read_parquet(self, handler, tmp_path):
         f = tmp_path / "data.parquet"
         pd.DataFrame({"a": [1], "b": [2]}).to_parquet(f)
-        df = handler.read(f)
+        stream = io.BytesIO(f.read_bytes())
+        df = handler.read(stream, format="parquet")
         assert list(df.columns) == ["a", "b"]
 
-    def test_read_passes_kwargs(self, handler, tmp_path):
-        f = tmp_path / "data.csv"
-        f.write_text("a,b\n1,2\n3,4\n")
-        df = handler.read(f, usecols=["a"])
+    def test_read_with_path_kwarg(self, handler):
+        stream = io.BytesIO(b"a,b\n1,2\n3,4\n")
+        df = handler.read(stream, path="data.csv")
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_passes_kwargs(self, handler):
+        stream = io.BytesIO(b"a,b\n1,2\n3,4\n")
+        df = handler.read(stream, format="csv", usecols=["a"])
         assert list(df.columns) == ["a"]
 
 
 class TestBuiltinFormatHandlerWrite:
-    def test_write_csv(self, handler, tmp_path):
-        f = tmp_path / "out.csv"
+    def test_write_csv(self, handler):
+        stream = io.BytesIO()
         df = pd.DataFrame({"x": [1, 2]})
-        handler.write(df, f, index=False)
-        result = pd.read_csv(f)
+        handler.write(df, stream, index=False)
+        stream.seek(0)
+        result = pd.read_csv(stream)
         assert list(result.columns) == ["x"]
         assert len(result) == 2
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -245,6 +245,9 @@ class TestLocalFileHandlerCanHandle:
     def test_file_scheme(self, local_handler):
         assert local_handler.can_handle("file:///tmp/data.csv")
 
+    def test_windows_drive_path(self, local_handler):
+        assert local_handler.can_handle("C:\\Users\\data.csv")
+
     def test_http_scheme(self, local_handler):
         assert not local_handler.can_handle("http://example.com/data.csv")
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from sunstone.handlers import BuiltinFormatHandler, HttpURLHandler
+from sunstone.handlers import BuiltinFormatHandler, HttpURLHandler, LocalFileHandler
 
 
 @pytest.fixture
@@ -210,6 +210,72 @@ class TestHttpURLHandlerFetch:
         ):
             with pytest.raises(ValueError, match="Too many redirects"):
                 http_handler.fetch("https://example.com/data.csv", dest)
+
+
+@pytest.fixture
+def local_handler():
+    return LocalFileHandler()
+
+
+class TestLocalFileHandlerCanHandle:
+    def test_bare_relative_path(self, local_handler):
+        assert local_handler.can_handle("data.csv")
+
+    def test_bare_absolute_path(self, local_handler):
+        assert local_handler.can_handle("/tmp/data.csv")
+
+    def test_file_scheme(self, local_handler):
+        assert local_handler.can_handle("file:///tmp/data.csv")
+
+    def test_http_scheme(self, local_handler):
+        assert not local_handler.can_handle("http://example.com/data.csv")
+
+    def test_gs_scheme(self, local_handler):
+        assert not local_handler.can_handle("gs://bucket/data.csv")
+
+    def test_s3_scheme(self, local_handler):
+        assert not local_handler.can_handle("s3://bucket/data.csv")
+
+    def test_r2_scheme(self, local_handler):
+        assert not local_handler.can_handle("r2://bucket/data.csv")
+
+
+class TestLocalFileHandlerOpen:
+    def test_read_binary(self, local_handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_bytes(b"a,b\n1,2\n")
+        with local_handler.open(str(f), "rb") as stream:
+            assert stream.read() == b"a,b\n1,2\n"
+
+    def test_read_text(self, local_handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n1,2\n")
+        with local_handler.open(str(f), "r") as stream:
+            assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_binary(self, local_handler, tmp_path):
+        f = tmp_path / "out.csv"
+        with local_handler.open(str(f), "wb") as stream:
+            stream.write(b"a,b\n1,2\n")
+        assert f.read_bytes() == b"a,b\n1,2\n"
+
+    def test_write_text(self, local_handler, tmp_path):
+        f = tmp_path / "out.csv"
+        with local_handler.open(str(f), "w") as stream:
+            stream.write("a,b\n1,2\n")
+        assert f.read_text() == "a,b\n1,2\n"
+
+    def test_file_scheme(self, local_handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_bytes(b"a,b\n1,2\n")
+        with local_handler.open(f"file://{f}", "rb") as stream:
+            assert stream.read() == b"a,b\n1,2\n"
+
+    def test_creates_parent_dirs_on_write(self, local_handler, tmp_path):
+        f = tmp_path / "sub" / "dir" / "out.csv"
+        with local_handler.open(str(f), "wb") as stream:
+            stream.write(b"data")
+        assert f.read_bytes() == b"data"
 
 
 def test_fetch_from_url_delegates_auth_to_http_handler(tmp_path):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -289,7 +289,8 @@ class TestLocalFileHandlerOpen:
     def test_file_scheme(self, local_handler, tmp_path):
         f = tmp_path / "data.csv"
         f.write_bytes(b"a,b\n1,2\n")
-        with local_handler.open(f"file://{f}", "rb") as stream:
+        file_url = f.as_uri()  # produces correct file:///... on all platforms
+        with local_handler.open(file_url, "rb") as stream:
             assert stream.read() == b"a,b\n1,2\n"
 
     def test_creates_parent_dirs_on_write(self, local_handler, tmp_path):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,11 +1,12 @@
 """Tests for internal plugin handlers."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 
-from sunstone.handlers import BuiltinFormatHandler
+from sunstone.handlers import BuiltinFormatHandler, HttpURLHandler
 
 
 @pytest.fixture
@@ -104,3 +105,108 @@ class TestBuiltinFormatHandlerWrite:
         result = pd.read_csv(f)
         assert list(result.columns) == ["x"]
         assert len(result) == 2
+
+
+@pytest.fixture
+def http_handler():
+    return HttpURLHandler()
+
+
+class TestHttpURLHandlerCanHandle:
+    def test_http(self, http_handler):
+        assert http_handler.can_handle("http://example.com/data.csv")
+
+    def test_https(self, http_handler):
+        assert http_handler.can_handle("https://example.com/data.csv")
+
+    def test_s3(self, http_handler):
+        assert not http_handler.can_handle("s3://bucket/data.csv")
+
+    def test_gs(self, http_handler):
+        assert not http_handler.can_handle("gs://bucket/data.csv")
+
+    def test_ftp(self, http_handler):
+        assert not http_handler.can_handle("ftp://example.com/data.csv")
+
+    def test_bare_path(self, http_handler):
+        assert not http_handler.can_handle("/local/path/data.csv")
+
+    def test_relative_path(self, http_handler):
+        assert not http_handler.can_handle("data.csv")
+
+
+class TestHttpURLHandlerFetch:
+    def test_fetches_to_dest(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        mock_response = MagicMock()
+        mock_response.is_redirect = False
+        mock_response.content = b"a,b\n1,2\n"
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", return_value=mock_response),
+        ):
+            result = http_handler.fetch("https://example.com/data.csv", dest)
+            assert result == dest
+            assert dest.read_bytes() == b"a,b\n1,2\n"
+
+    def test_rejects_private_url(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        with patch("sunstone.handlers._is_public_url", return_value=False):
+            with pytest.raises(ValueError, match="not allowed"):
+                http_handler.fetch("http://192.168.1.1/data.csv", dest)
+
+    def test_follows_redirects(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://cdn.example.com/data.csv"}
+
+        final_response = MagicMock()
+        final_response.is_redirect = False
+        final_response.content = b"a,b\n1,2\n"
+        final_response.raise_for_status = MagicMock()
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", side_effect=[redirect_response, final_response]),
+        ):
+            result = http_handler.fetch("https://example.com/redirect", dest)
+            assert result == dest
+
+    def test_strips_auth_on_cross_origin_redirect(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://other.com/data.csv"}
+
+        final_response = MagicMock()
+        final_response.is_redirect = False
+        final_response.content = b"data"
+        final_response.raise_for_status = MagicMock()
+
+        http_handler.headers = {"Authorization": "Bearer secret"}
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", side_effect=[redirect_response, final_response]) as mock_get,
+        ):
+            http_handler.fetch("https://example.com/data.csv", dest)
+            # Second call (redirect) should not have Authorization header
+            second_call_headers = mock_get.call_args_list[1][1]["headers"]
+            assert "Authorization" not in second_call_headers
+
+    def test_too_many_redirects(self, http_handler, tmp_path):
+        dest = tmp_path / "data.csv"
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://example.com/loop"}
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.requests.get", return_value=redirect_response),
+        ):
+            with pytest.raises(ValueError, match="Too many redirects"):
+                http_handler.fetch("https://example.com/data.csv", dest)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -143,81 +143,91 @@ class TestHttpURLHandlerCanHandle:
         assert not http_handler.can_handle("data.csv")
 
 
-class TestHttpURLHandlerFetch:
-    def test_fetches_to_dest(self, http_handler, tmp_path):
-        dest = tmp_path / "data.csv"
+class TestHttpURLHandlerOpen:
+    def test_read_binary(self, http_handler):
         mock_response = MagicMock()
-        mock_response.is_redirect = False
-        mock_response.content = b"a,b\n1,2\n"
-        mock_response.raise_for_status = MagicMock()
+        mock_response.read.return_value = b"a,b\n1,2\n"
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.requests.get", return_value=mock_response),
+            patch("sunstone.handlers.urlopen", return_value=mock_response),
         ):
-            result = http_handler.fetch("https://example.com/data.csv", dest)
-            assert result == dest
-            assert dest.read_bytes() == b"a,b\n1,2\n"
+            stream = http_handler.open("https://example.com/data.csv", "rb")
+            assert stream.read() == b"a,b\n1,2\n"
 
-    def test_rejects_private_url(self, http_handler, tmp_path):
-        dest = tmp_path / "data.csv"
+    def test_read_text(self, http_handler):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"a,b\n1,2\n"
+
+        with (
+            patch("sunstone.handlers._is_public_url", return_value=True),
+            patch("sunstone.handlers.urlopen", return_value=mock_response),
+        ):
+            stream = http_handler.open("https://example.com/data.csv", "r")
+            assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_raises(self, http_handler):
+        with pytest.raises(NotImplementedError):
+            http_handler.open("https://example.com/data.csv", "wb")
+
+    def test_rejects_private_url(self, http_handler):
         with patch("sunstone.handlers._is_public_url", return_value=False):
             with pytest.raises(ValueError, match="not allowed"):
-                http_handler.fetch("http://192.168.1.1/data.csv", dest)
+                http_handler.open("http://192.168.1.1/data.csv", "rb")
 
-    def test_follows_redirects(self, http_handler, tmp_path):
-        dest = tmp_path / "data.csv"
-        redirect_response = MagicMock()
-        redirect_response.is_redirect = True
-        redirect_response.headers = {"Location": "https://cdn.example.com/data.csv"}
+    def test_follows_redirects(self, http_handler):
+        from urllib.error import HTTPError as UrllibHTTPError
 
+        redirect_error = UrllibHTTPError(
+            "https://example.com/data.csv",
+            302,
+            "Found",
+            {"Location": "https://cdn.example.com/data.csv"},
+            io.BytesIO(b""),
+        )
         final_response = MagicMock()
-        final_response.is_redirect = False
-        final_response.content = b"a,b\n1,2\n"
-        final_response.raise_for_status = MagicMock()
+        final_response.read.return_value = b"a,b\n1,2\n"
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.requests.get", side_effect=[redirect_response, final_response]),
+            patch("sunstone.handlers.urlopen", side_effect=[redirect_error, final_response]),
         ):
-            result = http_handler.fetch("https://example.com/redirect", dest)
-            assert result == dest
+            stream = http_handler.open("https://example.com/redirect", "rb")
+            assert stream.read() == b"a,b\n1,2\n"
 
-    def test_strips_auth_on_cross_origin_redirect(self, http_handler, tmp_path):
-        dest = tmp_path / "data.csv"
+    def test_strips_auth_on_cross_origin_redirect(self, http_handler):
+        from urllib.error import HTTPError as UrllibHTTPError
 
-        redirect_response = MagicMock()
-        redirect_response.is_redirect = True
-        redirect_response.headers = {"Location": "https://other.com/data.csv"}
-
+        redirect_error = UrllibHTTPError(
+            "https://example.com/data.csv", 302, "Found", {"Location": "https://other.com/data.csv"}, io.BytesIO(b"")
+        )
         final_response = MagicMock()
-        final_response.is_redirect = False
-        final_response.content = b"data"
-        final_response.raise_for_status = MagicMock()
+        final_response.read.return_value = b"data"
 
         http_handler.headers = {"Authorization": "Bearer secret"}
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.requests.get", side_effect=[redirect_response, final_response]) as mock_get,
+            patch("sunstone.handlers.urlopen", side_effect=[redirect_error, final_response]) as mock_urlopen,
         ):
-            http_handler.fetch("https://example.com/data.csv", dest)
-            # Second call (redirect) should not have Authorization header
-            second_call_headers = mock_get.call_args_list[1][1]["headers"]
-            assert "Authorization" not in second_call_headers
+            http_handler.open("https://example.com/data.csv", "rb")
+            # Second call should not have Authorization header
+            second_request = mock_urlopen.call_args_list[1][0][0]
+            assert "Authorization" not in second_request.headers
 
-    def test_too_many_redirects(self, http_handler, tmp_path):
-        dest = tmp_path / "data.csv"
-        redirect_response = MagicMock()
-        redirect_response.is_redirect = True
-        redirect_response.headers = {"Location": "https://example.com/loop"}
+    def test_too_many_redirects(self, http_handler):
+        from urllib.error import HTTPError as UrllibHTTPError
+
+        redirect_error = UrllibHTTPError(
+            "https://example.com/loop", 302, "Found", {"Location": "https://example.com/loop"}, io.BytesIO(b"")
+        )
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.requests.get", return_value=redirect_response),
+            patch("sunstone.handlers.urlopen", side_effect=redirect_error),
         ):
             with pytest.raises(ValueError, match="Too many redirects"):
-                http_handler.fetch("https://example.com/data.csv", dest)
+                http_handler.open("https://example.com/data.csv", "rb")
 
 
 @pytest.fixture
@@ -317,20 +327,19 @@ def test_fetch_from_url_delegates_auth_to_http_handler(tmp_path):
             headers["Authorization"] = "Bearer test-token"
             return headers
 
+    handler = HttpURLHandler()
     registry = PluginRegistry()
     registry._auth_providers.append(TestAuth())
-    registry._url_handlers.append(HttpURLHandler())
+    registry._url_handlers.append(handler)
 
     mock_response = MagicMock()
-    mock_response.is_redirect = False
-    mock_response.content = b"col1,col2\na,b\n"
-    mock_response.raise_for_status = MagicMock()
+    mock_response.read.return_value = b"col1,col2\na,b\n"
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
+        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
     ):
         manager.fetch_from_url(dataset, force=True)
-        _, kwargs = mock_get.call_args
-        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.get_header("Authorization") == "Bearer test-token"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -146,22 +146,28 @@ class TestHttpURLHandlerCanHandle:
 class TestHttpURLHandlerOpen:
     def test_read_binary(self, http_handler):
         mock_response = MagicMock()
+        mock_response.status = 200
         mock_response.read.return_value = b"a,b\n1,2\n"
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_response
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.urlopen", return_value=mock_response),
+            patch("sunstone.handlers.build_opener", return_value=mock_opener),
         ):
             stream = http_handler.open("https://example.com/data.csv", "rb")
             assert stream.read() == b"a,b\n1,2\n"
 
     def test_read_text(self, http_handler):
         mock_response = MagicMock()
+        mock_response.status = 200
         mock_response.read.return_value = b"a,b\n1,2\n"
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_response
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.urlopen", return_value=mock_response),
+            patch("sunstone.handlers.build_opener", return_value=mock_opener),
         ):
             stream = http_handler.open("https://example.com/data.csv", "r")
             assert stream.read() == "a,b\n1,2\n"
@@ -176,55 +182,55 @@ class TestHttpURLHandlerOpen:
                 http_handler.open("http://192.168.1.1/data.csv", "rb")
 
     def test_follows_redirects(self, http_handler):
-        from urllib.error import HTTPError as UrllibHTTPError
-
-        redirect_error = UrllibHTTPError(
-            "https://example.com/data.csv",
-            302,
-            "Found",
-            {"Location": "https://cdn.example.com/data.csv"},
-            io.BytesIO(b""),
-        )
+        redirect_response = MagicMock()
+        redirect_response.status = 302
+        redirect_response.headers = {"Location": "https://cdn.example.com/data.csv"}
         final_response = MagicMock()
+        final_response.status = 200
         final_response.read.return_value = b"a,b\n1,2\n"
+        mock_opener = MagicMock()
+        mock_opener.open.side_effect = [redirect_response, final_response]
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.urlopen", side_effect=[redirect_error, final_response]),
+            patch("sunstone.handlers.build_opener", return_value=mock_opener),
         ):
             stream = http_handler.open("https://example.com/redirect", "rb")
             assert stream.read() == b"a,b\n1,2\n"
 
     def test_strips_auth_on_cross_origin_redirect(self, http_handler):
-        from urllib.error import HTTPError as UrllibHTTPError
-
-        redirect_error = UrllibHTTPError(
-            "https://example.com/data.csv", 302, "Found", {"Location": "https://other.com/data.csv"}, io.BytesIO(b"")
-        )
+        redirect_response = MagicMock()
+        redirect_response.status = 302
+        redirect_response.headers = {"Location": "https://other.com/data.csv"}
         final_response = MagicMock()
+        final_response.status = 200
         final_response.read.return_value = b"data"
-
-        http_handler.headers = {"Authorization": "Bearer secret"}
+        mock_opener = MagicMock()
+        mock_opener.open.side_effect = [redirect_response, final_response]
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.urlopen", side_effect=[redirect_error, final_response]) as mock_urlopen,
+            patch("sunstone.handlers.build_opener", return_value=mock_opener),
         ):
-            http_handler.open("https://example.com/data.csv", "rb")
+            http_handler.open("https://example.com/data.csv", "rb", headers={"Authorization": "Bearer secret"})
             # Second call should not have Authorization header
-            second_request = mock_urlopen.call_args_list[1][0][0]
+            second_request = mock_opener.open.call_args_list[1][0][0]
             assert "Authorization" not in second_request.headers
 
     def test_too_many_redirects(self, http_handler):
-        from urllib.error import HTTPError as UrllibHTTPError
-
-        redirect_error = UrllibHTTPError(
-            "https://example.com/loop", 302, "Found", {"Location": "https://example.com/loop"}, io.BytesIO(b"")
-        )
+        http_handler = HttpURLHandler(max_redirects=1)
+        redirect_responses = []
+        for _ in range(2):
+            response = MagicMock()
+            response.status = 302
+            response.headers = {"Location": "https://example.com/loop"}
+            redirect_responses.append(response)
+        mock_opener = MagicMock()
+        mock_opener.open.side_effect = redirect_responses
 
         with (
             patch("sunstone.handlers._is_public_url", return_value=True),
-            patch("sunstone.handlers.urlopen", side_effect=redirect_error),
+            patch("sunstone.handlers.build_opener", return_value=mock_opener),
         ):
             with pytest.raises(ValueError, match="Too many redirects"):
                 http_handler.open("https://example.com/data.csv", "rb")
@@ -337,13 +343,16 @@ def test_fetch_from_url_delegates_auth_to_http_handler(tmp_path):
     registry._url_handlers.append(handler)
 
     mock_response = MagicMock()
+    mock_response.status = 200
     mock_response.read.return_value = b"col1,col2\na,b\n"
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_response
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
+        patch("sunstone.handlers.build_opener", return_value=mock_opener),
     ):
         manager.fetch_from_url(dataset, force=True)
-        request_obj = mock_urlopen.call_args[0][0]
+        request_obj = mock_opener.open.call_args[0][0]
         assert request_obj.get_header("Authorization") == "Bearer test-token"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,106 @@
+"""Tests for internal plugin handlers."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sunstone.handlers import BuiltinFormatHandler
+
+
+@pytest.fixture
+def handler():
+    return BuiltinFormatHandler()
+
+
+class TestBuiltinFormatHandlerCanRead:
+    def test_csv(self, handler):
+        assert handler.can_read(Path("data.csv"), None)
+
+    def test_csv_with_format(self, handler):
+        assert handler.can_read(Path("data.whatever"), "csv")
+
+    def test_json(self, handler):
+        assert handler.can_read(Path("data.json"), None)
+
+    def test_excel_xlsx(self, handler):
+        assert handler.can_read(Path("data.xlsx"), None)
+
+    def test_excel_xls(self, handler):
+        assert handler.can_read(Path("data.xls"), None)
+
+    def test_parquet(self, handler):
+        assert handler.can_read(Path("data.parquet"), None)
+
+    def test_tsv(self, handler):
+        assert handler.can_read(Path("data.tsv"), None)
+
+    def test_txt_as_tsv(self, handler):
+        assert handler.can_read(Path("data.txt"), None)
+
+    def test_unknown_extension(self, handler):
+        assert not handler.can_read(Path("data.hdf5"), None)
+
+    def test_unknown_format_string(self, handler):
+        assert not handler.can_read(Path("data.whatever"), "hdf5")
+
+
+class TestBuiltinFormatHandlerCanWrite:
+    def test_csv(self, handler):
+        assert handler.can_write(Path("data.csv"), None)
+
+    def test_csv_with_format(self, handler):
+        assert handler.can_write(Path("data.whatever"), "csv")
+
+    def test_unknown(self, handler):
+        assert not handler.can_write(Path("data.hdf5"), None)
+
+
+class TestBuiltinFormatHandlerRead:
+    def test_read_csv(self, handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n1,2\n3,4\n")
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_read_tsv(self, handler, tmp_path):
+        f = tmp_path / "data.tsv"
+        f.write_text("a\tb\n1\t2\n3\t4\n")
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_read_txt_as_tsv(self, handler, tmp_path):
+        f = tmp_path / "data.txt"
+        f.write_text("a\tb\n1\t2\n")
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_json(self, handler, tmp_path):
+        f = tmp_path / "data.json"
+        f.write_text('[{"a": 1, "b": 2}]')
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_parquet(self, handler, tmp_path):
+        f = tmp_path / "data.parquet"
+        pd.DataFrame({"a": [1], "b": [2]}).to_parquet(f)
+        df = handler.read(f)
+        assert list(df.columns) == ["a", "b"]
+
+    def test_read_passes_kwargs(self, handler, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n1,2\n3,4\n")
+        df = handler.read(f, usecols=["a"])
+        assert list(df.columns) == ["a"]
+
+
+class TestBuiltinFormatHandlerWrite:
+    def test_write_csv(self, handler, tmp_path):
+        f = tmp_path / "out.csv"
+        df = pd.DataFrame({"x": [1, 2]})
+        handler.write(df, f, index=False)
+        result = pd.read_csv(f)
+        assert list(result.columns) == ["x"]
+        assert len(result) == 2

--- a/tests/test_handlers_gcs.py
+++ b/tests/test_handlers_gcs.py
@@ -1,0 +1,74 @@
+"""Tests for GCS URL handler (mocked — no real GCS calls)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def gcs_handler():
+    from sunstone.handlers_gcs import GcsURLHandler
+
+    handler = GcsURLHandler.__new__(GcsURLHandler)
+    handler._client = MagicMock()
+    return handler
+
+
+class TestGcsURLHandlerCanHandle:
+    def test_gs_scheme(self, gcs_handler):
+        assert gcs_handler.can_handle("gs://bucket/path/data.csv")
+
+    def test_http_scheme(self, gcs_handler):
+        assert not gcs_handler.can_handle("http://example.com/data.csv")
+
+    def test_s3_scheme(self, gcs_handler):
+        assert not gcs_handler.can_handle("s3://bucket/data.csv")
+
+    def test_local_path(self, gcs_handler):
+        assert not gcs_handler.can_handle("data.csv")
+
+
+class TestGcsURLHandlerOpen:
+    def test_read_binary(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_blob.download_as_bytes.return_value = b"a,b\n1,2\n"
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/data.csv", "rb")
+        assert stream.read() == b"a,b\n1,2\n"
+
+    def test_read_text(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_blob.download_as_bytes.return_value = b"a,b\n1,2\n"
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/data.csv", "r")
+        assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_binary(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/out.csv", "wb")
+        stream.write(b"a,b\n1,2\n")
+        stream.close()
+
+        mock_blob.upload_from_file.assert_called_once()
+
+    def test_write_text(self, gcs_handler):
+        mock_blob = MagicMock()
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        gcs_handler._client.bucket.return_value = mock_bucket
+
+        stream = gcs_handler.open("gs://my-bucket/out.csv", "w")
+        stream.write("a,b\n1,2\n")
+        stream.close()
+
+        mock_blob.upload_from_file.assert_called_once()

--- a/tests/test_handlers_s3.py
+++ b/tests/test_handlers_s3.py
@@ -1,0 +1,79 @@
+"""Tests for S3/R2 URL handler (mocked — no real AWS calls)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+from sunstone.handlers_s3 import S3URLHandler
+
+
+@pytest.fixture
+def s3_handler():
+    handler = S3URLHandler.__new__(S3URLHandler)
+    handler._client = MagicMock()
+    return handler
+
+
+@pytest.fixture
+def r2_handler():
+    handler = S3URLHandler.__new__(S3URLHandler)
+    handler._client = MagicMock()
+    return handler
+
+
+class TestS3URLHandlerCanHandle:
+    def test_s3_scheme(self, s3_handler):
+        assert s3_handler.can_handle("s3://bucket/data.csv")
+
+    def test_r2_scheme(self, s3_handler):
+        assert s3_handler.can_handle("r2://bucket/data.csv")
+
+    def test_gs_scheme(self, s3_handler):
+        assert not s3_handler.can_handle("gs://bucket/data.csv")
+
+    def test_http_scheme(self, s3_handler):
+        assert not s3_handler.can_handle("http://example.com/data.csv")
+
+    def test_local_path(self, s3_handler):
+        assert not s3_handler.can_handle("data.csv")
+
+
+class TestS3URLHandlerOpen:
+    def test_read_binary(self, s3_handler):
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"a,b\n1,2\n"
+        s3_handler._client.get_object.return_value = {"Body": mock_body}
+
+        stream = s3_handler.open("s3://my-bucket/data.csv", "rb")
+        assert stream.read() == b"a,b\n1,2\n"
+
+    def test_read_text(self, s3_handler):
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"a,b\n1,2\n"
+        s3_handler._client.get_object.return_value = {"Body": mock_body}
+
+        stream = s3_handler.open("s3://my-bucket/data.csv", "r")
+        assert stream.read() == "a,b\n1,2\n"
+
+    def test_write_binary(self, s3_handler):
+        stream = s3_handler.open("s3://my-bucket/out.csv", "wb")
+        stream.write(b"a,b\n1,2\n")
+        stream.close()
+
+        s3_handler._client.upload_fileobj.assert_called_once()
+
+    def test_write_text(self, s3_handler):
+        stream = s3_handler.open("s3://my-bucket/out.csv", "w")
+        stream.write("a,b\n1,2\n")
+        stream.close()
+
+        s3_handler._client.upload_fileobj.assert_called_once()
+
+    def test_r2_uses_correct_bucket_key(self, r2_handler):
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"data"
+        r2_handler._client.get_object.return_value = {"Body": mock_body}
+
+        r2_handler.open("r2://my-bucket/data.csv", "rb")
+        r2_handler._client.get_object.assert_called_once_with(Bucket="my-bucket", Key="data.csv")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -28,7 +28,7 @@ def lfs_pointer_file(tmp_path: Path) -> Path:
     """Create a file that looks like a Git LFS pointer."""
     p = tmp_path / "outputs" / "big.csv"
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text("version https://git-lfs.github.com/spec/v1\n" "oid sha256:abc123\n" "size 999999\n")
+    p.write_text("version https://git-lfs.github.com/spec/v1\noid sha256:abc123\nsize 999999\n")
     return p
 
 
@@ -207,7 +207,7 @@ def test_push_group_raises_on_lfs_pointers(tmp_path: Path) -> None:
     """push_group raises ValueError when data files are LFS pointers."""
     lfs_file = tmp_path / "outputs" / "big.csv"
     lfs_file.parent.mkdir(parents=True, exist_ok=True)
-    lfs_file.write_text("version https://git-lfs.github.com/spec/v1\n" "oid sha256:abc123\n" "size 999999\n")
+    lfs_file.write_text("version https://git-lfs.github.com/spec/v1\noid sha256:abc123\nsize 999999\n")
 
     ds = DatasetMetadata(slug="big", name="Big", location="outputs/big.csv", dataset_type="output")
     manager = MagicMock()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -115,7 +115,7 @@ def test_push_group_uploads_via_handler(tmp_path: Path) -> None:
     data_dir = tmp_path / "outputs"
     data_dir.mkdir()
     data_file = data_dir / "result.csv"
-    data_file.write_text("x,y\n3,4\n")
+    data_file.write_bytes(b"x,y\n3,4\n")
 
     ds = DatasetMetadata(
         slug="result",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,340 @@
+"""Tests for sunstone.packaging — the reusable push_group library."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any, Optional
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from sunstone.lineage import DatasetMetadata, PublishConfig
+from sunstone.packaging import is_lfs_pointer, push_group
+
+
+@pytest.fixture
+def tmp_data_file(tmp_path: Path) -> Path:
+    """Create a small CSV file for upload tests."""
+    p = tmp_path / "outputs" / "data.csv"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("a,b\n1,2\n")
+    return p
+
+
+@pytest.fixture
+def lfs_pointer_file(tmp_path: Path) -> Path:
+    """Create a file that looks like a Git LFS pointer."""
+    p = tmp_path / "outputs" / "big.csv"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("version https://git-lfs.github.com/spec/v1\n" "oid sha256:abc123\n" "size 999999\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# is_lfs_pointer
+# ---------------------------------------------------------------------------
+
+
+def test_is_lfs_pointer_true(lfs_pointer_file: Path) -> None:
+    assert is_lfs_pointer(lfs_pointer_file) is True
+
+
+def test_is_lfs_pointer_false(tmp_data_file: Path) -> None:
+    assert is_lfs_pointer(tmp_data_file) is False
+
+
+def test_is_lfs_pointer_missing_file(tmp_path: Path) -> None:
+    assert is_lfs_pointer(tmp_path / "nope.csv") is False
+
+
+def test_is_lfs_pointer_large_file(tmp_path: Path) -> None:
+    """Files larger than 1024 bytes are never LFS pointers."""
+    p = tmp_path / "big.bin"
+    p.write_bytes(b"x" * 2000)
+    assert is_lfs_pointer(p) is False
+
+
+# ---------------------------------------------------------------------------
+# push_group
+# ---------------------------------------------------------------------------
+
+
+class _FakeWriteStream(io.BytesIO):
+    """Collects bytes written; captures content on close so tests can inspect it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.captured: bytes = b""
+
+    def close(self) -> None:
+        self.captured = self.getvalue()
+        super().close()
+
+    def read_captured(self) -> bytes:
+        return self.captured
+
+
+class _FakeTextWriteStream(io.StringIO):
+    """Collects text written; captures content on close."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.captured: str = ""
+
+    def close(self) -> None:
+        self.captured = self.getvalue()
+        super().close()
+
+    def read_captured(self) -> str:
+        return self.captured
+
+
+def _make_handler(streams: dict[str, io.IOBase]) -> MagicMock:
+    """Build a mock URLHandler that returns pre-built streams keyed by URL."""
+    handler = MagicMock()
+    handler.can_handle.return_value = True
+
+    def _open(url: str, mode: str = "rb") -> io.IOBase:
+        if url not in streams:
+            if "b" not in mode:
+                s: io.IOBase = _FakeTextWriteStream()
+            else:
+                s = _FakeWriteStream()
+            streams[url] = s
+        return streams[url]
+
+    handler.open.side_effect = _open
+    return handler
+
+
+def test_push_group_uploads_via_handler(tmp_path: Path) -> None:
+    """push_group should use handler.open() for all uploads, not GCS directly."""
+    # Set up a data file
+    data_dir = tmp_path / "outputs"
+    data_dir.mkdir()
+    data_file = data_dir / "result.csv"
+    data_file.write_text("x,y\n3,4\n")
+
+    ds = DatasetMetadata(
+        slug="result",
+        name="Result",
+        location="outputs/result.csv",
+        dataset_type="output",
+    )
+
+    manager = MagicMock()
+    manager.get_absolute_path.return_value = data_file
+    manager.project_path = tmp_path
+
+    publish_config = PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False)
+
+    def build_resource(d: DatasetMetadata, m: Any, pc: Optional[PublishConfig]) -> Optional[dict[str, Any]]:
+        return {"path": d.location, "name": d.slug}
+
+    streams: dict[str, io.IOBase] = {}
+    mock_handler = _make_handler(streams)
+
+    mock_registry = MagicMock()
+    mock_registry.find_url_handler.return_value = mock_handler
+
+    with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+        MockPluginRegistry.get.return_value = mock_registry
+
+        uploaded = push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="test-project",
+            publish_config=publish_config,
+            build_resource_dict_fn=build_resource,
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[],
+        )
+
+    # Should have uploaded datapackage.json + the data file
+    assert len(uploaded) == 2
+    assert uploaded[0] == "pkg/datapackage.json"
+    assert uploaded[1] == "outputs/result.csv"
+
+    # Verify handler.open was called for the datapackage and the data file
+    open_calls = mock_handler.open.call_args_list
+    assert len(open_calls) == 2
+
+    # First call: datapackage.json in text mode
+    assert open_calls[0] == call("gs://bucket/pkg/datapackage.json", "w")
+
+    # Second call: data file in binary mode
+    assert open_calls[1] == call("gs://bucket/pkg/outputs/result.csv", "wb")
+
+    # Verify the datapackage JSON was written
+    dp_stream = streams["gs://bucket/pkg/datapackage.json"]
+    assert isinstance(dp_stream, _FakeTextWriteStream)
+    dp_json = json.loads(dp_stream.read_captured())
+    assert dp_json["name"] == "test-project"
+    assert dp_json["resources"] == [{"path": "outputs/result.csv", "name": "result"}]
+
+    # Verify the data was written
+    data_stream = streams["gs://bucket/pkg/outputs/result.csv"]
+    assert isinstance(data_stream, _FakeWriteStream)
+    assert data_stream.read_captured() == b"x,y\n3,4\n"
+
+
+def test_push_group_returns_empty_when_no_resources(tmp_path: Path) -> None:
+    """push_group returns empty list when build_resource_dict_fn returns None for all."""
+    ds = DatasetMetadata(slug="s", name="S", location="x.csv", dataset_type="output")
+    manager = MagicMock()
+
+    uploaded = push_group(
+        dest_url="gs://bucket/pkg/",
+        datasets=[ds],
+        manager=manager,
+        project_slug="p",
+        publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+        build_resource_dict_fn=lambda d, m, pc: None,
+        package_metadata_fn=lambda: None,
+        rdf_prefixes={},
+        top_level_props={},
+        methodology_files=[],
+    )
+    assert uploaded == []
+
+
+def test_push_group_raises_on_lfs_pointers(tmp_path: Path) -> None:
+    """push_group raises ValueError when data files are LFS pointers."""
+    lfs_file = tmp_path / "outputs" / "big.csv"
+    lfs_file.parent.mkdir(parents=True, exist_ok=True)
+    lfs_file.write_text("version https://git-lfs.github.com/spec/v1\n" "oid sha256:abc123\n" "size 999999\n")
+
+    ds = DatasetMetadata(slug="big", name="Big", location="outputs/big.csv", dataset_type="output")
+    manager = MagicMock()
+    manager.get_absolute_path.return_value = lfs_file
+
+    with pytest.raises(ValueError, match="LFS pointers"):
+        push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[],
+        )
+
+
+def test_push_group_no_handler_raises(tmp_path: Path) -> None:
+    """push_group raises ValueError when no URL handler matches."""
+    data_file = tmp_path / "data.csv"
+    data_file.write_text("a\n1\n")
+
+    ds = DatasetMetadata(slug="d", name="D", location="data.csv", dataset_type="output")
+    manager = MagicMock()
+    manager.get_absolute_path.return_value = data_file
+
+    mock_registry = MagicMock()
+    mock_registry.find_url_handler.return_value = None
+
+    with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+        MockPluginRegistry.get.return_value = mock_registry
+
+        with pytest.raises(ValueError, match="No URL handler found"):
+            push_group(
+                dest_url="xyz://unknown/dest/",
+                datasets=[ds],
+                manager=manager,
+                project_slug="p",
+                publish_config=PublishConfig(enabled=True, to="xyz://unknown/dest/", flatten=False),
+                build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+                package_metadata_fn=lambda: None,
+                rdf_prefixes={},
+                top_level_props={},
+                methodology_files=[],
+            )
+
+
+def test_push_group_with_methodology_files(tmp_path: Path) -> None:
+    """push_group uploads methodology files alongside data files."""
+    data_dir = tmp_path / "outputs"
+    data_dir.mkdir()
+    data_file = data_dir / "data.csv"
+    data_file.write_text("a\n1\n")
+
+    meth_file = tmp_path / "methodology.pdf"
+    meth_file.write_bytes(b"PDF content here")
+
+    ds = DatasetMetadata(slug="d", name="D", location="outputs/data.csv", dataset_type="output")
+    manager = MagicMock()
+    manager.get_absolute_path.return_value = data_file
+    manager.project_path = tmp_path
+
+    streams: dict[str, io.IOBase] = {}
+    mock_handler = _make_handler(streams)
+    mock_registry = MagicMock()
+    mock_registry.find_url_handler.return_value = mock_handler
+
+    with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+        MockPluginRegistry.get.return_value = mock_registry
+
+        uploaded = push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[(meth_file, "https://example.com/methodology.pdf")],
+        )
+
+    assert len(uploaded) == 3
+    assert uploaded[2] == "pkg/methodology.pdf"
+
+    # Verify methodology file content was uploaded
+    meth_stream = streams["gs://bucket/pkg/methodology.pdf"]
+    assert isinstance(meth_stream, _FakeWriteStream)
+    assert meth_stream.read_captured() == b"PDF content here"
+
+
+def test_push_group_flatten_mode(tmp_path: Path) -> None:
+    """With flatten=True, files should be uploaded to the base directory."""
+    data_dir = tmp_path / "outputs" / "sub"
+    data_dir.mkdir(parents=True)
+    data_file = data_dir / "result.csv"
+    data_file.write_text("a\n1\n")
+
+    ds = DatasetMetadata(slug="r", name="R", location="outputs/sub/result.csv", dataset_type="output")
+    manager = MagicMock()
+    manager.get_absolute_path.return_value = data_file
+    manager.project_path = tmp_path
+
+    streams: dict[str, io.IOBase] = {}
+    mock_handler = _make_handler(streams)
+    mock_registry = MagicMock()
+    mock_registry.find_url_handler.return_value = mock_handler
+
+    with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+        MockPluginRegistry.get.return_value = mock_registry
+
+        uploaded = push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=True),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[],
+        )
+
+    # With flatten, the data file name (not full path) is the resource path
+    assert uploaded[1] == "result.csv"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry, _load_cascading_config
+from sunstone.datasets import DatasetsManager
 
 
 class FakeAuth:
@@ -302,3 +303,135 @@ def test_find_format_writer_no_match():
 
     result = registry.find_format_writer(Path("data.csv"), None)
     assert result is None
+
+
+@pytest.fixture
+def dataset_with_url(tmp_path):
+    """Create a minimal project with a dataset that has a source URL."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Test Dataset\n"
+        "    slug: test-dataset\n"
+        "    location: inputs/test.csv\n"
+        "    source:\n"
+        "      name: Test Source\n"
+        "      location:\n"
+        "        data: https://example.com/test.csv\n"
+        "      attributedTo: Test Org\n"
+        "      acquiredAt: '2026-01-01'\n"
+        "      acquisitionMethod: manual-download\n"
+        "      license: CC-BY-4.0\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    return tmp_path
+
+
+def test_fetch_from_url_injects_auth_headers(dataset_with_url):
+    class TestAuth:
+        def authenticate(self, url, headers, dataset):
+            headers["Authorization"] = "Bearer test-token"
+            return headers
+
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()
+    registry._auth_providers.append(TestAuth())
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.datasets._is_public_url", return_value=True),
+        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+
+
+def test_fetch_from_url_stacks_auth_providers(dataset_with_url):
+    class AuthA:
+        def authenticate(self, url, headers, dataset):
+            headers["X-Auth-A"] = "a"
+            return headers
+
+    class AuthB:
+        def authenticate(self, url, headers, dataset):
+            headers["X-Auth-B"] = "b"
+            return headers
+
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()
+    registry._auth_providers.append(AuthA())
+    registry._auth_providers.append(AuthB())
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.datasets._is_public_url", return_value=True),
+        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["X-Auth-A"] == "a"
+        assert kwargs["headers"]["X-Auth-B"] == "b"
+
+
+def test_fetch_from_url_no_auth_still_works(dataset_with_url):
+    """Without auth plugins, fetch works exactly as before."""
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()  # No auth providers
+
+    mock_response = MagicMock()
+    mock_response.is_redirect = False
+    mock_response.content = b"col1,col2\na,b\n"
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.datasets._is_public_url", return_value=True),
+        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"] == {}
+
+
+def test_fetch_from_url_uses_url_handler(dataset_with_url):
+    """URL handler plugin handles the fetch instead of HTTP."""
+    fetched_urls = []
+
+    class TestURLHandler:
+        def can_handle(self, url):
+            return True  # Handle everything for this test
+
+        def fetch(self, url, dest):
+            fetched_urls.append(url)
+            dest.write_text("col1,col2\na,b\n")
+            return dest
+
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()
+    registry._url_handlers.append(TestURLHandler())
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        result = manager.fetch_from_url(dataset, force=True)
+        assert len(fetched_urls) == 1
+        assert fetched_urls[0] == "https://example.com/test.csv"
+        assert result.exists()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,7 +4,7 @@ import pytest
 import pandas as pd
 from unittest.mock import MagicMock, patch
 
-from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry
+from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry, _load_cascading_config
 
 
 class FakeAuth:
@@ -176,3 +176,74 @@ def test_registry_singleton():
             r1 = PluginRegistry.get()
             r2 = PluginRegistry.get()
             assert r1 is r2
+
+
+def test_config_from_pyproject(tmp_path):
+    """Config loaded from pyproject.toml [tool.sunstone.plugins.<name>]."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.sunstone.plugins.s3]\nregion = "eu-west-1"\n')
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "eu-west-1"}
+
+
+def test_config_from_datasets_yaml(tmp_path):
+    """Config loaded from datasets.yaml plugins section when no pyproject.toml."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\nplugins:\n  s3:\n    region: eu-west-1\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "eu-west-1"}
+
+
+def test_config_pyproject_overrides_datasets_yaml(tmp_path):
+    """pyproject.toml takes precedence over datasets.yaml."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.sunstone.plugins.s3]\nregion = "us-east-1"\n')
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\nplugins:\n  s3:\n    region: eu-west-1\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "us-east-1"}
+
+
+def test_config_env_var_override(tmp_path, monkeypatch):
+    """Environment variables override file-based config."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool.sunstone.plugins.s3]\nregion = "eu-west-1"\n')
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    monkeypatch.setenv("SUNSTONE_PLUGIN_S3_REGION", "ap-southeast-1")
+    config = _load_cascading_config("s3", tmp_path)
+    assert config["region"] == "ap-southeast-1"
+
+
+def test_config_env_var_hyphen_to_underscore(tmp_path, monkeypatch):
+    """Plugin names with hyphens convert to underscores in env vars."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    monkeypatch.setenv("SUNSTONE_PLUGIN_BEARER_AUTH_TOKEN", "secret123")
+    config = _load_cascading_config("bearer-auth", tmp_path)
+    assert config == {"token": "secret123"}
+
+
+def test_config_no_config_returns_none(tmp_path):
+    """Returns None when no config found anywhere."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\n")
+
+    config = _load_cascading_config("nonexistent", tmp_path)
+    assert config is None
+
+
+def test_config_no_pyproject_no_error(tmp_path):
+    """Missing pyproject.toml doesn't cause an error."""
+    datasets = tmp_path / "datasets.yaml"
+    datasets.write_text("inputs: []\noutputs: []\nplugins:\n  s3:\n    region: eu-west-1\n")
+
+    config = _load_cascading_config("s3", tmp_path)
+    assert config == {"region": "eu-west-1"}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -41,16 +41,16 @@ class FakeURLHandler:
 
 class FakeFormatHandler:
     def can_read(self, path, format):
-        return path.suffix == ".fake"
+        return str(path).endswith(".fake")
 
-    def read(self, path, **kwargs):
-        return pd.DataFrame({"x": [1, 2, 3]})
+    def read(self, stream, **kwargs):
+        return pd.read_csv(stream)
 
     def can_write(self, path, format):
-        return path.suffix == ".fake"
+        return str(path).endswith(".fake")
 
-    def write(self, df, path, **kwargs):
-        df.to_csv(path)
+    def write(self, df, stream, **kwargs):
+        df.to_csv(stream)
 
 
 class PartialFormatHandler:
@@ -59,7 +59,7 @@ class PartialFormatHandler:
     def can_read(self, path, format):
         return True
 
-    def read(self, path, **kwargs):
+    def read(self, stream, **kwargs):
         return pd.DataFrame()
 
 
@@ -196,15 +196,15 @@ def test_external_plugin_takes_priority_over_builtin():
 
     class ExternalCSVHandler:
         def can_read(self, path, format):
-            return path.suffix == ".csv"
+            return str(path).endswith(".csv")
 
-        def read(self, path, **kwargs):
+        def read(self, stream, **kwargs):
             return pd.DataFrame({"external": [True]})
 
         def can_write(self, path, format):
-            return path.suffix == ".csv"
+            return str(path).endswith(".csv")
 
-        def write(self, df, path, **kwargs):
+        def write(self, df, stream, **kwargs):
             pass
 
     with patch(
@@ -488,7 +488,7 @@ def project_with_fake_format(tmp_path):
         "inputs:\n" "  - name: Fake Data\n" "    slug: fake-data\n" "    location: inputs/data.fake\n" "outputs: []\n"
     )
     (tmp_path / "inputs").mkdir()
-    (tmp_path / "inputs" / "data.fake").write_text("custom format content")
+    (tmp_path / "inputs" / "data.fake").write_text("x\n1\n2\n3\n")
     return tmp_path
 
 
@@ -531,15 +531,15 @@ def test_read_dataset_plugin_overrides_builtin(tmp_path):
 
     class CustomCSVHandler:
         def can_read(self, path, format):
-            return path.suffix == ".csv"
+            return str(path).endswith(".csv")
 
-        def read(self, path, **kwargs):
+        def read(self, stream, **kwargs):
             return pd.DataFrame({"custom": [True]})
 
         def can_write(self, path, format):
             return False
 
-        def write(self, df, path, **kwargs):
+        def write(self, df, stream, **kwargs):
             pass
 
     registry = PluginRegistry()
@@ -569,17 +569,17 @@ def test_to_csv_uses_format_writer(tmp_path):
 
     class TrackingFormatHandler:
         def can_read(self, path, format):
-            return path.suffix == ".fake"
+            return str(path).endswith(".fake")
 
-        def read(self, path, **kwargs):
+        def read(self, stream, **kwargs):
             return pd.DataFrame()
 
         def can_write(self, path, format):
-            return path.suffix == ".fake"
+            return str(path).endswith(".fake")
 
-        def write(self, df, path, **kwargs):
-            write_called.append(path)
-            df.to_csv(path)
+        def write(self, df, stream, **kwargs):
+            write_called.append(stream)
+            df.to_csv(stream)
 
     registry = PluginRegistry()
     registry._format_handlers.append(TrackingFormatHandler())

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -404,20 +404,18 @@ def test_fetch_from_url_injects_auth_headers(dataset_with_url):
     registry._auth_providers.append(TestAuth())
 
     mock_response = MagicMock()
-    mock_response.is_redirect = False
-    mock_response.content = b"col1,col2\na,b\n"
-    mock_response.raise_for_status = MagicMock()
+    mock_response.read.return_value = b"col1,col2\na,b\n"
 
     registry._url_handlers.append(HttpURLHandler())
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
+        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
     ):
         manager.fetch_from_url(dataset, force=True)
-        _, kwargs = mock_get.call_args
-        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.get_header("Authorization") == "Bearer test-token"
 
 
 def test_fetch_from_url_stacks_auth_providers(dataset_with_url):
@@ -439,21 +437,19 @@ def test_fetch_from_url_stacks_auth_providers(dataset_with_url):
     registry._auth_providers.append(AuthB())
 
     mock_response = MagicMock()
-    mock_response.is_redirect = False
-    mock_response.content = b"col1,col2\na,b\n"
-    mock_response.raise_for_status = MagicMock()
+    mock_response.read.return_value = b"col1,col2\na,b\n"
 
     registry._url_handlers.append(HttpURLHandler())
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
+        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
     ):
         manager.fetch_from_url(dataset, force=True)
-        _, kwargs = mock_get.call_args
-        assert kwargs["headers"]["X-Auth-A"] == "a"
-        assert kwargs["headers"]["X-Auth-B"] == "b"
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.get_header("X-auth-a") == "a"
+        assert request_obj.get_header("X-auth-b") == "b"
 
 
 def test_fetch_from_url_no_auth_still_works(dataset_with_url):
@@ -464,20 +460,18 @@ def test_fetch_from_url_no_auth_still_works(dataset_with_url):
     registry = PluginRegistry()  # No auth providers
 
     mock_response = MagicMock()
-    mock_response.is_redirect = False
-    mock_response.content = b"col1,col2\na,b\n"
-    mock_response.raise_for_status = MagicMock()
+    mock_response.read.return_value = b"col1,col2\na,b\n"
 
     registry._url_handlers.append(HttpURLHandler())
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
+        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
     ):
         manager.fetch_from_url(dataset, force=True)
-        _, kwargs = mock_get.call_args
-        assert kwargs["headers"] == {}
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.headers == {}
 
 
 @pytest.fixture
@@ -616,16 +610,17 @@ def test_read_dataset_unknown_format_without_plugin(tmp_path):
 
 def test_fetch_from_url_uses_url_handler(dataset_with_url):
     """URL handler plugin handles the fetch instead of HTTP."""
+    import io as _io
+
     fetched_urls = []
 
     class TestURLHandler:
         def can_handle(self, url):
             return True  # Handle everything for this test
 
-        def fetch(self, url, dest):
+        def open(self, url, mode="rb"):
             fetched_urls.append(url)
-            dest.write_text("col1,col2\na,b\n")
-            return dest
+            return _io.BytesIO(b"col1,col2\na,b\n")
 
     manager = DatasetsManager(dataset_with_url)
     dataset = manager.find_dataset_by_slug("test-dataset")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,73 @@
+"""Tests for the plugin infrastructure."""
+
+import pandas as pd
+
+from sunstone.plugins import AuthProvider, FormatHandler, URLHandler
+
+
+class FakeAuth:
+    def authenticate(self, url, headers, dataset):
+        headers["X-Test"] = "value"
+        return headers
+
+
+class FakeURLHandler:
+    def can_handle(self, url):
+        return url.startswith("fake://")
+
+    def fetch(self, url, dest):
+        dest.write_text("col1,col2\na,b\n")
+        return dest
+
+
+class FakeFormatHandler:
+    def can_read(self, path, format):
+        return path.suffix == ".fake"
+
+    def read(self, path, **kwargs):
+        return pd.DataFrame({"x": [1, 2, 3]})
+
+    def can_write(self, path, format):
+        return path.suffix == ".fake"
+
+    def write(self, df, path, **kwargs):
+        df.to_csv(path)
+
+
+class PartialFormatHandler:
+    """Only implements read, not write."""
+
+    def can_read(self, path, format):
+        return True
+
+    def read(self, path, **kwargs):
+        return pd.DataFrame()
+
+
+class NotAPlugin:
+    """Implements no protocol."""
+
+    pass
+
+
+def test_auth_provider_structural_typing():
+    assert isinstance(FakeAuth(), AuthProvider)
+
+
+def test_url_handler_structural_typing():
+    assert isinstance(FakeURLHandler(), URLHandler)
+
+
+def test_format_handler_structural_typing():
+    assert isinstance(FakeFormatHandler(), FormatHandler)
+
+
+def test_partial_format_handler_is_not_format_handler():
+    """FormatHandler requires both read and write methods."""
+    assert not isinstance(PartialFormatHandler(), FormatHandler)
+
+
+def test_not_a_plugin():
+    assert not isinstance(NotAPlugin(), AuthProvider)
+    assert not isinstance(NotAPlugin(), URLHandler)
+    assert not isinstance(NotAPlugin(), FormatHandler)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -626,3 +626,17 @@ def test_fetch_from_url_uses_url_handler(dataset_with_url):
         assert len(fetched_urls) == 1
         assert fetched_urls[0] == "https://example.com/test.csv"
         assert result.exists()
+
+
+def test_read_csv_by_path_uses_registry(tmp_path):
+    """read_csv with a file path routes through the format handler registry."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n" "  - name: CSV Data\n" "    slug: csv-data\n" "    location: inputs/data.csv\n" "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n")
+
+    # This should work via the builtin format handler in the registry
+    df = DataFrame.read_csv("inputs/data.csv", project_path=tmp_path)
+    assert list(df.data.columns) == ["a", "b"]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -402,10 +402,12 @@ def test_fetch_from_url_injects_auth_headers(dataset_with_url):
     mock_response.content = b"col1,col2\na,b\n"
     mock_response.raise_for_status = MagicMock()
 
+    registry._url_handlers.append(HttpURLHandler())
+
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
-        patch("sunstone.datasets._is_public_url", return_value=True),
-        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
     ):
         manager.fetch_from_url(dataset, force=True)
         _, kwargs = mock_get.call_args
@@ -435,10 +437,12 @@ def test_fetch_from_url_stacks_auth_providers(dataset_with_url):
     mock_response.content = b"col1,col2\na,b\n"
     mock_response.raise_for_status = MagicMock()
 
+    registry._url_handlers.append(HttpURLHandler())
+
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
-        patch("sunstone.datasets._is_public_url", return_value=True),
-        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
     ):
         manager.fetch_from_url(dataset, force=True)
         _, kwargs = mock_get.call_args
@@ -458,10 +462,12 @@ def test_fetch_from_url_no_auth_still_works(dataset_with_url):
     mock_response.content = b"col1,col2\na,b\n"
     mock_response.raise_for_status = MagicMock()
 
+    registry._url_handlers.append(HttpURLHandler())
+
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
-        patch("sunstone.datasets._is_public_url", return_value=True),
-        patch("sunstone.datasets.requests.get", return_value=mock_response) as mock_get,
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.requests.get", return_value=mock_response) as mock_get,
     ):
         manager.fetch_from_url(dataset, force=True)
         _, kwargs = mock_get.call_args

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry, _load_cascading_config
+from sunstone.handlers import BuiltinFormatHandler, HttpURLHandler
 from sunstone.datasets import DatasetsManager
 from sunstone.dataframe import DataFrame
 
@@ -108,22 +109,22 @@ def test_registry_discovers_auth_provider():
         with patch("sunstone.plugins._load_plugin_config", return_value=None):
             registry = PluginRegistry.get()
             assert len(registry.get_auth_providers()) == 1
-            assert len(registry.get_url_handlers()) == 0
-            assert len(registry.get_format_handlers()) == 0
+            assert not any(isinstance(h, FakeURLHandler) for h in registry.get_url_handlers())
+            assert not any(isinstance(h, FakeFormatHandler) for h in registry.get_format_handlers())
 
 
 def test_registry_discovers_url_handler():
     with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-url", FakeURLHandler)]):
         with patch("sunstone.plugins._load_plugin_config", return_value=None):
             registry = PluginRegistry.get()
-            assert len(registry.get_url_handlers()) == 1
+            assert any(isinstance(h, FakeURLHandler) for h in registry.get_url_handlers())
 
 
 def test_registry_discovers_format_handler():
     with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-fmt", FakeFormatHandler)]):
         with patch("sunstone.plugins._load_plugin_config", return_value=None):
             registry = PluginRegistry.get()
-            assert len(registry.get_format_handlers()) == 1
+            assert any(isinstance(h, FakeFormatHandler) for h in registry.get_format_handlers())
 
 
 def test_registry_multi_protocol_plugin():
@@ -143,7 +144,7 @@ def test_registry_multi_protocol_plugin():
         with patch("sunstone.plugins._load_plugin_config", return_value=None):
             registry = PluginRegistry.get()
             assert len(registry.get_auth_providers()) == 1
-            assert len(registry.get_url_handlers()) == 1
+            assert any(isinstance(h, MultiPlugin) for h in registry.get_url_handlers())
 
 
 def test_registry_ignores_non_plugin(caplog):
@@ -151,8 +152,8 @@ def test_registry_ignores_non_plugin(caplog):
         with patch("sunstone.plugins._load_plugin_config", return_value=None):
             registry = PluginRegistry.get()
             assert len(registry.get_auth_providers()) == 0
-            assert len(registry.get_url_handlers()) == 0
-            assert len(registry.get_format_handlers()) == 0
+            assert not any(isinstance(h, NotAPlugin) for h in registry.get_url_handlers())
+            assert not any(isinstance(h, NotAPlugin) for h in registry.get_format_handlers())
             assert "does not implement any known plugin protocol" in caplog.text
 
 
@@ -161,8 +162,54 @@ def test_registry_no_plugins():
         with patch("sunstone.plugins._load_plugin_config", return_value=None):
             registry = PluginRegistry.get()
             assert len(registry.get_auth_providers()) == 0
-            assert len(registry.get_url_handlers()) == 0
-            assert len(registry.get_format_handlers()) == 0
+            # Internal handlers are always registered
+            assert any(isinstance(h, HttpURLHandler) for h in registry.get_url_handlers())
+            assert any(isinstance(h, BuiltinFormatHandler) for h in registry.get_format_handlers())
+
+
+def test_registry_registers_builtin_format_handler():
+    """BuiltinFormatHandler is registered as a default."""
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            handlers = registry.get_format_handlers()
+            assert any(isinstance(h, BuiltinFormatHandler) for h in handlers)
+
+
+def test_registry_registers_http_url_handler():
+    """HttpURLHandler is registered as a default."""
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            handlers = registry.get_url_handlers()
+            assert any(isinstance(h, HttpURLHandler) for h in handlers)
+
+
+def test_external_plugin_takes_priority_over_builtin():
+    """External plugins registered via entry points come before builtins."""
+
+    class ExternalCSVHandler:
+        def can_read(self, path, format):
+            return path.suffix == ".csv"
+
+        def read(self, path, **kwargs):
+            return pd.DataFrame({"external": [True]})
+
+        def can_write(self, path, format):
+            return path.suffix == ".csv"
+
+        def write(self, df, path, **kwargs):
+            pass
+
+    with patch(
+        "sunstone.plugins._get_entry_points",
+        return_value=[_make_entry_point("ext-csv", ExternalCSVHandler)],
+    ):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            handler = registry.find_format_reader(Path("data.csv"), None)
+            # External plugin should win because it's registered first
+            assert isinstance(handler, ExternalCSVHandler)
 
 
 def test_registry_passes_config_to_constructor():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -491,7 +491,7 @@ def test_read_dataset_uses_format_handler(project_with_fake_format):
 
 
 def test_read_dataset_builtin_format_still_works(tmp_path):
-    """CSV reading still works without any plugins."""
+    """CSV reading still works with only the builtin format handler registered."""
     datasets_yaml = tmp_path / "datasets.yaml"
     datasets_yaml.write_text(
         "inputs:\n" "  - name: CSV Data\n" "    slug: csv-data\n" "    location: inputs/data.csv\n" "outputs: []\n"
@@ -499,7 +499,8 @@ def test_read_dataset_builtin_format_still_works(tmp_path):
     (tmp_path / "inputs").mkdir()
     (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n3,4\n")
 
-    registry = PluginRegistry()  # No format handlers
+    registry = PluginRegistry()
+    registry._format_handlers.append(BuiltinFormatHandler())  # always registered in production
 
     with patch.object(PluginRegistry, "get", return_value=registry):
         df = DataFrame.read_dataset("csv-data", project_path=tmp_path)
@@ -582,6 +583,23 @@ def test_to_csv_uses_format_writer(tmp_path):
 
     assert len(write_called) == 1
     assert write_called[0].name == "data.fake"
+
+
+def test_read_dataset_unknown_format_without_plugin(tmp_path):
+    """Unknown format raises ValueError when no handler matches."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n"
+        "  - name: Unknown Data\n"
+        "    slug: unknown-data\n"
+        "    location: inputs/data.xyz\n"
+        "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.xyz").write_text("stuff")
+
+    with pytest.raises(ValueError, match="No format handler found"):
+        DataFrame.read_dataset("unknown-data", project_path=tmp_path)
 
 
 def test_fetch_from_url_uses_url_handler(dataset_with_url):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -479,7 +479,7 @@ def project_with_fake_format(tmp_path):
     """Create a project with a dataset using a custom format."""
     datasets_yaml = tmp_path / "datasets.yaml"
     datasets_yaml.write_text(
-        "inputs:\n" "  - name: Fake Data\n" "    slug: fake-data\n" "    location: inputs/data.fake\n" "outputs: []\n"
+        "inputs:\n  - name: Fake Data\n    slug: fake-data\n    location: inputs/data.fake\noutputs: []\n"
     )
     (tmp_path / "inputs").mkdir()
     (tmp_path / "inputs" / "data.fake").write_text("x\n1\n2\n3\n")
@@ -500,7 +500,7 @@ def test_read_dataset_builtin_format_still_works(tmp_path):
     """CSV reading still works with only the builtin format handler registered."""
     datasets_yaml = tmp_path / "datasets.yaml"
     datasets_yaml.write_text(
-        "inputs:\n" "  - name: CSV Data\n" "    slug: csv-data\n" "    location: inputs/data.csv\n" "outputs: []\n"
+        "inputs:\n  - name: CSV Data\n    slug: csv-data\n    location: inputs/data.csv\noutputs: []\n"
     )
     (tmp_path / "inputs").mkdir()
     (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n3,4\n")
@@ -518,7 +518,7 @@ def test_read_dataset_plugin_overrides_builtin(tmp_path):
     """A plugin that handles .csv overrides the builtin CSV reader."""
     datasets_yaml = tmp_path / "datasets.yaml"
     datasets_yaml.write_text(
-        "inputs:\n" "  - name: CSV Data\n" "    slug: csv-data\n" "    location: inputs/data.csv\n" "outputs: []\n"
+        "inputs:\n  - name: CSV Data\n    slug: csv-data\n    location: inputs/data.csv\noutputs: []\n"
     )
     (tmp_path / "inputs").mkdir()
     (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n")
@@ -595,11 +595,7 @@ def test_read_dataset_unknown_format_without_plugin(tmp_path):
     """Unknown format raises ValueError when no handler matches."""
     datasets_yaml = tmp_path / "datasets.yaml"
     datasets_yaml.write_text(
-        "inputs:\n"
-        "  - name: Unknown Data\n"
-        "    slug: unknown-data\n"
-        "    location: inputs/data.xyz\n"
-        "outputs: []\n"
+        "inputs:\n  - name: Unknown Data\n    slug: unknown-data\n    location: inputs/data.xyz\noutputs: []\n"
     )
     (tmp_path / "inputs").mkdir()
     (tmp_path / "inputs" / "data.xyz").write_text("stuff")
@@ -639,7 +635,7 @@ def test_read_csv_by_path_uses_registry(tmp_path):
     """read_csv with a file path routes through the format handler registry."""
     datasets_yaml = tmp_path / "datasets.yaml"
     datasets_yaml.write_text(
-        "inputs:\n" "  - name: CSV Data\n" "    slug: csv-data\n" "    location: inputs/data.csv\n" "outputs: []\n"
+        "inputs:\n  - name: CSV Data\n    slug: csv-data\n    location: inputs/data.csv\noutputs: []\n"
     )
     (tmp_path / "inputs").mkdir()
     (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -10,6 +10,15 @@ from sunstone.datasets import DatasetsManager
 from sunstone.dataframe import DataFrame
 
 
+def _mock_execution_context():
+    from sunstone.context import ExecutionContext
+
+    return ExecutionContext(
+        user="test-user",
+        execution_timestamp="2026-01-15T10:00:00+00:00",
+    )
+
+
 class FakeAuth:
     def authenticate(self, url, headers, dataset):
         headers["X-Test"] = "value"
@@ -479,6 +488,53 @@ def test_read_dataset_plugin_overrides_builtin(tmp_path):
     with patch.object(PluginRegistry, "get", return_value=registry):
         df = DataFrame.read_dataset("csv-data", project_path=tmp_path)
         assert list(df.data.columns) == ["custom"]
+
+
+def test_to_csv_uses_format_writer(tmp_path):
+    """When a format handler matches, it handles the write."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs: []\n"
+        "outputs:\n"
+        "  - name: Fake Output\n"
+        "    slug: fake-output\n"
+        "    location: outputs/data.fake\n"
+        "    fields:\n"
+        "      - name: x\n"
+        "        type: integer\n"
+    )
+    (tmp_path / "outputs").mkdir()
+
+    write_called = []
+
+    class TrackingFormatHandler:
+        def can_read(self, path, format):
+            return path.suffix == ".fake"
+
+        def read(self, path, **kwargs):
+            return pd.DataFrame()
+
+        def can_write(self, path, format):
+            return path.suffix == ".fake"
+
+        def write(self, df, path, **kwargs):
+            write_called.append(path)
+            df.to_csv(path)
+
+    registry = PluginRegistry()
+    registry._format_handlers.append(TrackingFormatHandler())
+
+    df = DataFrame(data=pd.DataFrame({"x": [1, 2, 3]}), project_path=tmp_path)
+
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.dataframe.compute_dataframe_hash", return_value="abc123"),
+        patch("sunstone.context.detect_execution_context", side_effect=_mock_execution_context),
+    ):
+        df.to_csv("outputs/data.fake", index=False)
+
+    assert len(write_called) == 1
+    assert write_called[0].name == "data.fake"
 
 
 def test_fetch_from_url_uses_url_handler(dataset_with_url):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,8 +1,10 @@
 """Tests for the plugin infrastructure."""
 
+import pytest
 import pandas as pd
+from unittest.mock import MagicMock, patch
 
-from sunstone.plugins import AuthProvider, FormatHandler, URLHandler
+from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry
 
 
 class FakeAuth:
@@ -71,3 +73,106 @@ def test_not_a_plugin():
     assert not isinstance(NotAPlugin(), AuthProvider)
     assert not isinstance(NotAPlugin(), URLHandler)
     assert not isinstance(NotAPlugin(), FormatHandler)
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset the singleton between tests."""
+    PluginRegistry._instance = None
+    yield
+    PluginRegistry._instance = None
+
+
+def _make_entry_point(name, plugin_cls):
+    """Create a mock entry point."""
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = plugin_cls
+    return ep
+
+
+def test_registry_discovers_auth_provider():
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-auth", FakeAuth)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 1
+            assert len(registry.get_url_handlers()) == 0
+            assert len(registry.get_format_handlers()) == 0
+
+
+def test_registry_discovers_url_handler():
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-url", FakeURLHandler)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_url_handlers()) == 1
+
+
+def test_registry_discovers_format_handler():
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("fake-fmt", FakeFormatHandler)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_format_handlers()) == 1
+
+
+def test_registry_multi_protocol_plugin():
+    """A plugin implementing multiple protocols gets classified into all matching lists."""
+
+    class MultiPlugin:
+        def authenticate(self, url, headers, dataset):
+            return headers
+
+        def can_handle(self, url):
+            return url.startswith("multi://")
+
+        def fetch(self, url, dest):
+            return dest
+
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("multi", MultiPlugin)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 1
+            assert len(registry.get_url_handlers()) == 1
+
+
+def test_registry_ignores_non_plugin(caplog):
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("nope", NotAPlugin)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 0
+            assert len(registry.get_url_handlers()) == 0
+            assert len(registry.get_format_handlers()) == 0
+            assert "does not implement any known plugin protocol" in caplog.text
+
+
+def test_registry_no_plugins():
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 0
+            assert len(registry.get_url_handlers()) == 0
+            assert len(registry.get_format_handlers()) == 0
+
+
+def test_registry_passes_config_to_constructor():
+    class ConfigPlugin:
+        def __init__(self, config=None):
+            self.config = config
+
+        def authenticate(self, url, headers, dataset):
+            return headers
+
+    config = {"key": "value"}
+    with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("cfg", ConfigPlugin)]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=config):
+            registry = PluginRegistry.get()
+            providers = registry.get_auth_providers()
+            assert len(providers) == 1
+            assert providers[0].config == config
+
+
+def test_registry_singleton():
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            r1 = PluginRegistry.get()
+            r2 = PluginRegistry.get()
+            assert r1 is r2

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,6 +2,7 @@
 
 import pytest
 import pandas as pd
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry, _load_cascading_config
@@ -247,3 +248,57 @@ def test_config_no_pyproject_no_error(tmp_path):
 
     config = _load_cascading_config("s3", tmp_path)
     assert config == {"region": "eu-west-1"}
+
+
+def test_find_url_handler_matching():
+    registry = PluginRegistry()
+    handler = FakeURLHandler()
+    registry._url_handlers.append(handler)
+
+    result = registry.find_url_handler("fake://bucket/file.csv")
+    assert result is handler
+
+
+def test_find_url_handler_no_match():
+    registry = PluginRegistry()
+    handler = FakeURLHandler()
+    registry._url_handlers.append(handler)
+
+    result = registry.find_url_handler("https://example.com/file.csv")
+    assert result is None
+
+
+def test_find_format_reader_matching():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_reader(Path("data.fake"), None)
+    assert result is handler
+
+
+def test_find_format_reader_no_match():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_reader(Path("data.csv"), None)
+    assert result is None
+
+
+def test_find_format_writer_matching():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_writer(Path("data.fake"), None)
+    assert result is handler
+
+
+def test_find_format_writer_no_match():
+    registry = PluginRegistry()
+    handler = FakeFormatHandler()
+    registry._format_handlers.append(handler)
+
+    result = registry.find_format_writer(Path("data.csv"), None)
+    assert result is None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -588,7 +588,7 @@ def test_to_csv_uses_format_writer(tmp_path):
         df.to_csv("outputs/data.fake", index=False)
 
     assert len(write_called) == 1
-    assert write_called[0].name == "data.fake"
+    assert Path(write_called[0].name).name == "data.fake"
 
 
 def test_read_dataset_unknown_format_without_plugin(tmp_path):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -96,8 +96,10 @@ def test_not_a_plugin():
 def reset_registry():
     """Reset the singleton between tests."""
     PluginRegistry._instance = None
+    PluginRegistry._instances = {}
     yield
     PluginRegistry._instance = None
+    PluginRegistry._instances = {}
 
 
 def _make_entry_point(name, plugin_cls):
@@ -241,6 +243,21 @@ def test_registry_singleton():
             r1 = PluginRegistry.get()
             r2 = PluginRegistry.get()
             assert r1 is r2
+
+
+def test_registry_scoped_by_project_path(tmp_path):
+    project_a = tmp_path / "a"
+    project_b = tmp_path / "b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    with patch("sunstone.plugins._get_entry_points", return_value=[]):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            r1 = PluginRegistry.get(project_a)
+            r2 = PluginRegistry.get(project_a)
+            r3 = PluginRegistry.get(project_b)
+            assert r1 is r2
+            assert r1 is not r3
 
 
 def test_config_from_pyproject(tmp_path):
@@ -404,17 +421,20 @@ def test_fetch_from_url_injects_auth_headers(dataset_with_url):
     registry._auth_providers.append(TestAuth())
 
     mock_response = MagicMock()
+    mock_response.status = 200
     mock_response.read.return_value = b"col1,col2\na,b\n"
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_response
 
     registry._url_handlers.append(HttpURLHandler())
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
+        patch("sunstone.handlers.build_opener", return_value=mock_opener),
     ):
         manager.fetch_from_url(dataset, force=True)
-        request_obj = mock_urlopen.call_args[0][0]
+        request_obj = mock_opener.open.call_args[0][0]
         assert request_obj.get_header("Authorization") == "Bearer test-token"
 
 
@@ -437,17 +457,20 @@ def test_fetch_from_url_stacks_auth_providers(dataset_with_url):
     registry._auth_providers.append(AuthB())
 
     mock_response = MagicMock()
+    mock_response.status = 200
     mock_response.read.return_value = b"col1,col2\na,b\n"
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_response
 
     registry._url_handlers.append(HttpURLHandler())
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
+        patch("sunstone.handlers.build_opener", return_value=mock_opener),
     ):
         manager.fetch_from_url(dataset, force=True)
-        request_obj = mock_urlopen.call_args[0][0]
+        request_obj = mock_opener.open.call_args[0][0]
         assert request_obj.get_header("X-auth-a") == "a"
         assert request_obj.get_header("X-auth-b") == "b"
 
@@ -460,18 +483,66 @@ def test_fetch_from_url_no_auth_still_works(dataset_with_url):
     registry = PluginRegistry()  # No auth providers
 
     mock_response = MagicMock()
+    mock_response.status = 200
     mock_response.read.return_value = b"col1,col2\na,b\n"
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_response
 
     registry._url_handlers.append(HttpURLHandler())
 
     with (
         patch.object(PluginRegistry, "get", return_value=registry),
         patch("sunstone.handlers._is_public_url", return_value=True),
-        patch("sunstone.handlers.urlopen", return_value=mock_response) as mock_urlopen,
+        patch("sunstone.handlers.build_opener", return_value=mock_opener),
     ):
         manager.fetch_from_url(dataset, force=True)
-        request_obj = mock_urlopen.call_args[0][0]
+        request_obj = mock_opener.open.call_args[0][0]
         assert request_obj.headers == {}
+
+
+def test_fetch_from_url_does_not_leak_auth_headers_between_calls(dataset_with_url):
+    class TestAuth:
+        def authenticate(self, url, headers, dataset):
+            headers["Authorization"] = "Bearer test-token"
+            return headers
+
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+
+    registry = PluginRegistry()
+    handler = HttpURLHandler()
+    registry._url_handlers.append(handler)
+
+    authed_response = MagicMock()
+    authed_response.status = 200
+    authed_response.read.return_value = b"col1,col2\na,b\n"
+    plain_response = MagicMock()
+    plain_response.status = 200
+    plain_response.read.return_value = b"col1,col2\na,b\n"
+
+    opener_with_auth = MagicMock()
+    opener_with_auth.open.return_value = authed_response
+    registry._auth_providers.append(TestAuth())
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.build_opener", return_value=opener_with_auth),
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        first_request = opener_with_auth.open.call_args[0][0]
+        assert first_request.get_header("Authorization") == "Bearer test-token"
+
+    registry._auth_providers.clear()
+    opener_without_auth = MagicMock()
+    opener_without_auth.open.return_value = plain_response
+    with (
+        patch.object(PluginRegistry, "get", return_value=registry),
+        patch("sunstone.handlers._is_public_url", return_value=True),
+        patch("sunstone.handlers.build_opener", return_value=opener_without_auth),
+    ):
+        manager.fetch_from_url(dataset, force=True)
+        second_request = opener_without_auth.open.call_args[0][0]
+        assert second_request.get_header("Authorization") is None
 
 
 @pytest.fixture
@@ -629,6 +700,33 @@ def test_fetch_from_url_uses_url_handler(dataset_with_url):
         assert len(fetched_urls) == 1
         assert fetched_urls[0] == "https://example.com/test.csv"
         assert result.exists()
+
+
+def test_fetch_from_url_supports_custom_url_schemes(dataset_with_url):
+    """Custom URL handlers discovered through the registry can bootstrap missing files."""
+    import io as _io
+
+    fetched_urls = []
+
+    class CustomURLHandler:
+        def can_handle(self, url):
+            return url.startswith("custom://")
+
+        def open(self, url, mode="rb"):
+            fetched_urls.append(url)
+            return _io.BytesIO(b"col1,col2\na,b\n")
+
+    manager = DatasetsManager(dataset_with_url)
+    dataset = manager.find_dataset_by_slug("test-dataset")
+    dataset.source.location.data = "custom://bucket/test.csv"
+
+    registry = PluginRegistry()
+    registry._url_handlers.append(CustomURLHandler())
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        result = manager.fetch_from_url(dataset, force=True)
+        assert result.exists()
+        assert fetched_urls == ["custom://bucket/test.csv"]
 
 
 def test_read_csv_by_path_uses_registry(tmp_path):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry, _load_cascading_config
 from sunstone.datasets import DatasetsManager
+from sunstone.dataframe import DataFrame
 
 
 class FakeAuth:
@@ -409,6 +410,75 @@ def test_fetch_from_url_no_auth_still_works(dataset_with_url):
         manager.fetch_from_url(dataset, force=True)
         _, kwargs = mock_get.call_args
         assert kwargs["headers"] == {}
+
+
+@pytest.fixture
+def project_with_fake_format(tmp_path):
+    """Create a project with a dataset using a custom format."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n" "  - name: Fake Data\n" "    slug: fake-data\n" "    location: inputs/data.fake\n" "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.fake").write_text("custom format content")
+    return tmp_path
+
+
+def test_read_dataset_uses_format_handler(project_with_fake_format):
+    registry = PluginRegistry()
+    registry._format_handlers.append(FakeFormatHandler())
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        df = DataFrame.read_dataset("fake-data", project_path=project_with_fake_format)
+        assert list(df.data.columns) == ["x"]
+        assert len(df.data) == 3
+
+
+def test_read_dataset_builtin_format_still_works(tmp_path):
+    """CSV reading still works without any plugins."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n" "  - name: CSV Data\n" "    slug: csv-data\n" "    location: inputs/data.csv\n" "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n3,4\n")
+
+    registry = PluginRegistry()  # No format handlers
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        df = DataFrame.read_dataset("csv-data", project_path=tmp_path)
+        assert list(df.data.columns) == ["a", "b"]
+        assert len(df.data) == 2
+
+
+def test_read_dataset_plugin_overrides_builtin(tmp_path):
+    """A plugin that handles .csv overrides the builtin CSV reader."""
+    datasets_yaml = tmp_path / "datasets.yaml"
+    datasets_yaml.write_text(
+        "inputs:\n" "  - name: CSV Data\n" "    slug: csv-data\n" "    location: inputs/data.csv\n" "outputs: []\n"
+    )
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "data.csv").write_text("a,b\n1,2\n")
+
+    class CustomCSVHandler:
+        def can_read(self, path, format):
+            return path.suffix == ".csv"
+
+        def read(self, path, **kwargs):
+            return pd.DataFrame({"custom": [True]})
+
+        def can_write(self, path, format):
+            return False
+
+        def write(self, df, path, **kwargs):
+            pass
+
+    registry = PluginRegistry()
+    registry._format_handlers.append(CustomCSVHandler())
+
+    with patch.object(PluginRegistry, "get", return_value=registry):
+        df = DataFrame.read_dataset("csv-data", project_path=tmp_path)
+        assert list(df.data.columns) == ["custom"]
 
 
 def test_fetch_from_url_uses_url_handler(dataset_with_url):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -30,9 +30,13 @@ class FakeURLHandler:
     def can_handle(self, url):
         return url.startswith("fake://")
 
-    def fetch(self, url, dest):
-        dest.write_text("col1,col2\na,b\n")
-        return dest
+    def open(self, url, mode="rb"):
+        import io
+
+        if "b" in mode:
+            return io.BytesIO(b"col1,col2\na,b\n")
+        else:
+            return io.StringIO("col1,col2\na,b\n")
 
 
 class FakeFormatHandler:
@@ -137,8 +141,10 @@ def test_registry_multi_protocol_plugin():
         def can_handle(self, url):
             return url.startswith("multi://")
 
-        def fetch(self, url, dest):
-            return dest
+        def open(self, url, mode="rb"):
+            import io
+
+            return io.BytesIO(b"")
 
     with patch("sunstone.plugins._get_entry_points", return_value=[_make_entry_point("multi", MultiPlugin)]):
         with patch("sunstone.plugins._load_plugin_config", return_value=None):
@@ -646,3 +652,19 @@ def test_read_csv_by_path_uses_registry(tmp_path):
     # This should work via the builtin format handler in the registry
     df = DataFrame.read_csv("inputs/data.csv", project_path=tmp_path)
     assert list(df.data.columns) == ["a", "b"]
+
+
+def test_registry_fetch_convenience(tmp_path):
+    registry = PluginRegistry()
+    registry._url_handlers.append(FakeURLHandler())
+
+    dest = tmp_path / "out.csv"
+    result = registry.fetch("fake://data.csv", dest)
+    assert result == dest
+    assert dest.read_bytes() == b"col1,col2\na,b\n"
+
+
+def test_registry_fetch_no_handler():
+    registry = PluginRegistry()
+    with pytest.raises(ValueError, match="No URL handler found"):
+        registry.fetch("unknown://data.csv", Path("/tmp/out"))

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/87/1ed88eaa1e814841a37e71fee74c2b74341d14b791c0c6038b7ba914bea1/boto3-1.42.83.tar.gz", hash = "sha256:cc5621e603982cb3145b7f6c9970e02e297a1a0eb94637cc7f7b69d3017640ee", size = 112719, upload-time = "2026-04-03T19:34:21.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/8a066bc8f02937d49783c0b3948ab951d8284e6fde436cab9f359dbd4d93/boto3-1.42.83-py3-none-any.whl", hash = "sha256:544846fdb10585bb7837e409868e8e04c6b372fa04479ba1597ce82cf1242076", size = 140555, upload-time = "2026-04-03T19:34:17.935Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/01/b46a3f8b6e9362258f78f1890db1a96d4ed73214d6a36420dc158dcfd221/botocore-1.42.83.tar.gz", hash = "sha256:34bc8cb64b17ac17f8901f073fe4fc9572a5cac9393a37b2b3ea372a83b87f4a", size = 15140337, upload-time = "2026-04-03T19:34:08.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/97/0d6f50822dc8c1df7f3eadb0bc6822fc0f98f02287c4efc7c7c88fde129a/botocore-1.42.83-py3-none-any.whl", hash = "sha256:ec0c3ecb3772936ed22a3bdda09883b34858933f71004686d460d829bab39d8e", size = 14818388, upload-time = "2026-04-03T19:34:03.333Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +618,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1605,6 +1642,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1638,14 +1687,20 @@ source = { editable = "." }
 dependencies = [
     { name = "frictionless" },
     { name = "google-auth" },
-    { name = "google-cloud-storage" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "typer" },
+]
+
+[package.optional-dependencies]
+gcs = [
+    { name = "google-cloud-storage" },
+]
+s3 = [
+    { name = "boto3" },
 ]
 
 [package.dev-dependencies]
@@ -1658,7 +1713,6 @@ dev = [
     { name = "ruff" },
     { name = "tomli-w" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
 ]
 docs = [
     { name = "mike" },
@@ -1667,17 +1721,18 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28" },
     { name = "frictionless", specifier = ">=5.18.1" },
     { name = "google-auth", specifier = ">=2.43.0" },
-    { name = "google-cloud-storage", specifier = ">=2.0.0" },
+    { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.0" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "requests", specifier = ">=2.31.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "typer", specifier = ">=0.15" },
 ]
+provides-extras = ["gcs", "s3"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1689,7 +1744,6 @@ dev = [
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
-    { name = "types-requests", specifier = ">=2.32.4.20250913" },
 ]
 docs = [
     { name = "mike", specifier = ">=2.1.0" },
@@ -1745,18 +1799,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260327"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/5f/2e3dbae6e21be6ae026563bad96cbf76602d73aa85ea09f13419ddbdabb4/types_requests-2.33.0.20260327.tar.gz", hash = "sha256:f4f74f0b44f059e3db420ff17bd1966e3587cdd34062fe38a23cda97868f8dd8", size = 23804, upload-time = "2026-03-27T04:23:38.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/55/951e733616c92cb96b57554746d2f65f4464d080cc2cc093605f897aba89/types_requests-2.33.0.20260327-py3-none-any.whl", hash = "sha256:fde0712be6d7c9a4d490042d6323115baf872d9a71a22900809d0432de15776e", size = 20737, upload-time = "2026-03-27T04:23:37.813Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1137,6 +1137,49 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1598,6 +1641,7 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "ruamel-yaml" },
@@ -1628,6 +1672,7 @@ requires-dist = [
     { name = "google-cloud-storage", specifier = ">=2.0.0" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },


### PR DESCRIPTION
## Summary

- Replace path-based plugin IO with stream-based `URLHandler.open(url, mode) -> BinaryIO | TextIO` mirroring Python's built-in `open()`
- Add `GcsURLHandler` (`gs://`), `S3URLHandler` (`s3://`, `r2://`), and `LocalFileHandler` for uniform data access
- Extract `sunstone.packaging` library from CLI so `package push` works from Python code
- Remove `requests` dependency (replaced by stdlib `urllib.request`)
- Move `google-cloud-storage` to optional `[gcs]` extra, add `[s3]` extra for boto3

## Test plan

- [x] 530 tests pass (48 new) — `uv run pytest tests/ -q`
- [ ] Install with `pip install sunstone-py` (no cloud deps) — verify core read/write works
- [ ] Install with `pip install sunstone-py[gcs]` — verify `gs://` URLs work
- [ ] Install with `pip install sunstone-py[s3]` — verify `s3://` URLs work
- [ ] Verify `sunstone package push` still works with GCS destinations
- [ ] Verify `print(..., file=handler.open(url, "w"))` works for text output to remote URLs