### PR TITLE
feat: CLIProvider protocol and environment config system

### DIFF
--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -47,7 +47,10 @@ from .lineage import (
 )
 
 # Plugin system
-from .plugins import AuthProvider, FormatHandler, PluginRegistry, URLHandler
+from .plugins import AuthProvider, CLIProvider, FormatHandler, PluginRegistry, URLHandler
+
+# Environment config
+from .env import DataEnvironment, resolve_environment
 
 # Packaging (library functions for building and pushing data packages)
 from . import packaging
@@ -111,9 +114,13 @@ __all__ = [
     "DatasetRead",
     # Plugin system
     "AuthProvider",
+    "CLIProvider",
     "URLHandler",
     "FormatHandler",
     "PluginRegistry",
+    # Environment config
+    "DataEnvironment",
+    "resolve_environment",
     # Packaging
     "packaging",
     # Lineage queries

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -503,13 +503,38 @@ def env_update(
     auth: str | None = typer.Option(None, "--auth", help="Auth method"),
 ) -> None:
     """Update fields on an existing environment in user config."""
-    from sunstone.env import _USER_CONFIG, _load_toml, _write_config
+    from sunstone.env import _SYSTEM_CONFIG, _USER_CONFIG, _find_project_config, _load_toml, _write_config
 
     user_data = _load_toml(_USER_CONFIG)
     user_envs = user_data.get("environments", {})
+    project_config = _find_project_config()
+    project_data = _load_toml(project_config) if project_config else {}
+    system_data = _load_toml(_SYSTEM_CONFIG)
 
     if name not in user_envs:
+        if name in project_data.get("environments", {}):
+            typer.echo(
+                f"Error: Environment '{name}' is defined in project config ({project_config}); "
+                "env update only modifies user config",
+                err=True,
+            )
+            raise typer.Exit(1)
+        if name in system_data.get("environments", {}):
+            typer.echo(
+                f"Error: Environment '{name}' is defined in system config ({_SYSTEM_CONFIG}); "
+                "env update only modifies user config",
+                err=True,
+            )
+            raise typer.Exit(1)
         typer.echo(f"Error: Environment '{name}' not found in {_USER_CONFIG}", err=True)
+        raise typer.Exit(1)
+
+    if all(value is None for value in (catalog_url, s3_endpoint, s3_access_key, s3_secret_key, auth)):
+        typer.echo(
+            "Error: No fields to update. Use --catalog-url, --s3-endpoint, --s3-access-key, "
+            "--s3-secret-key, or --auth.",
+            err=True,
+        )
         raise typer.Exit(1)
 
     if catalog_url is not None:

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -411,8 +411,12 @@ def env_show(ctx: typer.Context) -> None:
 
     from sunstone.env import environment_source, list_environments, resolve_environment
 
-    env = resolve_environment()
-    all_envs = list_environments()
+    try:
+        env = resolve_environment()
+        all_envs = list_environments()
+    except (RuntimeError, ValueError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
 
     if not all_envs and env is None:
         typer.echo("No environment configured.")

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -3,6 +3,7 @@ Sunstone command-line interface.
 """
 
 import json
+import logging
 import os
 import re
 import sys
@@ -18,6 +19,8 @@ from ruamel.yaml import YAML
 from .datasets import DatasetsManager
 from .exceptions import DatasetNotFoundError
 from .lineage import Contributor, DatasetMetadata, PackageMetadata, PublishConfig
+
+logger = logging.getLogger(__name__)
 
 # Configure ruamel.yaml for round-trip parsing
 _yaml = YAML()
@@ -364,6 +367,26 @@ lineage_app = typer.Typer(help="Query dataset lineage.")
 app.add_typer(dataset_app, name="dataset")
 app.add_typer(package_app, name="package")
 app.add_typer(lineage_app, name="lineage")
+
+# Mount plugin CLI groups
+_BUILTIN_GROUPS = {"dataset", "package", "lineage", "env"}
+
+
+def _mount_plugin_cli_groups() -> None:
+    try:
+        from sunstone.plugins import PluginRegistry
+
+        registry = PluginRegistry.get()
+        for name, typer_app in registry.get_cli_groups():
+            if name in _BUILTIN_GROUPS:
+                logger.warning("Plugin CLI group '%s' conflicts with built-in group, skipping", name)
+                continue
+            app.add_typer(typer_app, name=name)
+    except Exception:
+        logger.debug("Failed to load plugin CLI groups", exc_info=True)
+
+
+_mount_plugin_cli_groups()
 
 
 @app.callback()

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -414,7 +414,7 @@ def env_show(ctx: typer.Context) -> None:
     try:
         env = resolve_environment()
         all_envs = list_environments()
-    except (RuntimeError, ValueError) as e:
+    except (FileNotFoundError, RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -379,10 +379,15 @@ def _mount_plugin_cli_groups() -> None:
         from sunstone.plugins import PluginRegistry
 
         registry = PluginRegistry.get()
+        seen_names: set[str] = set()
         for name, typer_app in registry.get_cli_groups():
             if name in _BUILTIN_GROUPS:
                 logger.warning("Plugin CLI group '%s' conflicts with built-in group, skipping", name)
                 continue
+            if name in seen_names:
+                logger.warning("Plugin CLI group '%s' already registered by another plugin, skipping", name)
+                continue
+            seen_names.add(name)
             app.add_typer(typer_app, name=name)
     except Exception:
         logger.debug("Failed to load plugin CLI groups", exc_info=True)
@@ -446,7 +451,7 @@ def env_use(
     try:
         path = set_active(name, user=user)
         typer.echo(f"Active environment set to '{name}' in {path}")
-    except (RuntimeError, ValueError) as e:
+    except (OSError, RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -473,7 +478,7 @@ def env_add(
             auth=auth,
         )
         typer.echo(f"Added environment '{name}' to {path}")
-    except (RuntimeError, ValueError) as e:
+    except (OSError, RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -488,7 +493,7 @@ def env_remove(
     try:
         path = remove_environment(name)
         typer.echo(f"Removed environment '{name}' from {path}")
-    except (RuntimeError, ValueError) as e:
+    except (OSError, RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -549,6 +554,8 @@ def env_update(
         )
         raise typer.Exit(1)
 
+    shadowed_by_project = name in project_data.get("environments", {})
+
     if catalog_url is not None:
         user_envs[name]["catalog_url"] = catalog_url
     if s3_endpoint is not None:
@@ -561,8 +568,18 @@ def env_update(
         user_envs[name]["auth"] = auth
 
     user_data["environments"] = user_envs
-    _write_config(user_config, user_data)
+    try:
+        _write_config(user_config, user_data)
+    except OSError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
     typer.echo(f"Updated environment '{name}' in {user_config}")
+    if shadowed_by_project:
+        typer.echo(
+            f"Warning: Environment '{name}' is also defined in project config ({project_config}); "
+            "project config values will shadow this update",
+            err=True,
+        )
 
 
 # =============================================================================

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -414,25 +414,25 @@ def env_show(ctx: typer.Context) -> None:
     try:
         env = resolve_environment()
         all_envs = list_environments()
-    except (FileNotFoundError, RuntimeError, ValueError) as e:
-        typer.echo(f"Error: {e}", err=True)
+        if not all_envs and env is None:
+            typer.echo("No environment configured.")
+            typer.echo("Run 'sunstone env add <name>' to create one.")
+            return
+
+        if env:
+            typer.echo(f"Active: {env.name} (from {env.source})")
+        else:
+            typer.echo("Active: none")
+        typer.echo()
+
+        for name, defn in sorted(all_envs.items()):
+            marker = "* " if env and name == env.name else "  "
+            source = environment_source(name)
+            typer.echo(f"{marker}{name:<12} {defn.get('catalog_url', ''):<45} ({source})")
+    except (FileNotFoundError, KeyError, RuntimeError, ValueError) as e:
+        message = e.args[0] if isinstance(e, KeyError) else str(e)
+        typer.echo(f"Error: {message}", err=True)
         raise typer.Exit(1)
-
-    if not all_envs and env is None:
-        typer.echo("No environment configured.")
-        typer.echo("Run 'sunstone env add <name>' to create one.")
-        return
-
-    if env:
-        typer.echo(f"Active: {env.name} (from {env.source})")
-    else:
-        typer.echo("Active: none")
-    typer.echo()
-
-    for name, defn in sorted(all_envs.items()):
-        marker = "* " if env and name == env.name else "  "
-        source = environment_source(name)
-        typer.echo(f"{marker}{name:<12} {defn.get('catalog_url', ''):<45} ({source})")
 
 
 @env_app.command("use")
@@ -446,7 +446,7 @@ def env_use(
     try:
         path = set_active(name, user=user)
         typer.echo(f"Active environment set to '{name}' in {path}")
-    except ValueError as e:
+    except (RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -473,7 +473,7 @@ def env_add(
             auth=auth,
         )
         typer.echo(f"Added environment '{name}' to {path}")
-    except ValueError as e:
+    except (RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -488,7 +488,7 @@ def env_remove(
     try:
         path = remove_environment(name)
         typer.echo(f"Removed environment '{name}' from {path}")
-    except ValueError as e:
+    except (RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
@@ -503,9 +503,21 @@ def env_update(
     auth: str | None = typer.Option(None, "--auth", help="Auth method"),
 ) -> None:
     """Update fields on an existing environment in user config."""
-    from sunstone.env import _SYSTEM_CONFIG, _USER_CONFIG, _find_project_config, _load_toml, _write_config
+    from sunstone.env import (
+        _SYSTEM_CONFIG,
+        _find_project_config,
+        _get_user_config_path,
+        _load_toml,
+        _write_config,
+    )
 
-    user_data = _load_toml(_USER_CONFIG)
+    try:
+        user_config = _get_user_config_path(required=True)
+    except RuntimeError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+    user_data = _load_toml(user_config)
     user_envs = user_data.get("environments", {})
     project_config = _find_project_config()
     project_data = _load_toml(project_config) if project_config else {}
@@ -526,7 +538,7 @@ def env_update(
                 err=True,
             )
             raise typer.Exit(1)
-        typer.echo(f"Error: Environment '{name}' not found in {_USER_CONFIG}", err=True)
+        typer.echo(f"Error: Environment '{name}' not found in {user_config}", err=True)
         raise typer.Exit(1)
 
     if all(value is None for value in (catalog_url, s3_endpoint, s3_access_key, s3_secret_key, auth)):
@@ -549,8 +561,8 @@ def env_update(
         user_envs[name]["auth"] = auth
 
     user_data["environments"] = user_envs
-    _write_config(_USER_CONFIG, user_data)
-    typer.echo(f"Updated environment '{name}' in {_USER_CONFIG}")
+    _write_config(user_config, user_data)
+    typer.echo(f"Updated environment '{name}' in {user_config}")
 
 
 # =============================================================================

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -363,10 +363,12 @@ app = typer.Typer(help="Sunstone dataset and package management CLI.")
 dataset_app = typer.Typer(help="Manage datasets in datasets.yaml.")
 package_app = typer.Typer(help="Manage data packages.")
 lineage_app = typer.Typer(help="Query dataset lineage.")
+env_app = typer.Typer(help="Manage data platform environments.")
 
 app.add_typer(dataset_app, name="dataset")
 app.add_typer(package_app, name="package")
 app.add_typer(lineage_app, name="lineage")
+app.add_typer(env_app, name="env")
 
 # Mount plugin CLI groups
 _BUILTIN_GROUPS = {"dataset", "package", "lineage", "env"}
@@ -394,6 +396,132 @@ def main(
     version: bool = typer.Option(False, "--version", callback=_version_callback, is_eager=True, help="Show version"),
 ) -> None:
     """Sunstone dataset and package management CLI."""
+
+
+# =============================================================================
+# Environment commands
+# =============================================================================
+
+
+@env_app.callback(invoke_without_command=True)
+def env_show(ctx: typer.Context) -> None:
+    """Show active environment and all available environments."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    from sunstone.env import environment_source, list_environments, resolve_environment
+
+    env = resolve_environment()
+    all_envs = list_environments()
+
+    if not all_envs and env is None:
+        typer.echo("No environment configured.")
+        typer.echo("Run 'sunstone env add <name>' to create one.")
+        return
+
+    if env:
+        typer.echo(f"Active: {env.name} (from {env.source})")
+    else:
+        typer.echo("Active: none")
+    typer.echo()
+
+    for name, defn in sorted(all_envs.items()):
+        marker = "* " if env and name == env.name else "  "
+        source = environment_source(name)
+        typer.echo(f"{marker}{name:<12} {defn.get('catalog_url', ''):<45} ({source})")
+
+
+@env_app.command("use")
+def env_use(
+    name: str = typer.Argument(..., help="Environment name to activate"),
+    user: bool = typer.Option(False, "--user", help="Set in user config instead of project"),
+) -> None:
+    """Switch active environment."""
+    from sunstone.env import set_active
+
+    try:
+        path = set_active(name, user=user)
+        typer.echo(f"Active environment set to '{name}' in {path}")
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@env_app.command("add")
+def env_add(
+    name: str = typer.Argument(..., help="Environment name"),
+    catalog_url: str = typer.Option(..., "--catalog-url", help="Nessie catalog URL"),
+    s3_endpoint: str = typer.Option(..., "--s3-endpoint", help="S3/MinIO endpoint URL"),
+    s3_access_key: str | None = typer.Option(None, "--s3-access-key", help="S3 access key or op:// reference"),
+    s3_secret_key: str | None = typer.Option(None, "--s3-secret-key", help="S3 secret key or op:// reference"),
+    auth: str | None = typer.Option(None, "--auth", help="Auth method (e.g. gcloud-adc)"),
+) -> None:
+    """Add a new environment to user config."""
+    from sunstone.env import add_environment
+
+    try:
+        path = add_environment(
+            name,
+            catalog_url=catalog_url,
+            s3_endpoint=s3_endpoint,
+            s3_access_key=s3_access_key,
+            s3_secret_key=s3_secret_key,
+            auth=auth,
+        )
+        typer.echo(f"Added environment '{name}' to {path}")
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@env_app.command("remove")
+def env_remove(
+    name: str = typer.Argument(..., help="Environment name to remove"),
+) -> None:
+    """Remove an environment from user config."""
+    from sunstone.env import remove_environment
+
+    try:
+        path = remove_environment(name)
+        typer.echo(f"Removed environment '{name}' from {path}")
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@env_app.command("update")
+def env_update(
+    name: str = typer.Argument(..., help="Environment name to update"),
+    catalog_url: str | None = typer.Option(None, "--catalog-url", help="Nessie catalog URL"),
+    s3_endpoint: str | None = typer.Option(None, "--s3-endpoint", help="S3/MinIO endpoint URL"),
+    s3_access_key: str | None = typer.Option(None, "--s3-access-key", help="S3 access key or op:// reference"),
+    s3_secret_key: str | None = typer.Option(None, "--s3-secret-key", help="S3 secret key or op:// reference"),
+    auth: str | None = typer.Option(None, "--auth", help="Auth method"),
+) -> None:
+    """Update fields on an existing environment in user config."""
+    from sunstone.env import _USER_CONFIG, _load_toml, _write_config
+
+    user_data = _load_toml(_USER_CONFIG)
+    user_envs = user_data.get("environments", {})
+
+    if name not in user_envs:
+        typer.echo(f"Error: Environment '{name}' not found in {_USER_CONFIG}", err=True)
+        raise typer.Exit(1)
+
+    if catalog_url is not None:
+        user_envs[name]["catalog_url"] = catalog_url
+    if s3_endpoint is not None:
+        user_envs[name]["s3_endpoint"] = s3_endpoint
+    if s3_access_key is not None:
+        user_envs[name]["s3_access_key"] = s3_access_key
+    if s3_secret_key is not None:
+        user_envs[name]["s3_secret_key"] = s3_secret_key
+    if auth is not None:
+        user_envs[name]["auth"] = auth
+
+    user_data["environments"] = user_envs
+    _write_config(_USER_CONFIG, user_data)
+    typer.echo(f"Updated environment '{name}' in {_USER_CONFIG}")
 
 
 # =============================================================================

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -18,12 +18,49 @@ import subprocess
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, overload
 
 import tomli_w
 
 _SYSTEM_CONFIG = Path("/etc/sunstone/data_platform.toml")
-_USER_CONFIG = Path.home() / ".config" / "sunstone" / "data_platform.toml"
 _PROJECT_CONFIG_NAME = ".sunstone/data_platform.toml"
+
+
+def _default_user_config() -> Path | None:
+    """Return the default user config path, or None when home is unavailable."""
+    try:
+        return Path.home() / ".config" / "sunstone" / "data_platform.toml"
+    except RuntimeError:
+        return None
+
+
+_USER_CONFIG = _default_user_config()
+
+
+@overload
+def _get_user_config_path(user_config: Path, *, required: bool = False) -> Path: ...
+
+
+@overload
+def _get_user_config_path(user_config: None = None, *, required: Literal[True]) -> Path: ...
+
+
+@overload
+def _get_user_config_path(user_config: None = None, *, required: Literal[False] = False) -> Path | None: ...
+
+
+def _get_user_config_path(user_config: Path | None = None, *, required: bool = False) -> Path | None:
+    """Resolve the user config path, optionally requiring that it is available."""
+    if user_config is not None:
+        return user_config
+    if _USER_CONFIG is not None:
+        return _USER_CONFIG
+    if required:
+        raise RuntimeError(
+            "User config path is unavailable because the home directory could not be determined. "
+            "Set HOME or pass an explicit user_config path."
+        )
+    return None
 
 
 @dataclass(frozen=True)
@@ -163,11 +200,11 @@ def resolve_environment(
         ValueError: If the active environment name doesn't match any defined environment.
     """
     sys_path = system_config or _SYSTEM_CONFIG
-    usr_path = user_config or _USER_CONFIG
+    usr_path = _get_user_config_path(user_config)
     prj_path = project_config or _find_project_config()
 
     system_data = _load_toml(sys_path)
-    user_data = _load_toml(usr_path)
+    user_data = _load_toml(usr_path) if usr_path else {}
     project_data = _load_toml(prj_path) if prj_path else {}
 
     active_name, source_label = _resolve_active_name(project_data, user_data, system_data)
@@ -222,11 +259,6 @@ def resolve_environment(
     )
 
 
-def _get_project_config_dir() -> Path:
-    """Return the project config directory (cwd / .sunstone)."""
-    return Path.cwd() / ".sunstone"
-
-
 def list_environments(
     *,
     system_config: Path | None = None,
@@ -244,11 +276,11 @@ def list_environments(
         Dict mapping environment names to their config dicts.
     """
     sys_path = system_config or _SYSTEM_CONFIG
-    usr_path = user_config or _USER_CONFIG
+    usr_path = _get_user_config_path(user_config)
     prj_path = project_config or _find_project_config()
 
     system_data = _load_toml(sys_path)
-    user_data = _load_toml(usr_path)
+    user_data = _load_toml(usr_path) if usr_path else {}
     project_data = _load_toml(prj_path) if prj_path else {}
 
     merged = _merge_environments(system_data, user_data)
@@ -278,7 +310,7 @@ def environment_source(
         KeyError: If the environment is not found in any config.
     """
     sys_path = system_config or _SYSTEM_CONFIG
-    usr_path = user_config or _USER_CONFIG
+    usr_path = _get_user_config_path(user_config)
     prj_path = project_config or _find_project_config()
 
     if prj_path:
@@ -286,9 +318,10 @@ def environment_source(
         if name in project_data.get("environments", {}):
             return str(prj_path)
 
-    user_data = _load_toml(usr_path)
-    if name in user_data.get("environments", {}):
-        return str(usr_path)
+    if usr_path:
+        user_data = _load_toml(usr_path)
+        if name in user_data.get("environments", {}):
+            return str(usr_path)
 
     system_data = _load_toml(sys_path)
     if name in system_data.get("environments", {}):
@@ -319,7 +352,11 @@ def set_active(
         ValueError: If the environment doesn't exist.
     """
     sys_path = system_config or _SYSTEM_CONFIG
-    usr_path = user_config or _USER_CONFIG
+    usr_path: Path | None
+    if user:
+        usr_path = _get_user_config_path(user_config, required=True)
+    else:
+        usr_path = _get_user_config_path(user_config)
     prj_path = _find_project_config()
 
     all_envs = list_environments(system_config=sys_path, user_config=usr_path, project_config=prj_path)
@@ -327,6 +364,7 @@ def set_active(
         raise ValueError(f"Environment '{name}' does not exist")
 
     if user:
+        assert usr_path is not None
         target = usr_path
     else:
         target = prj_path or (Path.cwd() / _PROJECT_CONFIG_NAME)
@@ -364,7 +402,7 @@ def add_environment(
     Raises:
         ValueError: If the environment already exists.
     """
-    usr_path = user_config or _USER_CONFIG
+    usr_path = _get_user_config_path(user_config, required=True)
     data = _load_toml(usr_path)
 
     if "environments" not in data:
@@ -410,7 +448,7 @@ def remove_environment(
     Raises:
         ValueError: If the environment is only in system config or doesn't exist.
     """
-    usr_path = user_config or _USER_CONFIG
+    usr_path = _get_user_config_path(user_config, required=True)
     sys_path = system_config or _SYSTEM_CONFIG
     prj_path = project_config or _find_project_config()
 
@@ -424,6 +462,12 @@ def remove_environment(
             raise ValueError(
                 f"Environment '{name}' is defined in system config ({sys_path}), cannot remove from user config"
             )
+        if prj_path:
+            project_data = _load_toml(prj_path)
+            if name in project_data.get("environments", {}):
+                raise ValueError(
+                    f"Environment '{name}' is defined in project config ({prj_path}), cannot remove from user config"
+                )
         raise ValueError(f"Environment '{name}' not found in user config")
 
     del user_data["environments"][name]

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -128,7 +128,7 @@ def _resolve_op_reference(ref: str) -> str:
         )
     except FileNotFoundError:
         raise FileNotFoundError(
-            "1Password CLI (op) is not installed. " "Install it from https://1password.com/downloads/command-line/"
+            "1Password CLI (op) is not installed. Install it from https://1password.com/downloads/command-line/"
         )
 
     if result.returncode != 0:
@@ -402,7 +402,7 @@ def remove_environment(
         system_envs = system_data.get("environments", {})
         if name in system_envs:
             raise ValueError(
-                f"Environment '{name}' is defined in system config ({sys_path}), " "cannot remove from user config"
+                f"Environment '{name}' is defined in system config ({sys_path}), cannot remove from user config"
             )
         raise ValueError(f"Environment '{name}' not found in user config")
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -86,11 +86,21 @@ def _load_toml(path: Path) -> dict:
         return {}
 
 
-def _merge_environments(system: dict, user: dict) -> dict:
-    """Merge environment definitions; user shadows system by name."""
-    merged = {}
-    merged.update(system.get("environments", {}))
-    merged.update(user.get("environments", {}))
+def _merge_environments(*configs: dict) -> dict:
+    """Merge environment definitions with field-level precedence.
+
+    Later configs take precedence at the field level within each
+    environment.  For example, if system defines ``catalog_url`` and
+    ``s3_endpoint`` for *dev* and user only overrides ``catalog_url``,
+    the merged result keeps the system ``s3_endpoint``.
+    """
+    merged: dict[str, dict] = {}
+    for config in configs:
+        for name, env_def in config.get("environments", {}).items():
+            if name in merged:
+                merged[name] = {**merged[name], **env_def}
+            else:
+                merged[name] = dict(env_def)
     return merged
 
 
@@ -213,9 +223,7 @@ def resolve_environment(
     if active_name is None:
         return None
 
-    all_envs = _merge_environments(system_data, user_data)
-    # Also merge project environments
-    all_envs.update(project_data.get("environments", {}))
+    all_envs = _merge_environments(system_data, user_data, project_data)
 
     if active_name not in all_envs:
         raise ValueError(f"Active environment '{active_name}' is not defined in any config file")
@@ -284,9 +292,7 @@ def list_environments(
     user_data = _load_toml(usr_path) if usr_path else {}
     project_data = _load_toml(prj_path) if prj_path else {}
 
-    merged = _merge_environments(system_data, user_data)
-    merged.update(project_data.get("environments", {}))
-    return merged
+    return _merge_environments(system_data, user_data, project_data)
 
 
 def environment_source(

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -487,5 +488,15 @@ def remove_environment(
 def _write_config(path: Path, data: dict) -> None:
     """Write a config dict as TOML, creating parent directories as needed."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "wb") as f:
-        tomli_w.dump(data, f)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            tomli_w.dump(data, f)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -200,8 +200,8 @@ def resolve_environment(
     auth = env_def.get("auth")
 
     # Apply env var field overrides (highest precedence)
-    catalog_url = os.environ.get("SUNSTONE_DATA_CATALOG_URL", catalog_url)
-    s3_endpoint = os.environ.get("SUNSTONE_DATA_S3_ENDPOINT", s3_endpoint)
+    catalog_url = os.environ.get("SUNSTONE_DATA_CATALOG_URL") or catalog_url
+    s3_endpoint = os.environ.get("SUNSTONE_DATA_S3_ENDPOINT") or s3_endpoint
     s3_access_key = os.environ.get("SUNSTONE_DATA_S3_ACCESS_KEY", s3_access_key)
     s3_secret_key = os.environ.get("SUNSTONE_DATA_S3_SECRET_KEY", s3_secret_key)
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -229,23 +229,29 @@ def list_environments(
     *,
     system_config: Path | None = None,
     user_config: Path | None = None,
+    project_config: Path | None = None,
 ) -> dict[str, dict]:
     """Return all merged environment definitions.
 
     Args:
         system_config: Override path for system config.
         user_config: Override path for user config.
+        project_config: Override path for project config (default: auto-discovered).
 
     Returns:
         Dict mapping environment names to their config dicts.
     """
     sys_path = system_config or _SYSTEM_CONFIG
     usr_path = user_config or _USER_CONFIG
+    prj_path = project_config or _find_project_config()
 
     system_data = _load_toml(sys_path)
     user_data = _load_toml(usr_path)
+    project_data = _load_toml(prj_path) if prj_path else {}
 
-    return _merge_environments(system_data, user_data)
+    merged = _merge_environments(system_data, user_data)
+    merged.update(project_data.get("environments", {}))
+    return merged
 
 
 def environment_source(
@@ -253,6 +259,7 @@ def environment_source(
     *,
     system_config: Path | None = None,
     user_config: Path | None = None,
+    project_config: Path | None = None,
 ) -> str:
     """Return which config file defines an environment.
 
@@ -260,6 +267,7 @@ def environment_source(
         name: Environment name to look up.
         system_config: Override path for system config.
         user_config: Override path for user config.
+        project_config: Override path for project config (default: auto-discovered).
 
     Returns:
         The file path string where the environment is defined.
@@ -269,6 +277,12 @@ def environment_source(
     """
     sys_path = system_config or _SYSTEM_CONFIG
     usr_path = user_config or _USER_CONFIG
+    prj_path = project_config or _find_project_config()
+
+    if prj_path:
+        project_data = _load_toml(prj_path)
+        if name in project_data.get("environments", {}):
+            return str(prj_path)
 
     user_data = _load_toml(usr_path)
     if name in user_data.get("environments", {}):
@@ -407,6 +421,8 @@ def remove_environment(
         raise ValueError(f"Environment '{name}' not found in user config")
 
     del user_data["environments"][name]
+    if user_data.get("active") == name:
+        del user_data["active"]
     _write_config(usr_path, user_data)
     return usr_path
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -202,8 +202,8 @@ def resolve_environment(
     # Apply env var field overrides (highest precedence)
     catalog_url = os.environ.get("SUNSTONE_DATA_CATALOG_URL") or catalog_url
     s3_endpoint = os.environ.get("SUNSTONE_DATA_S3_ENDPOINT") or s3_endpoint
-    s3_access_key = os.environ.get("SUNSTONE_DATA_S3_ACCESS_KEY", s3_access_key)
-    s3_secret_key = os.environ.get("SUNSTONE_DATA_S3_SECRET_KEY", s3_secret_key)
+    s3_access_key = os.environ.get("SUNSTONE_DATA_S3_ACCESS_KEY") or s3_access_key
+    s3_secret_key = os.environ.get("SUNSTONE_DATA_S3_SECRET_KEY") or s3_secret_key
 
     # Resolve credentials
     s3_access_key = _resolve_credential(s3_access_key)

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -1,0 +1,418 @@
+"""Environment configuration for the Sunstone data platform.
+
+Resolves data platform environment settings from cascading TOML config
+files and environment variables.
+
+Config file precedence (highest wins):
+    1. Individual env vars (SUNSTONE_DATA_CATALOG_URL, etc.)
+    2. SUNSTONE_DATA_ENV env var (selects active environment name)
+    3. .sunstone/data_platform.toml (project config, walked up from cwd)
+    4. ~/.config/sunstone/data_platform.toml (user config)
+    5. /etc/sunstone/data_platform.toml (system config)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+import tomli_w
+
+_SYSTEM_CONFIG = Path("/etc/sunstone/data_platform.toml")
+_USER_CONFIG = Path.home() / ".config" / "sunstone" / "data_platform.toml"
+_PROJECT_CONFIG_NAME = ".sunstone/data_platform.toml"
+
+
+@dataclass(frozen=True)
+class DataEnvironment:
+    """Resolved data platform environment configuration."""
+
+    name: str
+    catalog_url: str
+    s3_endpoint: str
+    s3_access_key: str | None
+    s3_secret_key: str | None
+    auth: str | None
+    source: str
+
+
+def _load_toml(path: Path) -> dict:
+    """Load a TOML file, returning an empty dict if missing or invalid."""
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except (FileNotFoundError, tomllib.TOMLDecodeError, OSError):
+        return {}
+
+
+def _merge_environments(system: dict, user: dict) -> dict:
+    """Merge environment definitions; user shadows system by name."""
+    merged = {}
+    merged.update(system.get("environments", {}))
+    merged.update(user.get("environments", {}))
+    return merged
+
+
+def _resolve_active_name(project: dict, user: dict, system: dict) -> tuple[str | None, str | None]:
+    """Determine active environment name and its source.
+
+    Precedence: SUNSTONE_DATA_ENV env var > project > user > system.
+
+    Returns:
+        Tuple of (name, source_label). Both are None when nothing is set.
+    """
+    env_var = os.environ.get("SUNSTONE_DATA_ENV")
+    if env_var:
+        return env_var, "SUNSTONE_DATA_ENV"
+
+    if project.get("active"):
+        return project["active"], "project"
+
+    if user.get("active"):
+        return user["active"], "user"
+
+    if system.get("active"):
+        return system["active"], "system"
+
+    return None, None
+
+
+def _find_project_config(start: Path | None = None) -> Path | None:
+    """Walk up from start (or cwd) looking for .sunstone/data_platform.toml."""
+    current = start or Path.cwd()
+    current = current.resolve()
+
+    while True:
+        candidate = current / _PROJECT_CONFIG_NAME
+        if candidate.is_file():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    return None
+
+
+def _resolve_credential(value: str | None) -> str | None:
+    """Resolve a credential value.
+
+    Returns None for None/empty, calls _resolve_op_reference for op://
+    references, and returns the literal value otherwise.
+    """
+    if not value:
+        return None
+    if value.startswith("op://"):
+        return _resolve_op_reference(value)
+    return value
+
+
+def _resolve_op_reference(ref: str) -> str:
+    """Resolve a 1Password CLI reference.
+
+    Runs ``op read <ref>`` and returns the result.
+
+    Raises:
+        FileNotFoundError: If the ``op`` CLI is not installed.
+        RuntimeError: If the ``op`` command fails.
+    """
+    try:
+        result = subprocess.run(
+            ["op", "read", ref],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            "1Password CLI (op) is not installed. " "Install it from https://1password.com/downloads/command-line/"
+        )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to resolve 1Password reference {ref}: {result.stderr.strip()}")
+
+    return result.stdout.strip()
+
+
+def resolve_environment(
+    *,
+    system_config: Path | None = None,
+    user_config: Path | None = None,
+    project_config: Path | None = None,
+) -> DataEnvironment | None:
+    """Resolve the active data platform environment.
+
+    Loads all config files, merges environments, resolves the active
+    environment name, applies env var field overrides, resolves credentials,
+    and returns a DataEnvironment.
+
+    Args:
+        system_config: Override path for system config (default: /etc/sunstone/data_platform.toml).
+        user_config: Override path for user config (default: ~/.config/sunstone/data_platform.toml).
+        project_config: Override path for project config (default: auto-discovered).
+
+    Returns:
+        A DataEnvironment if an active environment is configured, or None.
+
+    Raises:
+        ValueError: If the active environment name doesn't match any defined environment.
+    """
+    sys_path = system_config or _SYSTEM_CONFIG
+    usr_path = user_config or _USER_CONFIG
+    prj_path = project_config or _find_project_config()
+
+    system_data = _load_toml(sys_path)
+    user_data = _load_toml(usr_path)
+    project_data = _load_toml(prj_path) if prj_path else {}
+
+    active_name, source_label = _resolve_active_name(project_data, user_data, system_data)
+
+    if active_name is None:
+        return None
+
+    all_envs = _merge_environments(system_data, user_data)
+    # Also merge project environments
+    all_envs.update(project_data.get("environments", {}))
+
+    if active_name not in all_envs:
+        raise ValueError(f"Active environment '{active_name}' is not defined in any config file")
+
+    env_def = all_envs[active_name]
+
+    # Determine source file path
+    if source_label == "SUNSTONE_DATA_ENV":
+        source = "SUNSTONE_DATA_ENV"
+    elif source_label == "project" and prj_path:
+        source = str(prj_path)
+    elif source_label == "user":
+        source = str(usr_path)
+    else:
+        source = str(sys_path)
+
+    # Start with values from config
+    catalog_url = env_def.get("catalog_url", "")
+    s3_endpoint = env_def.get("s3_endpoint", "")
+    s3_access_key = env_def.get("s3_access_key")
+    s3_secret_key = env_def.get("s3_secret_key")
+    auth = env_def.get("auth")
+
+    # Apply env var field overrides (highest precedence)
+    catalog_url = os.environ.get("SUNSTONE_DATA_CATALOG_URL", catalog_url)
+    s3_endpoint = os.environ.get("SUNSTONE_DATA_S3_ENDPOINT", s3_endpoint)
+    s3_access_key = os.environ.get("SUNSTONE_DATA_S3_ACCESS_KEY", s3_access_key)
+    s3_secret_key = os.environ.get("SUNSTONE_DATA_S3_SECRET_KEY", s3_secret_key)
+
+    # Resolve credentials
+    s3_access_key = _resolve_credential(s3_access_key)
+    s3_secret_key = _resolve_credential(s3_secret_key)
+
+    return DataEnvironment(
+        name=active_name,
+        catalog_url=catalog_url,
+        s3_endpoint=s3_endpoint,
+        s3_access_key=s3_access_key,
+        s3_secret_key=s3_secret_key,
+        auth=auth,
+        source=source,
+    )
+
+
+def _get_project_config_dir() -> Path:
+    """Return the project config directory (cwd / .sunstone)."""
+    return Path.cwd() / ".sunstone"
+
+
+def list_environments(
+    *,
+    system_config: Path | None = None,
+    user_config: Path | None = None,
+) -> dict[str, dict]:
+    """Return all merged environment definitions.
+
+    Args:
+        system_config: Override path for system config.
+        user_config: Override path for user config.
+
+    Returns:
+        Dict mapping environment names to their config dicts.
+    """
+    sys_path = system_config or _SYSTEM_CONFIG
+    usr_path = user_config or _USER_CONFIG
+
+    system_data = _load_toml(sys_path)
+    user_data = _load_toml(usr_path)
+
+    return _merge_environments(system_data, user_data)
+
+
+def environment_source(
+    name: str,
+    *,
+    system_config: Path | None = None,
+    user_config: Path | None = None,
+) -> str:
+    """Return which config file defines an environment.
+
+    Args:
+        name: Environment name to look up.
+        system_config: Override path for system config.
+        user_config: Override path for user config.
+
+    Returns:
+        The file path string where the environment is defined.
+
+    Raises:
+        KeyError: If the environment is not found in any config.
+    """
+    sys_path = system_config or _SYSTEM_CONFIG
+    usr_path = user_config or _USER_CONFIG
+
+    user_data = _load_toml(usr_path)
+    if name in user_data.get("environments", {}):
+        return str(usr_path)
+
+    system_data = _load_toml(sys_path)
+    if name in system_data.get("environments", {}):
+        return str(sys_path)
+
+    raise KeyError(f"Environment '{name}' not found in any config file")
+
+
+def set_active(
+    name: str,
+    *,
+    user: bool = False,
+    system_config: Path | None = None,
+    user_config: Path | None = None,
+) -> Path:
+    """Set the active environment in project or user config.
+
+    Args:
+        name: Environment name to activate.
+        user: If True, write to user config instead of project config.
+        system_config: Override path for system config.
+        user_config: Override path for user config.
+
+    Returns:
+        Path to the config file that was written.
+
+    Raises:
+        ValueError: If the environment doesn't exist.
+    """
+    sys_path = system_config or _SYSTEM_CONFIG
+    usr_path = user_config or _USER_CONFIG
+
+    all_envs = list_environments(system_config=sys_path, user_config=usr_path)
+    if name not in all_envs:
+        raise ValueError(f"Environment '{name}' does not exist")
+
+    if user:
+        target = usr_path
+    else:
+        target = Path.cwd() / _PROJECT_CONFIG_NAME
+
+    data = _load_toml(target)
+    data["active"] = name
+    _write_config(target, data)
+    return target
+
+
+def add_environment(
+    name: str,
+    *,
+    catalog_url: str,
+    s3_endpoint: str,
+    s3_access_key: str | None = None,
+    s3_secret_key: str | None = None,
+    auth: str | None = None,
+    user_config: Path | None = None,
+) -> Path:
+    """Add an environment to user config.
+
+    Args:
+        name: Environment name.
+        catalog_url: Nessie catalog URL.
+        s3_endpoint: S3-compatible endpoint URL.
+        s3_access_key: S3 access key or op:// reference.
+        s3_secret_key: S3 secret key or op:// reference.
+        auth: Authentication method (e.g. "gcloud-adc").
+        user_config: Override path for user config.
+
+    Returns:
+        Path to the config file that was written.
+
+    Raises:
+        ValueError: If the environment already exists.
+    """
+    usr_path = user_config or _USER_CONFIG
+    data = _load_toml(usr_path)
+
+    if "environments" not in data:
+        data["environments"] = {}
+
+    if name in data.get("environments", {}):
+        raise ValueError(f"Environment '{name}' already exists in {usr_path}")
+
+    env_def: dict[str, str] = {
+        "catalog_url": catalog_url,
+        "s3_endpoint": s3_endpoint,
+    }
+    if s3_access_key is not None:
+        env_def["s3_access_key"] = s3_access_key
+    if s3_secret_key is not None:
+        env_def["s3_secret_key"] = s3_secret_key
+    if auth is not None:
+        env_def["auth"] = auth
+
+    data["environments"][name] = env_def
+    _write_config(usr_path, data)
+    return usr_path
+
+
+def remove_environment(
+    name: str,
+    *,
+    user_config: Path | None = None,
+    system_config: Path | None = None,
+) -> Path:
+    """Remove an environment from user config.
+
+    Args:
+        name: Environment name to remove.
+        user_config: Override path for user config.
+        system_config: Override path for system config.
+
+    Returns:
+        Path to the config file that was modified.
+
+    Raises:
+        ValueError: If the environment is only in system config or doesn't exist.
+    """
+    usr_path = user_config or _USER_CONFIG
+    sys_path = system_config or _SYSTEM_CONFIG
+
+    user_data = _load_toml(usr_path)
+    user_envs = user_data.get("environments", {})
+
+    if name not in user_envs:
+        system_data = _load_toml(sys_path)
+        system_envs = system_data.get("environments", {})
+        if name in system_envs:
+            raise ValueError(
+                f"Environment '{name}' is defined in system config ({sys_path}), " "cannot remove from user config"
+            )
+        raise ValueError(f"Environment '{name}' not found in user config")
+
+    del user_data["environments"][name]
+    _write_config(usr_path, user_data)
+    return usr_path
+
+
+def _write_config(path: Path, data: dict) -> None:
+    """Write a config dict as TOML, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        tomli_w.dump(data, f)

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -394,6 +394,7 @@ def remove_environment(
     *,
     user_config: Path | None = None,
     system_config: Path | None = None,
+    project_config: Path | None = None,
 ) -> Path:
     """Remove an environment from user config.
 
@@ -401,6 +402,7 @@ def remove_environment(
         name: Environment name to remove.
         user_config: Override path for user config.
         system_config: Override path for system config.
+        project_config: Override path for project config (default: auto-discovered).
 
     Returns:
         Path to the config file that was modified.
@@ -410,6 +412,7 @@ def remove_environment(
     """
     usr_path = user_config or _USER_CONFIG
     sys_path = system_config or _SYSTEM_CONFIG
+    prj_path = project_config or _find_project_config()
 
     user_data = _load_toml(usr_path)
     user_envs = user_data.get("environments", {})
@@ -427,6 +430,13 @@ def remove_environment(
     if user_data.get("active") == name:
         del user_data["active"]
     _write_config(usr_path, user_data)
+
+    if prj_path:
+        project_data = _load_toml(prj_path)
+        if project_data.get("active") == name:
+            del project_data["active"]
+            _write_config(prj_path, project_data)
+
     return usr_path
 
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -117,7 +117,7 @@ def _resolve_op_reference(ref: str) -> str:
 
     Raises:
         FileNotFoundError: If the ``op`` CLI is not installed.
-        RuntimeError: If the ``op`` command fails.
+        RuntimeError: If the ``op`` command fails or times out.
     """
     try:
         result = subprocess.run(
@@ -126,10 +126,12 @@ def _resolve_op_reference(ref: str) -> str:
             text=True,
             timeout=10,
         )
-    except FileNotFoundError:
+    except FileNotFoundError as e:
         raise FileNotFoundError(
             "1Password CLI (op) is not installed. Install it from https://1password.com/downloads/command-line/"
-        )
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"1Password CLI timed out after 10s while resolving {ref}") from e
 
     if result.returncode != 0:
         raise RuntimeError(f"Failed to resolve 1Password reference {ref}: {result.stderr.strip()}")
@@ -318,15 +320,16 @@ def set_active(
     """
     sys_path = system_config or _SYSTEM_CONFIG
     usr_path = user_config or _USER_CONFIG
+    prj_path = _find_project_config()
 
-    all_envs = list_environments(system_config=sys_path, user_config=usr_path)
+    all_envs = list_environments(system_config=sys_path, user_config=usr_path, project_config=prj_path)
     if name not in all_envs:
         raise ValueError(f"Environment '{name}' does not exist")
 
     if user:
         target = usr_path
     else:
-        target = Path.cwd() / _PROJECT_CONFIG_NAME
+        target = prj_path or (Path.cwd() / _PROJECT_CONFIG_NAME)
 
     data = _load_toml(target)
     data["active"] = name

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -233,7 +233,10 @@ class PluginRegistry:
         """Return all (name, typer_app) tuples from registered CLIProviders."""
         groups: list[tuple[str, typer.Typer]] = []
         for provider in self._cli_providers:
-            groups.extend(provider.cli_groups())
+            try:
+                groups.extend(provider.cli_groups())
+            except Exception:
+                logger.exception("Failed to get CLI groups from provider %r", provider)
         return groups
 
     def find_url_handler(self, url: str) -> URLHandler | None:

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import BinaryIO, Literal, Protocol, TextIO, overload, runtime_checkable
 
 import pandas as pd
+import typer
 from ruamel.yaml import YAML
 
 from .lineage import DatasetMetadata
@@ -67,6 +68,15 @@ class FormatHandler(Protocol):
 
     def write(self, df: pd.DataFrame, stream: BinaryIO, **kwargs: object) -> None:
         """Write DataFrame to stream."""
+        ...
+
+
+@runtime_checkable
+class CLIProvider(Protocol):
+    """Provides CLI subcommand groups to mount on the main sunstone CLI."""
+
+    def cli_groups(self) -> list[tuple[str, typer.Typer]]:
+        """Return (name, typer_app) tuples to mount as CLI subcommand groups."""
         ...
 
 
@@ -135,6 +145,7 @@ class PluginRegistry:
 
         self._url_handlers: list[URLHandler] = [LocalFileHandler()]
         self._format_handlers: list[FormatHandler] = []
+        self._cli_providers: list[CLIProvider] = []
 
     @classmethod
     def get(cls, project_path: Path | str | None = None) -> PluginRegistry:
@@ -200,6 +211,9 @@ class PluginRegistry:
         if isinstance(plugin, FormatHandler):
             self._format_handlers.append(plugin)
             registered = True
+        if isinstance(plugin, CLIProvider):
+            self._cli_providers.append(plugin)
+            registered = True
         if not registered:
             logger.warning("Plugin '%s' does not implement any known plugin protocol", name)
 
@@ -214,6 +228,13 @@ class PluginRegistry:
     def get_format_handlers(self) -> list[FormatHandler]:
         """Return all registered format handlers."""
         return self._format_handlers
+
+    def get_cli_groups(self) -> list[tuple[str, typer.Typer]]:
+        """Return all (name, typer_app) tuples from registered CLIProviders."""
+        groups: list[tuple[str, typer.Typer]] = []
+        for provider in self._cli_providers:
+            groups.extend(provider.cli_groups())
+        return groups
 
     def find_url_handler(self, url: str) -> URLHandler | None:
         """Find the first URL handler that can handle the given URL."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1985,3 +1985,55 @@ def test_env_update_modifies_environment(tmp_path):
     assert "Updated environment 'dev'" in result.output
     config_text = user_config.read_text()
     assert "http://newhost:19120/api/v1" in config_text
+
+
+def test_env_update_reports_project_scoped_environment(tmp_path):
+    """sunstone env update explains when the env exists only in project config."""
+    user_config = tmp_path / "user.toml"
+    project_config = tmp_path / ".sunstone" / "data_platform.toml"
+    project_config.parent.mkdir(parents=True)
+    project_config.write_text(
+        '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
+    )
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=project_config),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "update",
+                "dev",
+                "--catalog-url",
+                "http://newhost:19120/api/v1",
+            ],
+        )
+    assert result.exit_code == 1
+    assert "defined in project config" in result.output
+
+
+def test_env_update_requires_at_least_one_field(tmp_path):
+    """sunstone env update refuses no-op invocations without rewriting the file."""
+    user_config = tmp_path / "user.toml"
+    original = (
+        "# keep me\n"
+        "[environments.dev]\n"
+        'catalog_url = "http://localhost:19120/api/v1"\n'
+        's3_endpoint = "http://localhost:9000"\n'
+    )
+    user_config.write_text(original)
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(app, ["env", "update", "dev"])
+    assert result.exit_code == 1
+    assert "No fields to update" in result.output
+    assert user_config.read_text() == original

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1851,6 +1851,29 @@ def test_env_show_reports_resolution_error(tmp_path):
     assert "Error: Active environment 'missing' is not defined in any config file" in result.output
 
 
+def test_env_show_reports_missing_op_cli(tmp_path):
+    """sunstone env reports missing 1Password CLI cleanly."""
+    user_config = tmp_path / "user.toml"
+    user_config.write_text(
+        'active = "dev"\n'
+        "[environments.dev]\n"
+        'catalog_url = "http://localhost:19120/api/v1"\n'
+        's3_endpoint = "http://localhost:9000"\n'
+        's3_access_key = "op://vault/item/key"\n'
+    )
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+        patch("sunstone.env.subprocess.run", side_effect=FileNotFoundError("op not found")),
+    ):
+        result = runner.invoke(app, ["env"])
+    assert result.exit_code == 1
+    assert "Error: 1Password CLI (op) is not installed." in result.output
+
+
 def test_env_use_writes_project_config(tmp_path):
     """sunstone env use writes .sunstone/data_platform.toml."""
     system_config = tmp_path / "system.toml"
@@ -1921,9 +1944,7 @@ def test_env_remove_deletes_environment(tmp_path):
     """sunstone env remove deletes an environment from user config."""
     user_config = tmp_path / "user.toml"
     user_config.write_text(
-        "[environments.dev]\n"
-        'catalog_url = "http://localhost:19120/api/v1"\n'
-        's3_endpoint = "http://localhost:9000"\n'
+        '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
     )
 
     runner = CliRunner()
@@ -1941,9 +1962,7 @@ def test_env_update_modifies_environment(tmp_path):
     """sunstone env update modifies an existing environment."""
     user_config = tmp_path / "user.toml"
     user_config.write_text(
-        "[environments.dev]\n"
-        'catalog_url = "http://localhost:19120/api/v1"\n'
-        's3_endpoint = "http://localhost:9000"\n'
+        '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
     )
 
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1793,3 +1793,160 @@ def test_plugin_cli_failure_does_not_break_cli():
 
         # Should not raise
         cli_mod._mount_plugin_cli_groups()
+
+
+# =============================================================================
+# Environment commands
+# =============================================================================
+
+
+def test_env_show_no_config(tmp_path):
+    """sunstone env with no config shows helpful message."""
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", tmp_path / "user.toml"),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(app, ["env"])
+    assert result.exit_code == 0
+    assert "No environment configured" in result.output
+
+
+def test_env_show_with_active(tmp_path):
+    """sunstone env shows active environment."""
+    system_config = tmp_path / "system.toml"
+    system_config.write_text(
+        "[environments.prod]\n"
+        'catalog_url = "https://nessie.prod.example.com"\n'
+        's3_endpoint = "https://s3.prod.example.com"\n'
+    )
+    user_config = tmp_path / "user.toml"
+    user_config.write_text('active = "prod"\n')
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", system_config),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(app, ["env"])
+    assert result.exit_code == 0
+    assert "prod" in result.output
+
+
+def test_env_use_writes_project_config(tmp_path):
+    """sunstone env use writes .sunstone/data_platform.toml."""
+    system_config = tmp_path / "system.toml"
+    system_config.write_text(
+        "[environments.prod]\n"
+        'catalog_url = "https://nessie.prod.example.com"\n'
+        's3_endpoint = "https://s3.prod.example.com"\n'
+    )
+
+    project_sunstone = tmp_path / ".sunstone"
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", system_config),
+        patch("sunstone.env._USER_CONFIG", tmp_path / "user.toml"),
+        patch("sunstone.env._find_project_config", return_value=None),
+        patch("sunstone.env._PROJECT_CONFIG_NAME", ".sunstone/data_platform.toml"),
+        patch("pathlib.Path.cwd", return_value=tmp_path),
+    ):
+        result = runner.invoke(app, ["env", "use", "prod"])
+    assert result.exit_code == 0
+    config_text = (project_sunstone / "data_platform.toml").read_text()
+    assert "prod" in config_text
+
+
+def test_env_use_rejects_unknown(tmp_path):
+    """sunstone env use rejects unknown environment."""
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", tmp_path / "user.toml"),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(app, ["env", "use", "nonexistent"])
+    assert result.exit_code != 0
+
+
+def test_env_add_creates_environment(tmp_path):
+    """sunstone env add creates a new environment in user config."""
+    user_config = tmp_path / "user.toml"
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "add",
+                "dev",
+                "--catalog-url",
+                "http://localhost:19120/api/v1",
+                "--s3-endpoint",
+                "http://localhost:9000",
+            ],
+        )
+    assert result.exit_code == 0
+    assert "Added environment 'dev'" in result.output
+    config_text = user_config.read_text()
+    assert "dev" in config_text
+    assert "http://localhost:19120/api/v1" in config_text
+
+
+def test_env_remove_deletes_environment(tmp_path):
+    """sunstone env remove deletes an environment from user config."""
+    user_config = tmp_path / "user.toml"
+    user_config.write_text(
+        "[environments.dev]\n"
+        'catalog_url = "http://localhost:19120/api/v1"\n'
+        's3_endpoint = "http://localhost:9000"\n'
+    )
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(app, ["env", "remove", "dev"])
+    assert result.exit_code == 0
+    assert "Removed environment 'dev'" in result.output
+
+
+def test_env_update_modifies_environment(tmp_path):
+    """sunstone env update modifies an existing environment."""
+    user_config = tmp_path / "user.toml"
+    user_config.write_text(
+        "[environments.dev]\n"
+        'catalog_url = "http://localhost:19120/api/v1"\n'
+        's3_endpoint = "http://localhost:9000"\n'
+    )
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "update",
+                "dev",
+                "--catalog-url",
+                "http://newhost:19120/api/v1",
+            ],
+        )
+    assert result.exit_code == 0
+    assert "Updated environment 'dev'" in result.output
+    config_text = user_config.read_text()
+    assert "http://newhost:19120/api/v1" in config_text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1874,6 +1874,28 @@ def test_env_show_reports_missing_op_cli(tmp_path):
     assert "Error: 1Password CLI (op) is not installed." in result.output
 
 
+def test_env_show_reports_environment_source_error(tmp_path):
+    """sunstone env reports display-time environment lookup errors cleanly."""
+    user_config = tmp_path / "user.toml"
+    user_config.write_text(
+        '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
+    )
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+        patch(
+            "sunstone.env.environment_source",
+            side_effect=KeyError("Environment 'dev' not found in any config file"),
+        ),
+    ):
+        result = runner.invoke(app, ["env"])
+    assert result.exit_code == 1
+    assert "Error: Environment 'dev' not found in any config file" in result.output
+
+
 def test_env_use_writes_project_config(tmp_path):
     """sunstone env use writes .sunstone/data_platform.toml."""
     system_config = tmp_path / "system.toml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,20 +2,19 @@
 Tests for Sunstone CLI.
 """
 
+import contextlib
+import io
 import os
 import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer as _typer
 from typer.testing import CliRunner
 
 from sunstone.cli import _contributor_to_dict, _package_metadata_to_dict, app, expand_env_vars, is_lfs_pointer
 from sunstone.lineage import Contributor, PackageMetadata
-
-
-import contextlib
-import io
 
 
 class _MockURLHandler:
@@ -1727,3 +1726,70 @@ class TestParquetResourceSupport:
         assert result is not None
         assert result["path"].startswith("https://cdn.example.com/test-project/")
         assert result["path"].endswith("population.parquet")
+
+
+# =============================================================================
+# Plugin CLI group mounting tests
+# =============================================================================
+
+
+def test_plugin_cli_group_mounted():
+    """Plugin CLI groups appear as subcommands."""
+    test_main_app = _typer.Typer()
+    plugin_app = _typer.Typer(help="Test plugin")
+
+    @plugin_app.command("ping")
+    def ping():
+        _typer.echo("pong")
+
+    mock_registry = MagicMock()
+    mock_registry.get_cli_groups.return_value = [("testplug", plugin_app)]
+
+    with patch("sunstone.plugins.PluginRegistry.get", return_value=mock_registry):
+        import sunstone.cli as cli_mod
+
+        original_app = cli_mod.app
+        cli_mod.app = test_main_app
+        try:
+            cli_mod._mount_plugin_cli_groups()
+            runner = CliRunner()
+            result = runner.invoke(test_main_app, ["testplug", "ping"])
+            assert result.exit_code == 0
+            assert "pong" in result.output
+        finally:
+            cli_mod.app = original_app
+
+
+def test_plugin_cli_builtin_collision_skipped():
+    """Plugin group names that collide with builtins are skipped."""
+    test_main_app = _typer.Typer()
+    colliding_app = _typer.Typer(help="Collides")
+
+    @colliding_app.command("evil")
+    def evil():
+        _typer.echo("should not mount")
+
+    mock_registry = MagicMock()
+    mock_registry.get_cli_groups.return_value = [("dataset", colliding_app)]
+
+    with patch("sunstone.plugins.PluginRegistry.get", return_value=mock_registry):
+        import sunstone.cli as cli_mod
+
+        original_app = cli_mod.app
+        cli_mod.app = test_main_app
+        try:
+            cli_mod._mount_plugin_cli_groups()
+            # The colliding group must not have been added
+            group_names = [g.name for g in test_main_app.registered_groups]
+            assert "dataset" not in group_names
+        finally:
+            cli_mod.app = original_app
+
+
+def test_plugin_cli_failure_does_not_break_cli():
+    """If plugin loading fails, CLI still works."""
+    with patch("sunstone.plugins.PluginRegistry.get", side_effect=RuntimeError("crash")):
+        import sunstone.cli as cli_mod
+
+        # Should not raise
+        cli_mod._mount_plugin_cli_groups()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1835,6 +1835,22 @@ def test_env_show_with_active(tmp_path):
     assert "prod" in result.output
 
 
+def test_env_show_reports_resolution_error(tmp_path):
+    """sunstone env reports environment resolution errors cleanly."""
+    user_config = tmp_path / "user.toml"
+    user_config.write_text('active = "missing"\n')
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+    ):
+        result = runner.invoke(app, ["env"])
+    assert result.exit_code == 1
+    assert "Error: Active environment 'missing' is not defined in any config file" in result.output
+
+
 def test_env_use_writes_project_config(tmp_path):
     """sunstone env use writes .sunstone/data_platform.toml."""
     system_config = tmp_path / "system.toml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ Tests for Sunstone CLI.
 
 import contextlib
 import io
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -1786,6 +1787,38 @@ def test_plugin_cli_builtin_collision_skipped():
             cli_mod.app = original_app
 
 
+def test_plugin_cli_duplicate_plugin_collision_skipped(caplog):
+    """Duplicate plugin CLI group names are skipped after the first registration."""
+    test_main_app = _typer.Typer()
+    first_app = _typer.Typer(help="First plugin")
+    second_app = _typer.Typer(help="Second plugin")
+
+    @first_app.command("first")
+    def first():
+        _typer.echo("first")
+
+    @second_app.command("second")
+    def second():
+        _typer.echo("second")
+
+    mock_registry = MagicMock()
+    mock_registry.get_cli_groups.return_value = [("analytics", first_app), ("analytics", second_app)]
+
+    with patch("sunstone.plugins.PluginRegistry.get", return_value=mock_registry):
+        import sunstone.cli as cli_mod
+
+        original_app = cli_mod.app
+        cli_mod.app = test_main_app
+        try:
+            with caplog.at_level(logging.WARNING):
+                cli_mod._mount_plugin_cli_groups()
+            group_names = [g.name for g in test_main_app.registered_groups]
+            assert group_names == ["analytics"]
+            assert "already registered by another plugin" in caplog.text
+        finally:
+            cli_mod.app = original_app
+
+
 def test_plugin_cli_failure_does_not_break_cli():
     """If plugin loading fails, CLI still works."""
     with patch("sunstone.plugins.PluginRegistry.get", side_effect=RuntimeError("crash")):
@@ -2059,3 +2092,85 @@ def test_env_update_requires_at_least_one_field(tmp_path):
     assert result.exit_code == 1
     assert "No fields to update" in result.output
     assert user_config.read_text() == original
+
+
+def test_env_update_warns_when_project_config_shadows_user(tmp_path):
+    """sunstone env update warns when project config will shadow the updated user env."""
+    user_config = tmp_path / "user.toml"
+    user_config.write_text(
+        '[environments.dev]\ncatalog_url = "http://user-dev"\ns3_endpoint = "http://localhost:9000"\n'
+    )
+    project_config = tmp_path / ".sunstone" / "data_platform.toml"
+    project_config.parent.mkdir(parents=True)
+    project_config.write_text(
+        '[environments.dev]\ncatalog_url = "http://project-dev"\ns3_endpoint = "http://localhost:9001"\n'
+    )
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=project_config),
+    ):
+        result = runner.invoke(app, ["env", "update", "dev", "--catalog-url", "http://new-user-dev"])
+    assert result.exit_code == 0
+    assert "Updated environment 'dev'" in result.output
+    assert "project config values will shadow this update" in result.output
+    assert "http://new-user-dev" in user_config.read_text()
+
+
+def test_env_use_reports_write_errors():
+    """sunstone env use reports config write failures cleanly."""
+    runner = CliRunner()
+    with patch("sunstone.env.set_active", side_effect=PermissionError("read-only filesystem")):
+        result = runner.invoke(app, ["env", "use", "dev"])
+    assert result.exit_code == 1
+    assert "read-only filesystem" in result.output
+
+
+def test_env_add_reports_write_errors():
+    """sunstone env add reports config write failures cleanly."""
+    runner = CliRunner()
+    with patch("sunstone.env.add_environment", side_effect=PermissionError("permission denied")):
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "add",
+                "dev",
+                "--catalog-url",
+                "http://localhost:19120/api/v1",
+                "--s3-endpoint",
+                "http://localhost:9000",
+            ],
+        )
+    assert result.exit_code == 1
+    assert "permission denied" in result.output
+
+
+def test_env_remove_reports_write_errors():
+    """sunstone env remove reports config write failures cleanly."""
+    runner = CliRunner()
+    with patch("sunstone.env.remove_environment", side_effect=PermissionError("read-only filesystem")):
+        result = runner.invoke(app, ["env", "remove", "dev"])
+    assert result.exit_code == 1
+    assert "read-only filesystem" in result.output
+
+
+def test_env_update_reports_write_errors(tmp_path):
+    """sunstone env update reports config write failures cleanly."""
+    user_config = tmp_path / "user.toml"
+    user_config.write_text(
+        '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
+    )
+
+    runner = CliRunner()
+    with (
+        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
+        patch("sunstone.env._USER_CONFIG", user_config),
+        patch("sunstone.env._find_project_config", return_value=None),
+        patch("sunstone.env._write_config", side_effect=PermissionError("permission denied")),
+    ):
+        result = runner.invoke(app, ["env", "update", "dev", "--catalog-url", "http://newhost:19120/api/v1"])
+    assert result.exit_code == 1
+    assert "permission denied" in result.output

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,547 @@
+"""Tests for sunstone.env — environment configuration resolution."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from sunstone.env import (
+    DataEnvironment,
+    _find_project_config,
+    _load_toml,
+    _merge_environments,
+    _resolve_active_name,
+    _resolve_credential,
+    _resolve_op_reference,
+    _write_config,
+    add_environment,
+    remove_environment,
+    resolve_environment,
+    set_active,
+)
+
+
+# ---------------------------------------------------------------------------
+# DataEnvironment dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestDataEnvironment:
+    def test_frozen(self):
+        env = DataEnvironment(
+            name="test",
+            catalog_url="http://localhost:19120",
+            s3_endpoint="http://localhost:9000",
+            s3_access_key="key",
+            s3_secret_key="secret",
+            auth=None,
+            source="test",
+        )
+        with pytest.raises(FrozenInstanceError):
+            env.name = "other"  # type: ignore[misc]
+
+    def test_fields(self):
+        env = DataEnvironment(
+            name="prod",
+            catalog_url="https://nessie.prod.example.com",
+            s3_endpoint="https://s3.prod.example.com",
+            s3_access_key=None,
+            s3_secret_key=None,
+            auth="gcloud-adc",
+            source="/etc/sunstone/data_platform.toml",
+        )
+        assert env.name == "prod"
+        assert env.auth == "gcloud-adc"
+        assert env.s3_access_key is None
+
+
+# ---------------------------------------------------------------------------
+# _load_toml
+# ---------------------------------------------------------------------------
+
+
+class TestLoadToml:
+    def test_missing_file(self, tmp_path: Path):
+        result = _load_toml(tmp_path / "nonexistent.toml")
+        assert result == {}
+
+    def test_valid_file(self, tmp_path: Path):
+        config = tmp_path / "config.toml"
+        config.write_text(
+            'active = "dev"\n'
+            "[environments.dev]\n"
+            'catalog_url = "http://localhost:19120"\n'
+            's3_endpoint = "http://localhost:9000"\n'
+        )
+        result = _load_toml(config)
+        assert result["active"] == "dev"
+        assert result["environments"]["dev"]["catalog_url"] == "http://localhost:19120"
+
+    def test_invalid_toml(self, tmp_path: Path):
+        config = tmp_path / "bad.toml"
+        config.write_text("this is not valid toml [[[")
+        result = _load_toml(config)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _merge_environments
+# ---------------------------------------------------------------------------
+
+
+class TestMergeEnvironments:
+    def test_user_shadows_system(self):
+        system = {
+            "environments": {
+                "prod": {"catalog_url": "http://system-prod"},
+                "staging": {"catalog_url": "http://system-staging"},
+            }
+        }
+        user = {
+            "environments": {
+                "prod": {"catalog_url": "http://user-prod"},
+            }
+        }
+        merged = _merge_environments(system, user)
+        assert merged["prod"]["catalog_url"] == "http://user-prod"
+        assert merged["staging"]["catalog_url"] == "http://system-staging"
+
+    def test_system_only(self):
+        system = {"environments": {"prod": {"catalog_url": "http://sys"}}}
+        merged = _merge_environments(system, {})
+        assert merged["prod"]["catalog_url"] == "http://sys"
+
+    def test_empty_both(self):
+        assert _merge_environments({}, {}) == {}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_active_name
+# ---------------------------------------------------------------------------
+
+
+class TestResolveActiveName:
+    def test_env_var_wins(self):
+        with patch.dict("os.environ", {"SUNSTONE_DATA_ENV": "from-env"}):
+            name, source = _resolve_active_name(
+                {"active": "project"},
+                {"active": "user"},
+                {"active": "system"},
+            )
+        assert name == "from-env"
+        assert source == "SUNSTONE_DATA_ENV"
+
+    def test_project_over_user(self):
+        with patch.dict("os.environ", {}, clear=True):
+            name, source = _resolve_active_name(
+                {"active": "project"},
+                {"active": "user"},
+                {"active": "system"},
+            )
+        assert name == "project"
+        assert source == "project"
+
+    def test_user_over_system(self):
+        with patch.dict("os.environ", {}, clear=True):
+            name, source = _resolve_active_name(
+                {},
+                {"active": "user"},
+                {"active": "system"},
+            )
+        assert name == "user"
+        assert source == "user"
+
+    def test_system_fallback(self):
+        with patch.dict("os.environ", {}, clear=True):
+            name, source = _resolve_active_name({}, {}, {"active": "system"})
+        assert name == "system"
+        assert source == "system"
+
+    def test_none_when_nothing_set(self):
+        with patch.dict("os.environ", {}, clear=True):
+            name, source = _resolve_active_name({}, {}, {})
+        assert name is None
+        assert source is None
+
+
+# ---------------------------------------------------------------------------
+# _find_project_config
+# ---------------------------------------------------------------------------
+
+
+class TestFindProjectConfig:
+    def test_finds_in_current_dir(self, tmp_path: Path):
+        config = tmp_path / ".sunstone" / "data_platform.toml"
+        config.parent.mkdir(parents=True)
+        config.write_text('active = "dev"\n')
+        result = _find_project_config(tmp_path)
+        assert result == config
+
+    def test_walks_up(self, tmp_path: Path):
+        config = tmp_path / ".sunstone" / "data_platform.toml"
+        config.parent.mkdir(parents=True)
+        config.write_text('active = "dev"\n')
+        subdir = tmp_path / "sub" / "deep"
+        subdir.mkdir(parents=True)
+        result = _find_project_config(subdir)
+        assert result == config
+
+    def test_returns_none_if_not_found(self, tmp_path: Path):
+        result = _find_project_config(tmp_path)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_credential
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCredential:
+    def test_literal(self):
+        assert _resolve_credential("my-secret") == "my-secret"
+
+    def test_none(self):
+        assert _resolve_credential(None) is None
+
+    def test_empty_string(self):
+        assert _resolve_credential("") is None
+
+    def test_op_reference(self):
+        with patch("sunstone.env._resolve_op_reference", return_value="resolved-secret") as mock:
+            result = _resolve_credential("op://vault/item/field")
+        assert result == "resolved-secret"
+        mock.assert_called_once_with("op://vault/item/field")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_op_reference
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOpReference:
+    def test_success(self):
+        mock_result = subprocess.CompletedProcess(
+            args=["op", "read", "op://vault/item/field"],
+            returncode=0,
+            stdout="the-secret\n",
+            stderr="",
+        )
+        with patch("sunstone.env.subprocess.run", return_value=mock_result):
+            result = _resolve_op_reference("op://vault/item/field")
+        assert result == "the-secret"
+
+    def test_failure(self):
+        mock_result = subprocess.CompletedProcess(
+            args=["op", "read", "op://vault/item/field"],
+            returncode=1,
+            stdout="",
+            stderr="not signed in",
+        )
+        with patch("sunstone.env.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="not signed in"):
+                _resolve_op_reference("op://vault/item/field")
+
+    def test_op_not_installed(self):
+        with patch(
+            "sunstone.env.subprocess.run",
+            side_effect=FileNotFoundError("op not found"),
+        ):
+            with pytest.raises(FileNotFoundError, match="1Password CLI"):
+                _resolve_op_reference("op://vault/item/field")
+
+
+# ---------------------------------------------------------------------------
+# resolve_environment — full integration
+# ---------------------------------------------------------------------------
+
+
+def _write_toml(path: Path, content: str) -> Path:
+    """Helper to write a TOML config file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+class TestResolveEnvironment:
+    def test_full_cascade(self, tmp_path: Path):
+        system = _write_toml(
+            tmp_path / "system.toml",
+            "[environments.prod]\n" 'catalog_url = "http://sys-prod"\n' 's3_endpoint = "http://sys-s3"\n',
+        )
+        user = _write_toml(
+            tmp_path / "user.toml",
+            'active = "prod"\n',
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = resolve_environment(
+                system_config=system,
+                user_config=user,
+                project_config=tmp_path / "nonexistent.toml",
+            )
+
+        assert env is not None
+        assert env.name == "prod"
+        assert env.catalog_url == "http://sys-prod"
+        assert env.s3_endpoint == "http://sys-s3"
+
+    def test_env_var_field_overrides(self, tmp_path: Path):
+        system = _write_toml(
+            tmp_path / "system.toml",
+            'active = "dev"\n'
+            "[environments.dev]\n"
+            'catalog_url = "http://original"\n'
+            's3_endpoint = "http://original-s3"\n',
+        )
+
+        overrides = {
+            "SUNSTONE_DATA_CATALOG_URL": "http://overridden",
+            "SUNSTONE_DATA_S3_ENDPOINT": "http://overridden-s3",
+            "SUNSTONE_DATA_S3_ACCESS_KEY": "env-key",
+            "SUNSTONE_DATA_S3_SECRET_KEY": "env-secret",
+        }
+        with patch.dict("os.environ", overrides, clear=True):
+            env = resolve_environment(
+                system_config=system,
+                user_config=tmp_path / "none.toml",
+                project_config=tmp_path / "none2.toml",
+            )
+
+        assert env is not None
+        assert env.catalog_url == "http://overridden"
+        assert env.s3_endpoint == "http://overridden-s3"
+        assert env.s3_access_key == "env-key"
+        assert env.s3_secret_key == "env-secret"
+
+    def test_returns_none_when_nothing_configured(self, tmp_path: Path):
+        with patch.dict("os.environ", {}, clear=True):
+            env = resolve_environment(
+                system_config=tmp_path / "no.toml",
+                user_config=tmp_path / "no2.toml",
+                project_config=tmp_path / "no3.toml",
+            )
+        assert env is None
+
+    def test_raises_for_unknown_active_env(self, tmp_path: Path):
+        config = _write_toml(
+            tmp_path / "user.toml",
+            'active = "nonexistent"\n',
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="nonexistent"):
+                resolve_environment(
+                    system_config=tmp_path / "no.toml",
+                    user_config=config,
+                    project_config=tmp_path / "no2.toml",
+                )
+
+    def test_env_var_selects_environment(self, tmp_path: Path):
+        system = _write_toml(
+            tmp_path / "system.toml",
+            "[environments.staging]\n" 'catalog_url = "http://staging"\n' 's3_endpoint = "http://staging-s3"\n',
+        )
+
+        with patch.dict("os.environ", {"SUNSTONE_DATA_ENV": "staging"}, clear=True):
+            env = resolve_environment(
+                system_config=system,
+                user_config=tmp_path / "no.toml",
+                project_config=tmp_path / "no2.toml",
+            )
+
+        assert env is not None
+        assert env.name == "staging"
+        assert env.source == "SUNSTONE_DATA_ENV"
+
+    def test_project_config_environments(self, tmp_path: Path):
+        project = _write_toml(
+            tmp_path / ".sunstone" / "data_platform.toml",
+            'active = "local"\n'
+            "[environments.local]\n"
+            'catalog_url = "http://localhost:19120"\n'
+            's3_endpoint = "http://localhost:9000"\n',
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = resolve_environment(
+                system_config=tmp_path / "no.toml",
+                user_config=tmp_path / "no2.toml",
+                project_config=project,
+            )
+
+        assert env is not None
+        assert env.name == "local"
+        assert env.catalog_url == "http://localhost:19120"
+
+    def test_credential_resolution(self, tmp_path: Path):
+        config = _write_toml(
+            tmp_path / "config.toml",
+            'active = "test"\n'
+            "[environments.test]\n"
+            'catalog_url = "http://test"\n'
+            's3_endpoint = "http://test-s3"\n'
+            's3_access_key = "op://vault/item/key"\n'
+            's3_secret_key = "literal-secret"\n',
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("sunstone.env._resolve_op_reference", return_value="resolved-key"):
+                env = resolve_environment(
+                    system_config=config,
+                    user_config=tmp_path / "no.toml",
+                    project_config=tmp_path / "no2.toml",
+                )
+
+        assert env is not None
+        assert env.s3_access_key == "resolved-key"
+        assert env.s3_secret_key == "literal-secret"
+
+
+# ---------------------------------------------------------------------------
+# set_active
+# ---------------------------------------------------------------------------
+
+
+class TestSetActive:
+    def test_writes_project_config(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        user = _write_toml(
+            tmp_path / "user.toml",
+            "[environments.dev]\n" 'catalog_url = "http://dev"\n' 's3_endpoint = "http://dev-s3"\n',
+        )
+
+        result = set_active(
+            "dev",
+            system_config=tmp_path / "no.toml",
+            user_config=user,
+        )
+
+        assert result == tmp_path / ".sunstone" / "data_platform.toml"
+        data = _load_toml(result)
+        assert data["active"] == "dev"
+
+    def test_writes_user_config(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            "[environments.staging]\n" 'catalog_url = "http://staging"\n' 's3_endpoint = "http://staging-s3"\n',
+        )
+
+        result = set_active(
+            "staging",
+            user=True,
+            system_config=tmp_path / "no.toml",
+            user_config=user,
+        )
+
+        assert result == user
+        data = _load_toml(result)
+        assert data["active"] == "staging"
+
+    def test_validates_env_exists(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="does not exist"):
+            set_active(
+                "nonexistent",
+                system_config=tmp_path / "no.toml",
+                user_config=tmp_path / "no2.toml",
+            )
+
+
+# ---------------------------------------------------------------------------
+# add_environment
+# ---------------------------------------------------------------------------
+
+
+class TestAddEnvironment:
+    def test_adds_to_user_config(self, tmp_path: Path):
+        user = tmp_path / "user.toml"
+
+        result = add_environment(
+            "dev",
+            catalog_url="http://dev",
+            s3_endpoint="http://dev-s3",
+            s3_access_key="key",
+            auth="gcloud-adc",
+            user_config=user,
+        )
+
+        assert result == user
+        data = _load_toml(user)
+        assert data["environments"]["dev"]["catalog_url"] == "http://dev"
+        assert data["environments"]["dev"]["auth"] == "gcloud-adc"
+        assert data["environments"]["dev"]["s3_access_key"] == "key"
+        assert "s3_secret_key" not in data["environments"]["dev"]
+
+    def test_rejects_duplicates(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            "[environments.dev]\n" 'catalog_url = "http://dev"\n' 's3_endpoint = "http://dev-s3"\n',
+        )
+
+        with pytest.raises(ValueError, match="already exists"):
+            add_environment(
+                "dev",
+                catalog_url="http://other",
+                s3_endpoint="http://other-s3",
+                user_config=user,
+            )
+
+
+# ---------------------------------------------------------------------------
+# remove_environment
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveEnvironment:
+    def test_removes_from_user_config(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            "[environments.dev]\n" 'catalog_url = "http://dev"\n' 's3_endpoint = "http://dev-s3"\n',
+        )
+
+        result = remove_environment(
+            "dev",
+            user_config=user,
+            system_config=tmp_path / "no.toml",
+        )
+
+        assert result == user
+        data = _load_toml(user)
+        assert "dev" not in data.get("environments", {})
+
+    def test_refuses_system_only(self, tmp_path: Path):
+        system = _write_toml(
+            tmp_path / "system.toml",
+            "[environments.prod]\n" 'catalog_url = "http://prod"\n' 's3_endpoint = "http://prod-s3"\n',
+        )
+
+        with pytest.raises(ValueError, match="system config"):
+            remove_environment(
+                "prod",
+                user_config=tmp_path / "empty.toml",
+                system_config=system,
+            )
+
+    def test_not_found(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="not found"):
+            remove_environment(
+                "nope",
+                user_config=tmp_path / "no.toml",
+                system_config=tmp_path / "no2.toml",
+            )
+
+
+# ---------------------------------------------------------------------------
+# _write_config
+# ---------------------------------------------------------------------------
+
+
+class TestWriteConfig:
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        path = tmp_path / "deep" / "nested" / "config.toml"
+        _write_config(path, {"active": "test"})
+        assert path.exists()
+        data = _load_toml(path)
+        assert data["active"] == "test"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -773,3 +773,17 @@ class TestWriteConfig:
         assert path.exists()
         data = _load_toml(path)
         assert data["active"] == "test"
+
+    def test_preserves_original_file_if_write_fails(self, tmp_path: Path):
+        path = _write_toml(
+            tmp_path / "config.toml",
+            'active = "original"\n',
+        )
+        original = path.read_text()
+
+        with patch("sunstone.env.tomli_w.dump", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                _write_config(path, {"active": "updated"})
+
+        assert path.read_text() == original
+        assert not any(candidate.suffix == ".tmp" for candidate in tmp_path.iterdir())

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -255,6 +255,17 @@ class TestResolveOpReference:
             with pytest.raises(FileNotFoundError, match="1Password CLI"):
                 _resolve_op_reference("op://vault/item/field")
 
+    def test_timeout(self):
+        with patch(
+            "sunstone.env.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd=["op", "read", "op://vault/item/field"],
+                timeout=10,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="timed out after 10s"):
+                _resolve_op_reference("op://vault/item/field")
+
 
 # ---------------------------------------------------------------------------
 # resolve_environment — full integration
@@ -677,6 +688,26 @@ class TestSetActiveProjectConfig:
         assert result == project
         data = _load_toml(result)
         assert data["active"] == "local"
+
+    def test_uses_discovered_project_config_from_subdirectory(self, tmp_path: Path, monkeypatch):
+        project = _write_toml(
+            tmp_path / ".sunstone" / "data_platform.toml",
+            '[environments.local]\ncatalog_url = "http://localhost:19120"\ns3_endpoint = "http://localhost:9000"\n',
+        )
+        subdir = tmp_path / "src" / "nested"
+        subdir.mkdir(parents=True)
+        monkeypatch.chdir(subdir)
+
+        result = set_active(
+            "local",
+            system_config=tmp_path / "no.toml",
+            user_config=tmp_path / "no2.toml",
+        )
+
+        assert result == project
+        data = _load_toml(result)
+        assert data["active"] == "local"
+        assert not (subdir / ".sunstone" / "data_platform.toml").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -603,6 +603,26 @@ class TestRemoveEnvironment:
         data = _load_toml(user)
         assert data["active"] == "prod"
 
+    def test_clears_project_active_when_removing_active_env(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            '[environments.dev]\ncatalog_url = "http://dev"\ns3_endpoint = "http://dev-s3"\n',
+        )
+        project = _write_toml(
+            tmp_path / ".sunstone" / "data_platform.toml",
+            'active = "dev"\n',
+        )
+
+        remove_environment(
+            "dev",
+            user_config=user,
+            system_config=tmp_path / "no.toml",
+            project_config=project,
+        )
+
+        data = _load_toml(project)
+        assert "active" not in data
+
 
 # ---------------------------------------------------------------------------
 # list_environments — project config inclusion

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -113,7 +113,7 @@ class TestLoadToml:
 
 
 class TestMergeEnvironments:
-    def test_user_shadows_system(self):
+    def test_user_overrides_system_field(self):
         system = {
             "environments": {
                 "prod": {"catalog_url": "http://system-prod"},
@@ -128,6 +128,43 @@ class TestMergeEnvironments:
         merged = _merge_environments(system, user)
         assert merged["prod"]["catalog_url"] == "http://user-prod"
         assert merged["staging"]["catalog_url"] == "http://system-staging"
+
+    def test_field_level_merge_preserves_lower_layer_fields(self):
+        system = {
+            "environments": {
+                "dev": {"catalog_url": "http://sys", "s3_endpoint": "http://sys-s3", "auth": "basic"},
+            }
+        }
+        user = {
+            "environments": {
+                "dev": {"catalog_url": "http://user"},
+            }
+        }
+        merged = _merge_environments(system, user)
+        assert merged["dev"]["catalog_url"] == "http://user"
+        assert merged["dev"]["s3_endpoint"] == "http://sys-s3"
+        assert merged["dev"]["auth"] == "basic"
+
+    def test_three_layer_field_merge(self):
+        system = {
+            "environments": {
+                "dev": {"catalog_url": "http://sys", "s3_endpoint": "http://sys-s3", "auth": "basic"},
+            }
+        }
+        user = {
+            "environments": {
+                "dev": {"s3_endpoint": "http://user-s3"},
+            }
+        }
+        project = {
+            "environments": {
+                "dev": {"catalog_url": "http://project"},
+            }
+        }
+        merged = _merge_environments(system, user, project)
+        assert merged["dev"]["catalog_url"] == "http://project"
+        assert merged["dev"]["s3_endpoint"] == "http://user-s3"
+        assert merged["dev"]["auth"] == "basic"
 
     def test_system_only(self):
         system = {"environments": {"prod": {"catalog_url": "http://sys"}}}
@@ -428,6 +465,34 @@ class TestResolveEnvironment:
         assert env.name == "local"
         assert env.catalog_url == "http://localhost:19120"
 
+    def test_field_level_merge_across_layers(self, tmp_path: Path):
+        system = _write_toml(
+            tmp_path / "system.toml",
+            '[environments.dev]\nauth = "basic"\ns3_endpoint = "http://sys-s3"\n',
+        )
+        user = _write_toml(
+            tmp_path / "user.toml",
+            'active = "dev"\n[environments.dev]\ns3_access_key = "user-key"\n',
+        )
+        project = _write_toml(
+            tmp_path / "project.toml",
+            '[environments.dev]\ncatalog_url = "http://project-dev"\n',
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = resolve_environment(
+                system_config=system,
+                user_config=user,
+                project_config=project,
+            )
+
+        assert env is not None
+        assert env.name == "dev"
+        assert env.catalog_url == "http://project-dev"
+        assert env.s3_endpoint == "http://sys-s3"
+        assert env.s3_access_key == "user-key"
+        assert env.auth == "basic"
+
     def test_credential_resolution(self, tmp_path: Path):
         config = _write_toml(
             tmp_path / "config.toml",
@@ -676,7 +741,7 @@ class TestListEnvironmentsProjectConfig:
         assert "local" in envs
         assert envs["local"]["catalog_url"] == "http://localhost:19120"
 
-    def test_project_shadows_user(self, tmp_path: Path):
+    def test_project_overrides_user_field(self, tmp_path: Path):
         user = _write_toml(
             tmp_path / "user.toml",
             '[environments.dev]\ncatalog_url = "http://user-dev"\ns3_endpoint = "http://user-s3"\n',
@@ -693,6 +758,31 @@ class TestListEnvironmentsProjectConfig:
         )
 
         assert envs["dev"]["catalog_url"] == "http://project-dev"
+
+    def test_field_level_merge_across_layers(self, tmp_path: Path):
+        system = _write_toml(
+            tmp_path / "system.toml",
+            '[environments.dev]\nauth = "basic"\n',
+        )
+        user = _write_toml(
+            tmp_path / "user.toml",
+            '[environments.dev]\ns3_endpoint = "http://user-s3"\ns3_access_key = "user-key"\n',
+        )
+        project = _write_toml(
+            tmp_path / "project.toml",
+            '[environments.dev]\ncatalog_url = "http://project-dev"\n',
+        )
+
+        envs = list_environments(
+            system_config=system,
+            user_config=user,
+            project_config=project,
+        )
+
+        assert envs["dev"]["catalog_url"] == "http://project-dev"
+        assert envs["dev"]["s3_endpoint"] == "http://user-s3"
+        assert envs["dev"]["s3_access_key"] == "user-key"
+        assert envs["dev"]["auth"] == "basic"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -316,6 +316,31 @@ class TestResolveEnvironment:
         assert env.s3_access_key == "env-key"
         assert env.s3_secret_key == "env-secret"
 
+    def test_empty_env_vars_do_not_override_config(self, tmp_path: Path):
+        system = _write_toml(
+            tmp_path / "system.toml",
+            'active = "dev"\n[environments.dev]\ncatalog_url = "http://original"\ns3_endpoint = "http://original-s3"\ns3_access_key = "configured-key"\ns3_secret_key = "configured-secret"\n',
+        )
+
+        overrides = {
+            "SUNSTONE_DATA_CATALOG_URL": "",
+            "SUNSTONE_DATA_S3_ENDPOINT": "",
+            "SUNSTONE_DATA_S3_ACCESS_KEY": "",
+            "SUNSTONE_DATA_S3_SECRET_KEY": "",
+        }
+        with patch.dict("os.environ", overrides, clear=True):
+            env = resolve_environment(
+                system_config=system,
+                user_config=tmp_path / "none.toml",
+                project_config=tmp_path / "none2.toml",
+            )
+
+        assert env is not None
+        assert env.catalog_url == "http://original"
+        assert env.s3_endpoint == "http://original-s3"
+        assert env.s3_access_key == "configured-key"
+        assert env.s3_secret_key == "configured-secret"
+
     def test_returns_none_when_nothing_configured(self, tmp_path: Path):
         with patch.dict("os.environ", {}, clear=True):
             env = resolve_environment(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import subprocess
 from dataclasses import FrozenInstanceError
 from pathlib import Path
@@ -59,6 +60,22 @@ class TestDataEnvironment:
         assert env.name == "prod"
         assert env.auth == "gcloud-adc"
         assert env.s3_access_key is None
+
+
+def test_import_env_tolerates_missing_home(monkeypatch):
+    """Reloading sunstone.env should not fail when Path.home() is unavailable."""
+    import sunstone.env as env_mod
+
+    def fail_home() -> Path:
+        raise RuntimeError("Failed to get home directory")
+
+    monkeypatch.setattr("pathlib.Path.home", fail_home)
+    try:
+        reloaded = importlib.reload(env_mod)
+        assert reloaded._USER_CONFIG is None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(env_mod)
 
 
 # ---------------------------------------------------------------------------
@@ -622,6 +639,20 @@ class TestRemoveEnvironment:
 
         data = _load_toml(project)
         assert "active" not in data
+
+    def test_reports_project_scoped_environment(self, tmp_path: Path):
+        project = _write_toml(
+            tmp_path / ".sunstone" / "data_platform.toml",
+            '[environments.local]\ncatalog_url = "http://local"\ns3_endpoint = "http://local-s3"\n',
+        )
+
+        with pytest.raises(ValueError, match="defined in project config"):
+            remove_environment(
+                "local",
+                user_config=tmp_path / "user.toml",
+                system_config=tmp_path / "no.toml",
+                project_config=project,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -19,6 +19,8 @@ from sunstone.env import (
     _resolve_op_reference,
     _write_config,
     add_environment,
+    environment_source,
+    list_environments,
     remove_environment,
     resolve_environment,
     set_active,
@@ -270,7 +272,7 @@ class TestResolveEnvironment:
     def test_full_cascade(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
-            "[environments.prod]\n" 'catalog_url = "http://sys-prod"\n' 's3_endpoint = "http://sys-s3"\n',
+            '[environments.prod]\ncatalog_url = "http://sys-prod"\ns3_endpoint = "http://sys-s3"\n',
         )
         user = _write_toml(
             tmp_path / "user.toml",
@@ -292,10 +294,7 @@ class TestResolveEnvironment:
     def test_env_var_field_overrides(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
-            'active = "dev"\n'
-            "[environments.dev]\n"
-            'catalog_url = "http://original"\n'
-            's3_endpoint = "http://original-s3"\n',
+            'active = "dev"\n[environments.dev]\ncatalog_url = "http://original"\ns3_endpoint = "http://original-s3"\n',
         )
 
         overrides = {
@@ -342,7 +341,7 @@ class TestResolveEnvironment:
     def test_env_var_selects_environment(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
-            "[environments.staging]\n" 'catalog_url = "http://staging"\n' 's3_endpoint = "http://staging-s3"\n',
+            '[environments.staging]\ncatalog_url = "http://staging"\ns3_endpoint = "http://staging-s3"\n',
         )
 
         with patch.dict("os.environ", {"SUNSTONE_DATA_ENV": "staging"}, clear=True):
@@ -410,7 +409,7 @@ class TestSetActive:
         monkeypatch.chdir(tmp_path)
         user = _write_toml(
             tmp_path / "user.toml",
-            "[environments.dev]\n" 'catalog_url = "http://dev"\n' 's3_endpoint = "http://dev-s3"\n',
+            '[environments.dev]\ncatalog_url = "http://dev"\ns3_endpoint = "http://dev-s3"\n',
         )
 
         result = set_active(
@@ -426,7 +425,7 @@ class TestSetActive:
     def test_writes_user_config(self, tmp_path: Path):
         user = _write_toml(
             tmp_path / "user.toml",
-            "[environments.staging]\n" 'catalog_url = "http://staging"\n' 's3_endpoint = "http://staging-s3"\n',
+            '[environments.staging]\ncatalog_url = "http://staging"\ns3_endpoint = "http://staging-s3"\n',
         )
 
         result = set_active(
@@ -477,7 +476,7 @@ class TestAddEnvironment:
     def test_rejects_duplicates(self, tmp_path: Path):
         user = _write_toml(
             tmp_path / "user.toml",
-            "[environments.dev]\n" 'catalog_url = "http://dev"\n' 's3_endpoint = "http://dev-s3"\n',
+            '[environments.dev]\ncatalog_url = "http://dev"\ns3_endpoint = "http://dev-s3"\n',
         )
 
         with pytest.raises(ValueError, match="already exists"):
@@ -498,7 +497,7 @@ class TestRemoveEnvironment:
     def test_removes_from_user_config(self, tmp_path: Path):
         user = _write_toml(
             tmp_path / "user.toml",
-            "[environments.dev]\n" 'catalog_url = "http://dev"\n' 's3_endpoint = "http://dev-s3"\n',
+            '[environments.dev]\ncatalog_url = "http://dev"\ns3_endpoint = "http://dev-s3"\n',
         )
 
         result = remove_environment(
@@ -514,7 +513,7 @@ class TestRemoveEnvironment:
     def test_refuses_system_only(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
-            "[environments.prod]\n" 'catalog_url = "http://prod"\n' 's3_endpoint = "http://prod-s3"\n',
+            '[environments.prod]\ncatalog_url = "http://prod"\ns3_endpoint = "http://prod-s3"\n',
         )
 
         with pytest.raises(ValueError, match="system config"):
@@ -531,6 +530,128 @@ class TestRemoveEnvironment:
                 user_config=tmp_path / "no.toml",
                 system_config=tmp_path / "no2.toml",
             )
+
+    def test_clears_active_when_removing_active_env(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            'active = "dev"\n[environments.dev]\ncatalog_url = "http://dev"\ns3_endpoint = "http://dev-s3"\n',
+        )
+
+        remove_environment(
+            "dev",
+            user_config=user,
+            system_config=tmp_path / "no.toml",
+        )
+
+        data = _load_toml(user)
+        assert "active" not in data
+
+    def test_preserves_active_when_removing_other_env(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            'active = "prod"\n'
+            "[environments.dev]\n"
+            'catalog_url = "http://dev"\n'
+            's3_endpoint = "http://dev-s3"\n'
+            "[environments.prod]\n"
+            'catalog_url = "http://prod"\n'
+            's3_endpoint = "http://prod-s3"\n',
+        )
+
+        remove_environment(
+            "dev",
+            user_config=user,
+            system_config=tmp_path / "no.toml",
+        )
+
+        data = _load_toml(user)
+        assert data["active"] == "prod"
+
+
+# ---------------------------------------------------------------------------
+# list_environments — project config inclusion
+# ---------------------------------------------------------------------------
+
+
+class TestListEnvironmentsProjectConfig:
+    def test_includes_project_environments(self, tmp_path: Path):
+        project = _write_toml(
+            tmp_path / "project.toml",
+            '[environments.local]\ncatalog_url = "http://localhost:19120"\ns3_endpoint = "http://localhost:9000"\n',
+        )
+
+        envs = list_environments(
+            system_config=tmp_path / "no.toml",
+            user_config=tmp_path / "no2.toml",
+            project_config=project,
+        )
+
+        assert "local" in envs
+        assert envs["local"]["catalog_url"] == "http://localhost:19120"
+
+    def test_project_shadows_user(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            '[environments.dev]\ncatalog_url = "http://user-dev"\ns3_endpoint = "http://user-s3"\n',
+        )
+        project = _write_toml(
+            tmp_path / "project.toml",
+            '[environments.dev]\ncatalog_url = "http://project-dev"\ns3_endpoint = "http://project-s3"\n',
+        )
+
+        envs = list_environments(
+            system_config=tmp_path / "no.toml",
+            user_config=user,
+            project_config=project,
+        )
+
+        assert envs["dev"]["catalog_url"] == "http://project-dev"
+
+
+# ---------------------------------------------------------------------------
+# environment_source — project config inclusion
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentSourceProjectConfig:
+    def test_returns_project_config_path(self, tmp_path: Path):
+        project = _write_toml(
+            tmp_path / "project.toml",
+            '[environments.local]\ncatalog_url = "http://localhost:19120"\ns3_endpoint = "http://localhost:9000"\n',
+        )
+
+        source = environment_source(
+            "local",
+            system_config=tmp_path / "no.toml",
+            user_config=tmp_path / "no2.toml",
+            project_config=project,
+        )
+
+        assert source == str(project)
+
+
+# ---------------------------------------------------------------------------
+# set_active — project-defined environments
+# ---------------------------------------------------------------------------
+
+
+class TestSetActiveProjectConfig:
+    def test_accepts_project_defined_env(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        project = _write_toml(
+            tmp_path / ".sunstone" / "data_platform.toml",
+            '[environments.local]\ncatalog_url = "http://localhost:19120"\ns3_endpoint = "http://localhost:9000"\n',
+        )
+
+        result = set_active(
+            "local",
+            system_config=tmp_path / "no.toml",
+            user_config=tmp_path / "no2.toml",
+        )
+
+        assert result == project
+        data = _load_toml(result)
+        assert data["active"] == "local"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,7 +5,16 @@ import pandas as pd
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from sunstone.plugins import AuthProvider, FormatHandler, URLHandler, PluginRegistry, _load_cascading_config
+import typer
+
+from sunstone.plugins import (
+    AuthProvider,
+    CLIProvider,
+    FormatHandler,
+    URLHandler,
+    PluginRegistry,
+    _load_cascading_config,
+)
 from sunstone.handlers import BuiltinFormatHandler, HttpURLHandler
 from sunstone.datasets import DatasetsManager
 from sunstone.dataframe import DataFrame
@@ -757,3 +766,59 @@ def test_registry_fetch_no_handler():
     registry = PluginRegistry()
     with pytest.raises(ValueError, match="No URL handler found"):
         registry.fetch("unknown://data.csv", Path("/tmp/out"))
+
+
+# --- CLIProvider tests ---
+
+
+class FakeCLIProvider:
+    def cli_groups(self):
+        test_app = typer.Typer(help="Test CLI group")
+        return [("test", test_app)]
+
+
+class NotACLIProvider:
+    pass
+
+
+def test_cli_provider_structural_typing():
+    assert isinstance(FakeCLIProvider(), CLIProvider)
+
+
+def test_cli_provider_negative():
+    assert not isinstance(NotACLIProvider(), CLIProvider)
+
+
+def test_cli_provider_registration():
+    registry = PluginRegistry()
+    provider = FakeCLIProvider()
+    registry._register("fake_cli", provider)
+    groups = registry.get_cli_groups()
+    assert len(groups) == 1
+    assert groups[0][0] == "test"
+
+
+def test_cli_provider_not_registered_for_non_provider():
+    registry = PluginRegistry()
+    registry._register("not_cli", NotAPlugin())
+    groups = registry.get_cli_groups()
+    assert len(groups) == 0
+
+
+def test_multi_protocol_plugin_with_cli():
+    class MultiPlugin:
+        def can_handle(self, url):
+            return url.startswith("multi://")
+
+        def open(self, url, mode="rb"):
+            import io
+
+            return io.BytesIO(b"")
+
+        def cli_groups(self):
+            return [("multi", typer.Typer(help="Multi"))]
+
+    registry = PluginRegistry()
+    registry._register("multi", MultiPlugin())
+    assert len(registry.get_cli_groups()) == 1
+    assert registry.find_url_handler("multi://test") is not None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -442,7 +442,8 @@ def test_fetch_from_url_injects_auth_headers(dataset_with_url):
         patch("sunstone.handlers._is_public_url", return_value=True),
         patch("sunstone.handlers.build_opener", return_value=mock_opener),
     ):
-        manager.fetch_from_url(dataset, force=True)
+        with pytest.deprecated_call(match="fetch_from_url is deprecated"):
+            manager.fetch_from_url(dataset, force=True)
         request_obj = mock_opener.open.call_args[0][0]
         assert request_obj.get_header("Authorization") == "Bearer test-token"
 
@@ -478,7 +479,8 @@ def test_fetch_from_url_stacks_auth_providers(dataset_with_url):
         patch("sunstone.handlers._is_public_url", return_value=True),
         patch("sunstone.handlers.build_opener", return_value=mock_opener),
     ):
-        manager.fetch_from_url(dataset, force=True)
+        with pytest.deprecated_call(match="fetch_from_url is deprecated"):
+            manager.fetch_from_url(dataset, force=True)
         request_obj = mock_opener.open.call_args[0][0]
         assert request_obj.get_header("X-auth-a") == "a"
         assert request_obj.get_header("X-auth-b") == "b"
@@ -504,7 +506,8 @@ def test_fetch_from_url_no_auth_still_works(dataset_with_url):
         patch("sunstone.handlers._is_public_url", return_value=True),
         patch("sunstone.handlers.build_opener", return_value=mock_opener),
     ):
-        manager.fetch_from_url(dataset, force=True)
+        with pytest.deprecated_call(match="fetch_from_url is deprecated"):
+            manager.fetch_from_url(dataset, force=True)
         request_obj = mock_opener.open.call_args[0][0]
         assert request_obj.headers == {}
 
@@ -537,7 +540,8 @@ def test_fetch_from_url_does_not_leak_auth_headers_between_calls(dataset_with_ur
         patch("sunstone.handlers._is_public_url", return_value=True),
         patch("sunstone.handlers.build_opener", return_value=opener_with_auth),
     ):
-        manager.fetch_from_url(dataset, force=True)
+        with pytest.deprecated_call(match="fetch_from_url is deprecated"):
+            manager.fetch_from_url(dataset, force=True)
         first_request = opener_with_auth.open.call_args[0][0]
         assert first_request.get_header("Authorization") == "Bearer test-token"
 
@@ -549,7 +553,8 @@ def test_fetch_from_url_does_not_leak_auth_headers_between_calls(dataset_with_ur
         patch("sunstone.handlers._is_public_url", return_value=True),
         patch("sunstone.handlers.build_opener", return_value=opener_without_auth),
     ):
-        manager.fetch_from_url(dataset, force=True)
+        with pytest.deprecated_call(match="fetch_from_url is deprecated"):
+            manager.fetch_from_url(dataset, force=True)
         second_request = opener_without_auth.open.call_args[0][0]
         assert second_request.get_header("Authorization") is None
 
@@ -705,7 +710,8 @@ def test_fetch_from_url_uses_url_handler(dataset_with_url):
     registry._url_handlers.append(TestURLHandler())
 
     with patch.object(PluginRegistry, "get", return_value=registry):
-        result = manager.fetch_from_url(dataset, force=True)
+        with pytest.deprecated_call(match="fetch_from_url is deprecated"):
+            result = manager.fetch_from_url(dataset, force=True)
         assert len(fetched_urls) == 1
         assert fetched_urls[0] == "https://example.com/test.csv"
         assert result.exists()
@@ -733,7 +739,8 @@ def test_fetch_from_url_supports_custom_url_schemes(dataset_with_url):
     registry._url_handlers.append(CustomURLHandler())
 
     with patch.object(PluginRegistry, "get", return_value=registry):
-        result = manager.fetch_from_url(dataset, force=True)
+        with pytest.deprecated_call(match="fetch_from_url is deprecated"):
+            result = manager.fetch_from_url(dataset, force=True)
         assert result.exists()
         assert fetched_urls == ["custom://bucket/test.csv"]
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -822,3 +822,17 @@ def test_multi_protocol_plugin_with_cli():
     registry._register("multi", MultiPlugin())
     assert len(registry.get_cli_groups()) == 1
     assert registry.find_url_handler("multi://test") is not None
+
+
+def test_cli_provider_exception_does_not_hide_other_groups():
+    class BrokenCLIProvider:
+        def cli_groups(self):
+            raise ImportError("optional dependency missing")
+
+    registry = PluginRegistry()
+    registry._register("broken_cli", BrokenCLIProvider())
+    registry._register("healthy_cli", FakeCLIProvider())
+
+    groups = registry.get_cli_groups()
+    assert len(groups) == 1
+    assert groups[0][0] == "test"


### PR DESCRIPTION
## Summary

- Add `CLIProvider` protocol to the plugin system, allowing plugins to mount Typer subcommand groups on the `sunstone` CLI
- Add `sunstone env` command for managing data platform environments with cascading TOML config (`/etc/sunstone/` → `~/.config/sunstone/` → `.sunstone/`)
- Support `op://` credential references (resolved via `op read`) and `gcloud-adc` auth
- Export `CLIProvider`, `DataEnvironment`, `resolve_environment` as public API

## Motivation

sunstone-py and data-platform both define a `sunstone` CLI executable, causing a collision. This PR adds the extension mechanism so data-platform can deliver its CLI as a plugin instead of a standalone executable.

## Changes

- `plugins.py`: New `CLIProvider` protocol + registry support (5 new tests)
- `cli.py`: Mount plugin CLI groups with collision guard + `sunstone env` commands (10 new tests)
- `env.py`: New module — cascading TOML config, credential resolution, environment CRUD (39 new tests)
- `__init__.py`: Public exports
- `pyproject.toml`: Added `tomli-w` dependency

## Test plan

- [x] `uv run pytest` — 748 tests pass (CI green across ubuntu/macos/windows × Python 3.12/3.13/3.14)
- [x] Verify `sunstone env` commands work with real TOML config files
- [x] Verify plugin CLI mounting works with data-platform installed