### PR TITLE
feat: unit-aware arithmetic for Sunstone DataFrames

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,17 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 
+- repo: local
+  hooks:
+  - id: check-ruff-version
+    name: check ruff version consistency
+    entry: scripts/check-ruff-version.sh
+    language: script
+    files: (uv\.lock|\.pre-commit-config\.yaml)$
+    pass_filenames: false
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.1
+  rev: v0.15.8
   hooks:
   - id: ruff
     args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
 
 - repo: local
   hooks:
-  - id: check-ruff-version
-    name: check ruff version consistency
+  - id: check-tool-versions
+    name: check tool version consistency
     entry: scripts/check-ruff-version.sh
     language: script
     files: (uv\.lock|\.pre-commit-config\.yaml)$
@@ -26,7 +26,7 @@ repos:
   - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.13.0
+  rev: v1.19.1
   hooks:
   - id: mypy
     additional_dependencies: [pandas-stubs, types-PyYAML, types-requests]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added: Unit-aware arithmetic with Pint integration (`sunstone.units`)
+- Added: `UnitSeries` proxy for column-level unit tracking
+- Added: Unit handling modes — relaxed (default), strict, auto (`set_unit_mode()` / `SUNSTONE_UNIT_MODE`)
+- Added: QUDT URI detection and round-tripping via ontopint (`sunstone-py[qudt]`)
+- Added: Unit validation in `set_field_metadata(unit=...)`
+- Added: Unit resolution in `concat()`, `merge()`, `join()`
 - Added: Metadata container for DataFrame with description, RDF prefixes, custom properties, and field-level metadata
 - Added: `set_field_metadata()` method for annotating DataFrame columns with description, unit, source
 - Added: `read_json()` to sunstone.pandas module

--- a/docs/superpowers/plans/2026-04-10-unit-aware-arithmetic.md
+++ b/docs/superpowers/plans/2026-04-10-unit-aware-arithmetic.md
@@ -1,0 +1,1692 @@
+# Unit-Aware Arithmetic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add unit-aware arithmetic to Sunstone DataFrames so operations on columns with declared units validate compatibility, convert scales, and track result units — with relaxed/strict/auto modes.
+
+**Architecture:** New `units.py` module owns the Pint registry, mode setting, `resolve_units()` logic, and `UnitSeries` proxy. DataFrame's `__getitem__`/`__setitem__`/concat/merge/join get thin integration points. QUDT support via ontopint at read/write boundaries only.
+
+**Tech Stack:** Pint (unit engine), ontopint (optional QUDT bridge), Python warnings module (relaxed mode)
+
+---
+
+### Task 1: Add Pint Dependency and UnitError Exception
+
+**Files:**
+- Modify: `pyproject.toml:26-36` (dependencies)
+- Modify: `pyproject.toml:38-41` (optional-dependencies)
+- Modify: `src/sunstone/exceptions.py:30-33` (add UnitError)
+- Modify: `src/sunstone/__init__.py:30-36` (export UnitError)
+
+- [ ] **Step 1: Write failing test for UnitError**
+
+Create `tests/test_units.py`:
+
+```python
+import pytest
+
+from sunstone.exceptions import UnitError
+
+
+def test_unit_error_is_sunstone_error():
+    from sunstone.exceptions import SunstoneError
+
+    err = UnitError("test")
+    assert isinstance(err, SunstoneError)
+
+
+def test_unit_error_importable_from_sunstone():
+    from sunstone import UnitError as UE
+
+    assert UE is UnitError
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_units.py::test_unit_error_is_sunstone_error -v`
+Expected: FAIL with `ImportError: cannot import name 'UnitError'`
+
+- [ ] **Step 3: Add UnitError to exceptions.py**
+
+Add to `src/sunstone/exceptions.py` after `LineageError`:
+
+```python
+class UnitError(SunstoneError):
+    """Raised when a unit operation fails (incompatible dimensions, unparseable unit, etc.)."""
+
+    pass
+```
+
+- [ ] **Step 4: Export UnitError from __init__.py**
+
+In `src/sunstone/__init__.py`, add `UnitError` to the exceptions import and to `__all__`.
+
+- [ ] **Step 5: Add pint dependency to pyproject.toml**
+
+In `pyproject.toml`, add `"pint>=0.24"` to `dependencies` and add `qudt = ["ontopint>=0.1"]` to `[project.optional-dependencies]`.
+
+- [ ] **Step 6: Run uv sync and tests**
+
+Run: `uv sync && uv run pytest tests/test_units.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/sunstone/exceptions.py src/sunstone/__init__.py tests/test_units.py
+git commit -m "feat: add pint dependency and UnitError exception"
+```
+
+---
+
+### Task 2: Unit Registry Singleton and Mode Setting
+
+**Files:**
+- Create: `src/sunstone/units.py`
+- Test: `tests/test_units.py`
+
+- [ ] **Step 1: Write failing tests for registry and mode**
+
+Append to `tests/test_units.py`:
+
+```python
+import os
+import warnings
+
+
+def test_ureg_is_pint_registry():
+    from sunstone.units import ureg
+    import pint
+
+    assert isinstance(ureg, pint.UnitRegistry)
+
+
+def test_ureg_singleton():
+    from sunstone.units import ureg as ureg1
+    from sunstone.units import ureg as ureg2
+
+    assert ureg1 is ureg2
+
+
+def test_default_mode_is_relaxed():
+    from sunstone.units import get_unit_mode
+
+    assert get_unit_mode() == "relaxed"
+
+
+def test_set_unit_mode():
+    from sunstone.units import get_unit_mode, set_unit_mode
+
+    original = get_unit_mode()
+    try:
+        set_unit_mode("strict")
+        assert get_unit_mode() == "strict"
+        set_unit_mode("auto")
+        assert get_unit_mode() == "auto"
+    finally:
+        set_unit_mode(original)
+
+
+def test_set_unit_mode_invalid():
+    from sunstone.units import set_unit_mode
+
+    with pytest.raises(ValueError, match="Invalid unit mode"):
+        set_unit_mode("bogus")  # type: ignore[arg-type]
+
+
+def test_env_var_sets_mode(monkeypatch):
+    monkeypatch.setenv("SUNSTONE_UNIT_MODE", "strict")
+    # Re-import to pick up env var
+    import importlib
+    import sunstone.units
+    importlib.reload(sunstone.units)
+    try:
+        assert sunstone.units.get_unit_mode() == "strict"
+    finally:
+        importlib.reload(sunstone.units)
+
+
+def test_parse_unit_string():
+    from sunstone.units import parse_unit
+
+    unit = parse_unit("kWh")
+    assert str(unit) == "kilowatt_hour"
+
+
+def test_parse_unit_invalid():
+    from sunstone.units import parse_unit
+
+    with pytest.raises(UnitError, match="Cannot parse unit"):
+        parse_unit("flarbnitz")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_units.py::test_ureg_is_pint_registry -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'sunstone.units'`
+
+- [ ] **Step 3: Implement units.py**
+
+Create `src/sunstone/units.py`:
+
+```python
+"""
+Unit handling for Sunstone DataFrames.
+
+Provides a shared Pint UnitRegistry, unit mode management (relaxed/strict/auto),
+unit parsing, and unit resolution for arithmetic operations.
+"""
+
+import os
+import warnings
+from dataclasses import dataclass
+from typing import Literal
+
+import pint
+
+from .exceptions import UnitError
+
+UnitMode = Literal["relaxed", "strict", "auto"]
+
+# Shared registry — all Pint units in Sunstone must come from this instance.
+ureg = pint.UnitRegistry()
+Q_ = ureg.Quantity
+
+# Global mode setting
+_VALID_MODES: set[UnitMode] = {"relaxed", "strict", "auto"}
+_unit_mode: UnitMode = "relaxed"
+
+_env_mode = os.environ.get("SUNSTONE_UNIT_MODE", "").lower()
+if _env_mode in _VALID_MODES:
+    _unit_mode = _env_mode  # type: ignore[assignment]
+
+
+def get_unit_mode() -> UnitMode:
+    """Return the current unit handling mode."""
+    return _unit_mode
+
+
+def set_unit_mode(mode: UnitMode) -> None:
+    """Set the global unit handling mode.
+
+    Args:
+        mode: One of 'relaxed', 'strict', or 'auto'.
+
+    Raises:
+        ValueError: If mode is not valid.
+    """
+    global _unit_mode
+    if mode not in _VALID_MODES:
+        raise ValueError(f"Invalid unit mode '{mode}'. Must be one of: {', '.join(sorted(_VALID_MODES))}")
+    _unit_mode = mode
+
+
+def parse_unit(unit_str: str) -> pint.Unit:
+    """Parse a unit string into a Pint Unit.
+
+    Args:
+        unit_str: A Pint-compatible unit string (e.g. 'kWh', 'meter / second').
+
+    Returns:
+        A pint.Unit instance.
+
+    Raises:
+        UnitError: If the string cannot be parsed.
+    """
+    try:
+        return ureg.Unit(unit_str)
+    except (pint.UndefinedUnitError, pint.errors.UndefinedUnitError) as e:
+        raise UnitError(f"Cannot parse unit '{unit_str}': {e}") from e
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_units.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/units.py tests/test_units.py
+git commit -m "feat: add unit registry singleton and mode setting"
+```
+
+---
+
+### Task 3: resolve_units() — Core Resolution Logic
+
+**Files:**
+- Modify: `src/sunstone/units.py`
+- Test: `tests/test_units.py`
+
+- [ ] **Step 1: Write failing tests for resolve_units**
+
+Append to `tests/test_units.py`:
+
+```python
+from sunstone.units import parse_unit, resolve_units, set_unit_mode, get_unit_mode
+
+
+class TestResolveUnitsCommon:
+    """Rules common to all modes."""
+
+    def test_both_none_any_op(self):
+        result = resolve_units(None, None, "add")
+        assert result.result_unit is None
+        assert result.convert_a is None
+        assert result.convert_b is None
+        assert result.warning is None
+
+    def test_none_and_set_mul(self):
+        kw = parse_unit("kW")
+        result = resolve_units(None, kw, "mul")
+        assert result.result_unit == kw
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+    def test_set_and_none_mul(self):
+        kw = parse_unit("kW")
+        result = resolve_units(kw, None, "mul")
+        assert result.result_unit == kw
+
+    def test_none_and_set_div(self):
+        kw = parse_unit("kW")
+        result = resolve_units(None, kw, "div")
+        assert result.result_unit == 1 / kw
+
+    def test_set_and_none_div(self):
+        kw = parse_unit("kW")
+        result = resolve_units(kw, None, "div")
+        assert result.result_unit == kw
+
+    def test_none_and_set_add(self):
+        kw = parse_unit("kW")
+        result = resolve_units(None, kw, "add")
+        assert result.result_unit == kw
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+    def test_set_and_none_add(self):
+        kw = parse_unit("kW")
+        result = resolve_units(kw, None, "add")
+        assert result.result_unit == kw
+
+    def test_both_set_mul(self):
+        w = parse_unit("watt")
+        hr = parse_unit("hour")
+        result = resolve_units(w, hr, "mul")
+        assert result.result_unit == w * hr
+
+    def test_both_set_div(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        result = resolve_units(m, s, "div")
+        assert result.result_unit == m / s
+
+    def test_both_set_mod(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "mod")
+        assert result.result_unit == kwh
+
+
+class TestResolveUnitsRelaxed:
+    """Relaxed mode: warn but proceed."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("relaxed")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_same_unit_add(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "add")
+        assert result.result_unit == kwh
+        assert result.warning is None
+
+    def test_same_dimension_different_scale_warns(self):
+        kwh = parse_unit("kWh")
+        twh = parse_unit("TWh")
+        result = resolve_units(kwh, twh, "add")
+        assert result.warning is not None
+        assert result.convert_a is None  # no conversion in relaxed
+        assert result.convert_b is None
+
+    def test_incompatible_dimensions_warns(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        result = resolve_units(m, s, "add")
+        assert result.warning is not None
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+
+class TestResolveUnitsStrict:
+    """Strict mode: raise on mismatch."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("strict")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_same_unit_add_ok(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "add")
+        assert result.result_unit == kwh
+
+    def test_same_dimension_different_scale_raises(self):
+        kwh = parse_unit("kWh")
+        twh = parse_unit("TWh")
+        with pytest.raises(UnitError, match="units differ"):
+            resolve_units(kwh, twh, "add")
+
+    def test_incompatible_dimensions_raises(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            resolve_units(m, s, "add")
+
+
+class TestResolveUnitsAuto:
+    """Auto mode: convert when possible, raise otherwise."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_same_unit_add(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "add")
+        assert result.result_unit == kwh
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+    def test_same_dimension_converts_to_finer(self):
+        kwh = parse_unit("kWh")
+        twh = parse_unit("TWh")
+        result = resolve_units(kwh, twh, "add")
+        # kWh is finer granularity
+        assert result.result_unit == kwh
+        # b (TWh) needs conversion to kWh
+        assert result.convert_a is None
+        assert result.convert_b is not None
+        assert result.convert_b == pytest.approx(1e9)  # 1 TWh = 1e9 kWh
+
+    def test_finer_granularity_picks_smaller_factor(self):
+        mm = parse_unit("millimeter")
+        m = parse_unit("meter")
+        result = resolve_units(m, mm, "add")
+        assert result.result_unit == mm
+        # a (meter) needs conversion to mm
+        assert result.convert_a == pytest.approx(1000.0)
+        assert result.convert_b is None
+
+    def test_incompatible_dimensions_raises(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            resolve_units(m, s, "add")
+
+    def test_concat_same_dimension_converts(self):
+        kwh = parse_unit("kWh")
+        mwh = parse_unit("MWh")
+        result = resolve_units(kwh, mwh, "concat")
+        assert result.result_unit == kwh
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_units.py::TestResolveUnitsCommon::test_both_none_any_op -v`
+Expected: FAIL with `ImportError: cannot import name 'resolve_units'`
+
+- [ ] **Step 3: Implement resolve_units**
+
+Add to `src/sunstone/units.py`:
+
+```python
+@dataclass
+class ResolvedUnits:
+    """Result of unit resolution for an arithmetic operation."""
+
+    result_unit: pint.Unit | None
+    convert_a: float | None = None
+    convert_b: float | None = None
+    warning: str | None = None
+
+
+def _finer_granularity(unit_a: pint.Unit, unit_b: pint.Unit) -> tuple[pint.Unit, float | None, float | None]:
+    """Pick the unit with smaller base-equivalent magnitude.
+
+    Returns (winner_unit, convert_a, convert_b) where convert_a/b
+    is the multiplication factor to apply to the other operand's values,
+    or None if that operand is already in the winner unit.
+    """
+    # Get the magnitude of 1 unit in base SI
+    mag_a = Q_(1, unit_a).to_base_units().magnitude
+    mag_b = Q_(1, unit_b).to_base_units().magnitude
+
+    if abs(mag_a) <= abs(mag_b):
+        # a is finer, convert b to a
+        factor = Q_(1, unit_b).to(unit_a).magnitude
+        return unit_a, None, float(factor)
+    else:
+        # b is finer, convert a to b
+        factor = Q_(1, unit_a).to(unit_b).magnitude
+        return unit_b, float(factor), None
+
+
+def resolve_units(
+    unit_a: pint.Unit | None,
+    unit_b: pint.Unit | None,
+    operation: Literal["add", "sub", "mul", "div", "mod", "concat"],
+    mode: UnitMode | None = None,
+) -> ResolvedUnits:
+    """Resolve unit compatibility for an arithmetic operation.
+
+    Args:
+        unit_a: Unit of the left operand, or None.
+        unit_b: Unit of the right operand, or None.
+        operation: The kind of operation being performed.
+        mode: Override the global unit mode. If None, uses get_unit_mode().
+
+    Returns:
+        ResolvedUnits with the result unit and any conversion factors.
+
+    Raises:
+        UnitError: In strict/auto mode when units are incompatible.
+    """
+    if mode is None:
+        mode = get_unit_mode()
+
+    # Both None → passthrough
+    if unit_a is None and unit_b is None:
+        return ResolvedUnits(result_unit=None)
+
+    # Multiplicative ops (mul/div/mod) — always allowed
+    if operation in ("mul", "div", "mod"):
+        if unit_a is None and unit_b is None:
+            return ResolvedUnits(result_unit=None)
+        if operation == "mul":
+            if unit_a is None:
+                return ResolvedUnits(result_unit=unit_b)
+            if unit_b is None:
+                return ResolvedUnits(result_unit=unit_a)
+            return ResolvedUnits(result_unit=unit_a * unit_b)
+        if operation == "div":
+            if unit_a is None:
+                return ResolvedUnits(result_unit=1 / unit_b)  # type: ignore[operator]
+            if unit_b is None:
+                return ResolvedUnits(result_unit=unit_a)
+            return ResolvedUnits(result_unit=unit_a / unit_b)
+        # mod
+        if unit_a is None:
+            return ResolvedUnits(result_unit=unit_b)
+        return ResolvedUnits(result_unit=unit_a)
+
+    # Additive ops (add/sub/concat) — one side None
+    if unit_a is None:
+        return ResolvedUnits(result_unit=unit_b)
+    if unit_b is None:
+        return ResolvedUnits(result_unit=unit_a)
+
+    # Both set — check compatibility
+    if unit_a == unit_b:
+        return ResolvedUnits(result_unit=unit_a)
+
+    # Check dimensional compatibility
+    dim_compatible = unit_a.dimensionality == unit_b.dimensionality
+
+    if not dim_compatible:
+        msg = (
+            f"Cannot {operation} '{unit_a}' and '{unit_b}': "
+            f"incompatible dimensions {unit_a.dimensionality} vs {unit_b.dimensionality}"
+        )
+        if mode == "relaxed":
+            return ResolvedUnits(result_unit=unit_a, warning=msg)
+        raise UnitError(msg)
+
+    # Same dimension, different scale
+    if mode == "relaxed":
+        msg = (
+            f"Adding '{unit_a}' and '{unit_b}': units have same dimension but different scale. "
+            f"No conversion applied. Use auto mode for automatic conversion."
+        )
+        return ResolvedUnits(result_unit=unit_a, warning=msg)
+
+    if mode == "strict":
+        raise UnitError(
+            f"Cannot {operation} '{unit_a}' and '{unit_b}': "
+            f"units differ. Use auto mode for automatic conversion."
+        )
+
+    # Auto mode — convert to finer granularity
+    winner, conv_a, conv_b = _finer_granularity(unit_a, unit_b)
+    return ResolvedUnits(result_unit=winner, convert_a=conv_a, convert_b=conv_b)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_units.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/units.py tests/test_units.py
+git commit -m "feat: implement resolve_units with relaxed/strict/auto modes"
+```
+
+---
+
+### Task 4: UnitSeries Proxy
+
+**Files:**
+- Modify: `src/sunstone/units.py` (add UnitSeries class)
+- Test: `tests/test_units.py`
+
+- [ ] **Step 1: Write failing tests for UnitSeries**
+
+Append to `tests/test_units.py`:
+
+```python
+import pandas as pd
+
+from sunstone.units import UnitSeries, parse_unit, set_unit_mode, get_unit_mode
+
+
+class TestUnitSeriesBasic:
+    def test_construction(self):
+        s = pd.Series([1.0, 2.0, 3.0], name="power")
+        us = UnitSeries(s, parse_unit("kW"))
+        assert us.unit == parse_unit("kW")
+        assert len(us) == 3
+
+    def test_unit_property(self):
+        s = pd.Series([100.0], name="energy")
+        us = UnitSeries(s, parse_unit("kWh"))
+        assert str(us.unit) == "kilowatt_hour"
+
+    def test_delegates_to_series(self):
+        s = pd.Series([1.0, 2.0, 3.0], name="power")
+        us = UnitSeries(s, parse_unit("kW"))
+        assert us.name == "power"
+        assert us.mean() == 2.0
+        assert list(us.values) == [1.0, 2.0, 3.0]
+
+    def test_transparent_repr(self):
+        s = pd.Series([1.0, 2.0], name="x")
+        us = UnitSeries(s, parse_unit("meter"), unit_display="transparent")
+        r = repr(us)
+        assert "meter" not in r  # unit not in repr
+
+    def test_explicit_repr(self):
+        s = pd.Series([1.0, 2.0], name="x")
+        us = UnitSeries(s, parse_unit("meter"), unit_display="explicit")
+        r = repr(us)
+        assert "meter" in r
+
+
+class TestUnitSeriesArithmeticAuto:
+    """Test arithmetic in auto mode where conversions happen."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_add_same_unit(self):
+        a = UnitSeries(pd.Series([1.0, 2.0]), parse_unit("kWh"))
+        b = UnitSeries(pd.Series([3.0, 4.0]), parse_unit("kWh"))
+        result = a + b
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kWh")
+        assert list(result.series) == [4.0, 6.0]
+
+    def test_add_compatible_units_converts(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("km"))
+        b = UnitSeries(pd.Series([500.0]), parse_unit("meter"))
+        result = a + b
+        assert result.unit == parse_unit("meter")
+        assert result.series.iloc[0] == pytest.approx(1500.0)
+
+    def test_mul_units_combine(self):
+        power = UnitSeries(pd.Series([100.0]), parse_unit("watt"))
+        time = UnitSeries(pd.Series([2.0]), parse_unit("hour"))
+        result = power * time
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("watt") * parse_unit("hour")
+        assert result.series.iloc[0] == pytest.approx(200.0)
+
+    def test_div_units_combine(self):
+        dist = UnitSeries(pd.Series([100.0]), parse_unit("meter"))
+        time = UnitSeries(pd.Series([10.0]), parse_unit("second"))
+        result = dist / time
+        assert result.unit == parse_unit("meter") / parse_unit("second")
+        assert result.series.iloc[0] == pytest.approx(10.0)
+
+    def test_mul_scalar(self):
+        us = UnitSeries(pd.Series([2.0, 3.0]), parse_unit("kW"))
+        result = us * 1000
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kW")
+        assert list(result.series) == [2000.0, 3000.0]
+
+    def test_rmul_scalar(self):
+        us = UnitSeries(pd.Series([2.0, 3.0]), parse_unit("kW"))
+        result = 5 * us
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kW")
+        assert list(result.series) == [10.0, 15.0]
+
+    def test_sub_compatible(self):
+        a = UnitSeries(pd.Series([10.0]), parse_unit("km"))
+        b = UnitSeries(pd.Series([3000.0]), parse_unit("meter"))
+        result = a - b
+        assert result.unit == parse_unit("meter")
+        assert result.series.iloc[0] == pytest.approx(7000.0)
+
+    def test_add_incompatible_raises(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("meter"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("second"))
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            a + b
+
+    def test_mod_preserves_dividend_unit(self):
+        a = UnitSeries(pd.Series([10.0]), parse_unit("kWh"))
+        b = UnitSeries(pd.Series([3.0]), parse_unit("kWh"))
+        result = a % b
+        assert result.unit == parse_unit("kWh")
+        assert result.series.iloc[0] == pytest.approx(1.0)
+
+    def test_add_plain_series(self):
+        us = UnitSeries(pd.Series([1.0, 2.0]), parse_unit("meter"))
+        plain = pd.Series([10.0, 20.0])
+        result = us + plain
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("meter")
+        assert list(result.series) == [11.0, 22.0]
+
+    def test_radd_plain_series(self):
+        us = UnitSeries(pd.Series([1.0, 2.0]), parse_unit("meter"))
+        plain = pd.Series([10.0, 20.0])
+        result = plain + us
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("meter")
+
+
+class TestUnitSeriesRelaxed:
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("relaxed")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_incompatible_add_warns(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("meter"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("second"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = a + b
+            assert len(w) == 1
+            assert "incompatible dimensions" in str(w[0].message)
+        assert isinstance(result, UnitSeries)
+        assert list(result.series) == [2.0]  # pandas just added them
+
+    def test_different_scale_warns(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("kWh"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("TWh"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = a + b
+            assert len(w) == 1
+            assert "different scale" in str(w[0].message)
+        assert isinstance(result, UnitSeries)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_units.py::TestUnitSeriesBasic::test_construction -v`
+Expected: FAIL with `ImportError: cannot import name 'UnitSeries'`
+
+- [ ] **Step 3: Implement UnitSeries**
+
+Add to `src/sunstone/units.py`:
+
+```python
+class UnitSeries:
+    """A pandas Series proxy that tracks a Pint unit.
+
+    Wraps a pandas Series and overrides arithmetic operators to resolve
+    units according to the current unit handling mode.
+    """
+
+    __slots__ = ("_series", "_unit", "_unit_display")
+
+    def __init__(
+        self,
+        series: "pd.Series",  # type: ignore[type-arg]
+        unit: pint.Unit,
+        unit_display: Literal["transparent", "explicit"] = "transparent",
+    ) -> None:
+        self._series = series
+        self._unit = unit
+        self._unit_display = unit_display
+
+    @property
+    def series(self) -> "pd.Series":  # type: ignore[type-arg]
+        """The underlying pandas Series."""
+        return self._series
+
+    @property
+    def unit(self) -> pint.Unit:
+        """The unit of this series."""
+        return self._unit
+
+    def _extract_other(self, other: object) -> tuple["pd.Series | float | int", pint.Unit | None]:  # type: ignore[type-arg]
+        """Extract the raw values and unit from the other operand."""
+        if isinstance(other, UnitSeries):
+            return other._series, other._unit
+        return other, None  # type: ignore[return-value]
+
+    def _arith(
+        self,
+        other: object,
+        op: Literal["add", "sub", "mul", "div", "mod"],
+        reverse: bool = False,
+    ) -> "UnitSeries":
+        import pandas as pd
+
+        other_values, other_unit = self._extract_other(other)
+
+        if reverse:
+            resolved = resolve_units(other_unit, self._unit, op)
+        else:
+            resolved = resolve_units(self._unit, other_unit, op)
+
+        if resolved.warning:
+            warnings.warn(resolved.warning, UserWarning, stacklevel=3)
+
+        # Apply conversion factors
+        self_values = self._series
+        if reverse:
+            if resolved.convert_a is not None and isinstance(other_values, pd.Series):
+                other_values = other_values * resolved.convert_a
+            elif resolved.convert_a is not None and isinstance(other_values, (int, float)):
+                other_values = other_values * resolved.convert_a
+            if resolved.convert_b is not None:
+                self_values = self_values * resolved.convert_b
+        else:
+            if resolved.convert_a is not None:
+                self_values = self_values * resolved.convert_a
+            if resolved.convert_b is not None and isinstance(other_values, pd.Series):
+                other_values = other_values * resolved.convert_b
+            elif resolved.convert_b is not None and isinstance(other_values, (int, float)):
+                other_values = other_values * resolved.convert_b
+
+        # Perform pandas operation
+        pandas_ops = {"add": "__add__", "sub": "__sub__", "mul": "__mul__", "div": "__truediv__", "mod": "__mod__"}
+        if reverse:
+            result_series = getattr(other_values, pandas_ops[op])(self_values) if isinstance(other_values, pd.Series) else getattr(self_values, f"__r{pandas_ops[op][2:]}")(other_values)
+        else:
+            result_series = getattr(self_values, pandas_ops[op])(other_values)
+
+        if resolved.result_unit is not None:
+            return UnitSeries(result_series, resolved.result_unit, self._unit_display)
+        return UnitSeries(result_series, self._unit, self._unit_display)
+
+    def __add__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "add")
+
+    def __radd__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "add", reverse=True)
+
+    def __sub__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "sub")
+
+    def __rsub__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "sub", reverse=True)
+
+    def __mul__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "mul")
+
+    def __rmul__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "mul", reverse=True)
+
+    def __truediv__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "div")
+
+    def __rtruediv__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "div", reverse=True)
+
+    def __mod__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "mod")
+
+    def __rmod__(self, other: object) -> "UnitSeries":
+        return self._arith(other, "mod", reverse=True)
+
+    def __len__(self) -> int:
+        return len(self._series)
+
+    def __repr__(self) -> str:
+        base = repr(self._series)
+        if self._unit_display == "explicit":
+            return f"{base}\nUnit: {self._unit}"
+        return base
+
+    def __str__(self) -> str:
+        return str(self._series)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._series, name)
+```
+
+Add `import pandas as pd` at the module level (guarded for type checking) or use inline import. Since pint is already imported, just add:
+
+```python
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import pandas as pd
+```
+
+at the top of `units.py`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_units.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/units.py tests/test_units.py
+git commit -m "feat: implement UnitSeries proxy with arithmetic operators"
+```
+
+---
+
+### Task 5: DataFrame Integration — __getitem__ and __setitem__
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py:807-829`
+- Test: `tests/test_unit_integration.py` (new file)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_unit_integration.py`:
+
+```python
+import pandas as pd
+import pytest
+
+from sunstone.dataframe import DataFrame
+from sunstone.units import UnitSeries, parse_unit, set_unit_mode, get_unit_mode
+
+
+class TestGetitemReturnsUnitSeries:
+    def test_column_with_unit_returns_unit_series(self):
+        df = DataFrame(data=pd.DataFrame({"power": [1.0, 2.0, 3.0]}))
+        df.set_field_metadata("power", unit="kW")
+        result = df["power"]
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kW")
+
+    def test_column_without_unit_returns_plain_series(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1, 2, 3]}))
+        result = df["x"]
+        assert not isinstance(result, UnitSeries)
+        assert isinstance(result, pd.Series)
+
+    def test_multi_column_returns_dataframe(self):
+        df = DataFrame(data=pd.DataFrame({"a": [1.0], "b": [2.0]}))
+        df.set_field_metadata("a", unit="kW")
+        result = df[["a", "b"]]
+        assert isinstance(result, DataFrame)
+
+    def test_unit_display_passed_through(self):
+        df = DataFrame(data=pd.DataFrame({"power": [1.0]}))
+        df.unit_display = "explicit"
+        df.set_field_metadata("power", unit="kW")
+        result = df["power"]
+        assert isinstance(result, UnitSeries)
+        assert "kilowatt" in repr(result)
+
+
+class TestSetitemPropagatesUnit:
+    def test_assign_unit_series_sets_field_metadata(self):
+        df = DataFrame(data=pd.DataFrame({"a": [1.0], "b": [2.0]}))
+        df.set_field_metadata("a", unit="watt")
+        df.set_field_metadata("b", unit="hour")
+        set_unit_mode("auto")
+        try:
+            df["energy"] = df["a"] * df["b"]
+        finally:
+            set_unit_mode("relaxed")
+        assert "energy" in df.metadata.field_metadata
+        assert df.metadata.field_metadata["energy"].unit is not None
+
+    def test_assign_plain_series_no_unit(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1, 2]}))
+        df["y"] = pd.Series([3, 4])
+        assert "y" not in df.metadata.field_metadata or df.metadata.field_metadata.get("y") is None or df.metadata.field_metadata.get("y", FieldSchema(name="y")).unit is None
+
+
+class TestSetFieldMetadataValidation:
+    def test_invalid_unit_raises(self):
+        from sunstone.exceptions import UnitError
+
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        with pytest.raises(UnitError, match="Cannot parse unit"):
+            df.set_field_metadata("x", unit="flarbnitz")
+
+    def test_valid_unit_accepted(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        df.set_field_metadata("x", unit="kWh")
+        assert df.metadata.field_metadata["x"].unit == "kWh"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_unit_integration.py::TestGetitemReturnsUnitSeries::test_column_with_unit_returns_unit_series -v`
+Expected: FAIL (returns pd.Series, not UnitSeries)
+
+- [ ] **Step 3: Modify DataFrame.__getitem__**
+
+In `src/sunstone/dataframe.py`, replace `__getitem__`:
+
+```python
+def __getitem__(self, key: Any) -> Any:
+    """
+    Delegate item access to the underlying pandas DataFrame.
+
+    If the key is a single column name with a unit in field metadata,
+    returns a UnitSeries proxy. Otherwise returns a plain Series or
+    wrapped DataFrame.
+    """
+    result = self.data[key]
+    if isinstance(result, pd.Series) and isinstance(key, str):
+        field = self.metadata.field_metadata.get(key)
+        if field and field.unit:
+            from .units import UnitSeries, parse_unit
+
+            unit = parse_unit(field.unit)
+            display = getattr(self, "_unit_display", "transparent")
+            return UnitSeries(result, unit, unit_display=display)
+    return self._wrap_result(result)
+```
+
+- [ ] **Step 4: Modify DataFrame.__setitem__**
+
+In `src/sunstone/dataframe.py`, replace `__setitem__`:
+
+```python
+def __setitem__(self, key: Any, value: Any) -> None:
+    """
+    Delegate item assignment to the underlying pandas DataFrame.
+
+    If value is a UnitSeries, propagates its unit into field_metadata.
+    """
+    from .units import UnitSeries
+
+    if isinstance(value, UnitSeries):
+        self.data[key] = value.series
+        unit_str = str(value.unit)
+        existing = self.metadata.field_metadata.get(key)
+        if existing:
+            existing.unit = unit_str
+        else:
+            from .lineage import FieldSchema
+
+            self.metadata.field_metadata[key] = FieldSchema(name=key, unit=unit_str)
+    else:
+        self.data[key] = value
+```
+
+- [ ] **Step 5: Add unit_display property to DataFrame**
+
+Add after the `custom_properties` property in `src/sunstone/dataframe.py`:
+
+```python
+@property
+def unit_display(self) -> str:
+    """Unit display mode: 'transparent' (default) or 'explicit'."""
+    return getattr(self, "_unit_display", "transparent")
+
+@unit_display.setter
+def unit_display(self, value: str) -> None:
+    self._unit_display = value
+```
+
+- [ ] **Step 6: Add unit validation to set_field_metadata**
+
+In `src/sunstone/dataframe.py`, modify `set_field_metadata` to validate units at set time. Add at the start of the method, before the `existing = ...` line:
+
+```python
+if unit is not None:
+    from .units import parse_unit
+
+    parse_unit(unit)  # raises UnitError if invalid
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `uv run pytest tests/test_unit_integration.py -v`
+Expected: All PASS
+
+- [ ] **Step 8: Run full test suite to check for regressions**
+
+Run: `uv run pytest -v`
+Expected: All PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/sunstone/dataframe.py tests/test_unit_integration.py
+git commit -m "feat: integrate UnitSeries into DataFrame getitem/setitem"
+```
+
+---
+
+### Task 6: DataFrame concat/merge/join Unit Resolution
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py:700-753` (merge, join, concat)
+- Test: `tests/test_unit_integration.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_unit_integration.py`:
+
+```python
+from sunstone.exceptions import UnitError
+
+
+class TestConcatUnits:
+    def setup_method(self):
+        self._original = get_unit_mode()
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_concat_same_units(self):
+        set_unit_mode("auto")
+        df1 = DataFrame(data=pd.DataFrame({"energy": [1.0, 2.0]}))
+        df1.set_field_metadata("energy", unit="kWh")
+        df2 = DataFrame(data=pd.DataFrame({"energy": [3.0, 4.0]}))
+        df2.set_field_metadata("energy", unit="kWh")
+        result = df1.concat([df2], ignore_index=True)
+        assert result.metadata.field_metadata["energy"].unit == "kWh"
+        assert list(result.data["energy"]) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_concat_compatible_units_auto_converts(self):
+        set_unit_mode("auto")
+        df1 = DataFrame(data=pd.DataFrame({"dist": [1.0]}))
+        df1.set_field_metadata("dist", unit="km")
+        df2 = DataFrame(data=pd.DataFrame({"dist": [500.0]}))
+        df2.set_field_metadata("dist", unit="meter")
+        result = df1.concat([df2], ignore_index=True)
+        # meter is finer, so result should be in meters
+        assert result.metadata.field_metadata["dist"].unit == "meter"
+        assert result.data["dist"].iloc[0] == pytest.approx(1000.0)
+        assert result.data["dist"].iloc[1] == pytest.approx(500.0)
+
+    def test_concat_incompatible_units_auto_raises(self):
+        set_unit_mode("auto")
+        df1 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df1.set_field_metadata("x", unit="meter")
+        df2 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df2.set_field_metadata("x", unit="second")
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            df1.concat([df2])
+
+    def test_concat_relaxed_warns(self):
+        import warnings
+
+        set_unit_mode("relaxed")
+        df1 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df1.set_field_metadata("x", unit="meter")
+        df2 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df2.set_field_metadata("x", unit="second")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = df1.concat([df2], ignore_index=True)
+            assert len(w) >= 1
+
+    def test_concat_no_units_passthrough(self):
+        df1 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df2 = DataFrame(data=pd.DataFrame({"x": [2.0]}))
+        result = df1.concat([df2], ignore_index=True)
+        assert list(result.data["x"]) == [1.0, 2.0]
+
+
+class TestMergeUnits:
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_merge_shared_column_compatible_units(self):
+        df1 = DataFrame(data=pd.DataFrame({"id": [1], "val": [1.0]}))
+        df1.set_field_metadata("val", unit="km")
+        df2 = DataFrame(data=pd.DataFrame({"id": [1], "val2": [500.0]}))
+        df2.set_field_metadata("val2", unit="meter")
+        result = df1.merge(df2, on="id")
+        # No shared value columns to convert — just join
+        assert "val" in result.data.columns
+        assert "val2" in result.data.columns
+
+
+class TestJoinUnits:
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_join_preserves_units(self):
+        df1 = DataFrame(data=pd.DataFrame({"a": [1.0]}, index=[0]))
+        df1.set_field_metadata("a", unit="kW")
+        df2 = DataFrame(data=pd.DataFrame({"b": [2.0]}, index=[0]))
+        df2.set_field_metadata("b", unit="hour")
+        result = df1.join(df2)
+        assert result.metadata.field_metadata.get("a") is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_unit_integration.py::TestConcatUnits::test_concat_compatible_units_auto_converts -v`
+Expected: FAIL (no unit conversion happening in concat)
+
+- [ ] **Step 3: Modify concat to resolve units**
+
+Replace the `concat` method in `src/sunstone/dataframe.py`:
+
+```python
+def concat(self, others: List["DataFrame"], **kwargs: Any) -> "DataFrame":
+    """Concatenate with other Sunstone DataFrames, combining lineage and resolving units."""
+    import warnings
+
+    from .units import get_unit_mode, parse_unit, resolve_units
+
+    mode = get_unit_mode()
+
+    # Find shared columns with units that need resolution
+    all_frames = [self] + others
+    shared_cols = set(self.data.columns)
+    for other in others:
+        shared_cols &= set(other.data.columns)
+
+    # Resolve units for shared columns and build conversion info
+    unit_resolutions: dict[str, Any] = {}
+    for col in shared_cols:
+        col_str = str(col)
+        units_by_frame: list[tuple[int, pint.Unit | None]] = []
+        for i, frame in enumerate(all_frames):
+            field = frame.metadata.field_metadata.get(col_str)
+            u = parse_unit(field.unit) if field and field.unit else None
+            units_by_frame.append((i, u))
+
+        # Only resolve if at least two frames have units for this column
+        units_set = [(i, u) for i, u in units_by_frame if u is not None]
+        if len(units_set) >= 2:
+            # Resolve pairwise against the first unit
+            first_idx, first_unit = units_set[0]
+            for other_idx, other_unit in units_set[1:]:
+                resolved = resolve_units(first_unit, other_unit, "concat", mode)
+                if resolved.warning:
+                    warnings.warn(resolved.warning, UserWarning, stacklevel=2)
+                if resolved.convert_a is not None or resolved.convert_b is not None:
+                    unit_resolutions[col_str] = resolved
+
+    # Build data frames with conversions applied
+    all_dfs = []
+    for i, frame in enumerate(all_frames):
+        frame_data = frame.data
+        needs_copy = False
+        for col_str, resolved in unit_resolutions.items():
+            if i == 0 and resolved.convert_a is not None:
+                if not needs_copy:
+                    frame_data = frame_data.copy()
+                    needs_copy = True
+                frame_data[col_str] = frame_data[col_str] * resolved.convert_a
+            elif i > 0 and resolved.convert_b is not None:
+                if not needs_copy:
+                    frame_data = frame_data.copy()
+                    needs_copy = True
+                frame_data[col_str] = frame_data[col_str] * resolved.convert_b
+        all_dfs.append(frame_data)
+
+    concatenated_data = pd.concat(all_dfs, **kwargs)
+
+    combined_lineage = self.metadata.lineage
+    for other in others:
+        combined_lineage = combined_lineage.merge(other.metadata.lineage)
+
+    # Build field metadata with resolved units
+    new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in concatenated_data.columns}
+    for col_str, resolved in unit_resolutions.items():
+        if resolved.result_unit is not None and col_str in new_field_meta:
+            new_field_meta[col_str] = FieldSchema(
+                name=new_field_meta[col_str].name,
+                type=new_field_meta[col_str].type,
+                description=new_field_meta[col_str].description,
+                unit=str(resolved.result_unit),
+                source=new_field_meta[col_str].source,
+                constraints=new_field_meta[col_str].constraints,
+            )
+
+    new_metadata = Metadata(
+        lineage=combined_lineage,
+        description=self.metadata.description,
+        rdf_prefixes=self.metadata.rdf_prefixes,
+        custom_properties=self.metadata.custom_properties,
+        field_metadata=new_field_meta,
+        slug=self.metadata.slug,
+        name=self.metadata.name,
+    )
+    return DataFrame(data=concatenated_data, metadata=new_metadata, strict=self.strict_mode)
+```
+
+Add `import pint` to the imports at the top of `dataframe.py` (or use the already-imported types).
+
+- [ ] **Step 4: Modify merge to validate units on shared columns**
+
+Replace the `merge` method in `src/sunstone/dataframe.py`:
+
+```python
+def merge(self, right: "DataFrame", **kwargs: Any) -> "DataFrame":
+    """Merge with another Sunstone DataFrame, combining lineage and validating units."""
+    import warnings
+
+    from .units import get_unit_mode, parse_unit, resolve_units
+
+    mode = get_unit_mode()
+
+    # Validate units on overlapping value columns (not join keys)
+    left_cols = set(self.data.columns)
+    right_cols = set(right.data.columns)
+    shared = left_cols & right_cols
+
+    # Exclude join key columns from unit validation (they're used for matching, not arithmetic)
+    on_cols = set()
+    if "on" in kwargs:
+        on = kwargs["on"]
+        on_cols = {on} if isinstance(on, str) else set(on)
+
+    for col in shared - on_cols:
+        col_str = str(col)
+        left_field = self.metadata.field_metadata.get(col_str)
+        right_field = right.metadata.field_metadata.get(col_str)
+        left_unit = parse_unit(left_field.unit) if left_field and left_field.unit else None
+        right_unit = parse_unit(right_field.unit) if right_field and right_field.unit else None
+
+        if left_unit is not None and right_unit is not None:
+            resolved = resolve_units(left_unit, right_unit, "concat", mode)
+            if resolved.warning:
+                warnings.warn(resolved.warning, UserWarning, stacklevel=2)
+
+    merged_data = pd.merge(self.data, right.data, **kwargs)
+    merged_lineage = self.metadata.lineage.merge(right.metadata.lineage)
+
+    new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in merged_data.columns}
+    # Also bring in right-side field metadata for columns not in left
+    for k, v in right.metadata.field_metadata.items():
+        if k in merged_data.columns and k not in new_field_meta:
+            new_field_meta[k] = v
+
+    new_metadata = Metadata(
+        lineage=merged_lineage,
+        description=self.metadata.description,
+        rdf_prefixes=self.metadata.rdf_prefixes,
+        custom_properties=self.metadata.custom_properties,
+        field_metadata=new_field_meta,
+        slug=self.metadata.slug,
+        name=self.metadata.name,
+    )
+    return DataFrame(data=merged_data, metadata=new_metadata, strict=self.strict_mode)
+```
+
+- [ ] **Step 5: Modify join to validate units on shared columns**
+
+Replace the `join` method similarly — validate units on overlapping columns, then proceed:
+
+```python
+def join(self, other: "DataFrame", **kwargs: Any) -> "DataFrame":
+    """Join with another Sunstone DataFrame, combining lineage and validating units."""
+    import warnings
+
+    from .units import get_unit_mode, parse_unit, resolve_units
+
+    mode = get_unit_mode()
+
+    # Validate units on overlapping columns
+    left_cols = set(self.data.columns)
+    right_cols = set(other.data.columns)
+    shared = left_cols & right_cols
+
+    for col in shared:
+        col_str = str(col)
+        left_field = self.metadata.field_metadata.get(col_str)
+        right_field = other.metadata.field_metadata.get(col_str)
+        left_unit = parse_unit(left_field.unit) if left_field and left_field.unit else None
+        right_unit = parse_unit(right_field.unit) if right_field and right_field.unit else None
+
+        if left_unit is not None and right_unit is not None:
+            resolved = resolve_units(left_unit, right_unit, "concat", mode)
+            if resolved.warning:
+                warnings.warn(resolved.warning, UserWarning, stacklevel=2)
+
+    joined_data = self.data.join(other.data, **kwargs)
+    joined_lineage = self.metadata.lineage.merge(other.metadata.lineage)
+
+    new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in joined_data.columns}
+    for k, v in other.metadata.field_metadata.items():
+        if k in joined_data.columns and k not in new_field_meta:
+            new_field_meta[k] = v
+
+    new_metadata = Metadata(
+        lineage=joined_lineage,
+        description=self.metadata.description,
+        rdf_prefixes=self.metadata.rdf_prefixes,
+        custom_properties=self.metadata.custom_properties,
+        field_metadata=new_field_meta,
+        slug=self.metadata.slug,
+        name=self.metadata.name,
+    )
+    return DataFrame(data=joined_data, metadata=new_metadata, strict=self.strict_mode)
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `uv run pytest tests/test_unit_integration.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/sunstone/dataframe.py tests/test_unit_integration.py
+git commit -m "feat: add unit resolution to concat/merge/join"
+```
+
+---
+
+### Task 7: FieldSchema unit_source and QUDT Integration
+
+**Files:**
+- Modify: `src/sunstone/lineage.py:56-75` (add unit_source to FieldSchema)
+- Modify: `src/sunstone/datasets.py:35-48` (update serialization)
+- Modify: `src/sunstone/datasets.py:120-132` (update parsing)
+- Modify: `src/sunstone/units.py` (add parse_unit_string with QUDT detection)
+- Test: `tests/test_units.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_units.py`:
+
+```python
+class TestQUDTDetection:
+    def test_is_qudt_uri(self):
+        from sunstone.units import is_qudt_uri
+
+        assert is_qudt_uri("http://qudt.org/vocab/unit/KiloW-HR") is True
+        assert is_qudt_uri("https://qudt.org/vocab/unit/M") is True
+        assert is_qudt_uri("qudt:KiloW-HR") is True
+        assert is_qudt_uri("kWh") is False
+        assert is_qudt_uri("meter / second") is False
+
+    def test_parse_unit_string_pint(self):
+        from sunstone.units import parse_unit_string
+
+        unit, source = parse_unit_string("kWh")
+        assert str(unit) == "kilowatt_hour"
+        assert source is None
+
+    def test_parse_unit_string_qudt_without_ontopint_raises(self):
+        from sunstone.units import parse_unit_string
+
+        # This test works whether or not ontopint is installed —
+        # if it is, we mock it away; if not, the real error is raised
+        import unittest.mock
+
+        with unittest.mock.patch.dict("sys.modules", {"ontopint": None}):
+            with pytest.raises(UnitError, match="QUDT URI.*Install sunstone-py\\[qudt\\]"):
+                parse_unit_string("http://qudt.org/vocab/unit/KiloW-HR")
+
+
+class TestFieldSchemaUnitSource:
+    def test_unit_source_default_none(self):
+        from sunstone.lineage import FieldSchema
+
+        f = FieldSchema(name="x", unit="kWh")
+        assert f.unit_source is None
+
+    def test_unit_source_set(self):
+        from sunstone.lineage import FieldSchema
+
+        f = FieldSchema(name="x", unit="kWh", unit_source="http://qudt.org/vocab/unit/KiloW-HR")
+        assert f.unit_source == "http://qudt.org/vocab/unit/KiloW-HR"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_units.py::TestQUDTDetection -v`
+Expected: FAIL with `ImportError`
+
+- [ ] **Step 3: Add unit_source to FieldSchema**
+
+In `src/sunstone/lineage.py`, add to FieldSchema after `source`:
+
+```python
+unit_source: Optional[str] = None
+"""Original unit string format for round-tripping (e.g. QUDT URI). None means Pint string."""
+```
+
+- [ ] **Step 4: Add QUDT helpers to units.py**
+
+Add to `src/sunstone/units.py`:
+
+```python
+def is_qudt_uri(unit_str: str) -> bool:
+    """Check if a unit string looks like a QUDT URI or prefixed name."""
+    return (
+        unit_str.startswith("http://qudt.org/")
+        or unit_str.startswith("https://qudt.org/")
+        or unit_str.startswith("qudt:")
+    )
+
+
+def parse_unit_string(unit_str: str) -> tuple[pint.Unit, str | None]:
+    """Parse a unit string that may be a Pint string or QUDT URI.
+
+    Args:
+        unit_str: A Pint unit string or QUDT URI.
+
+    Returns:
+        Tuple of (pint.Unit, unit_source). unit_source is the QUDT URI
+        if the input was a URI, or None if it was a plain Pint string.
+
+    Raises:
+        UnitError: If the unit cannot be parsed or QUDT resolution fails.
+    """
+    if is_qudt_uri(unit_str):
+        try:
+            import ontopint
+        except ImportError:
+            raise UnitError(
+                f"Unit '{unit_str}' is a QUDT URI. "
+                f"Install sunstone-py[qudt] to resolve QUDT units."
+            )
+        try:
+            ucum_code = ontopint.get_ucum_code_from_unit_iri(unit_str)
+            unit = ontopint.ureg.Unit(ucum_code)
+            return unit, unit_str
+        except Exception as e:
+            raise UnitError(
+                f"Cannot resolve QUDT unit '{unit_str}': {e}"
+            ) from e
+
+    return parse_unit(unit_str), None
+```
+
+- [ ] **Step 5: Update datasets.py serialization**
+
+In `src/sunstone/datasets.py`, modify `_field_schema_to_dict`:
+
+```python
+def _field_schema_to_dict(field: FieldSchema) -> dict:
+    """Convert a FieldSchema to a dict for YAML serialization, omitting None values."""
+    d: dict = {"name": field.name}
+    if field.type is not None:
+        d["type"] = field.type
+    if field.constraints:
+        d["constraints"] = field.constraints
+    if field.description:
+        d["description"] = field.description
+    if field.unit:
+        # Prefer QUDT URI if original was QUDT
+        d["unit"] = field.unit_source if field.unit_source else field.unit
+    if field.source:
+        d["source"] = field.source
+    return d
+```
+
+- [ ] **Step 6: Update datasets.py parsing**
+
+In `src/sunstone/datasets.py`, modify `_parse_fields` to detect QUDT URIs:
+
+```python
+def _parse_fields(self, fields_data: List[Dict[str, Any]]) -> List[FieldSchema]:
+    """Parse field schema data from YAML."""
+    from .units import is_qudt_uri, parse_unit_string
+
+    result = []
+    for field in fields_data:
+        unit_str = field.get("unit")
+        unit_value = unit_str
+        unit_source = None
+
+        if unit_str and is_qudt_uri(unit_str):
+            try:
+                pint_unit, unit_source = parse_unit_string(unit_str)
+                unit_value = str(pint_unit)
+            except Exception:
+                # Store as-is if we can't resolve; will fail at arithmetic time
+                unit_value = unit_str
+                unit_source = unit_str
+
+        result.append(
+            FieldSchema(
+                name=field["name"],
+                type=field["type"],
+                constraints=field.get("constraints"),
+                description=field.get("description"),
+                unit=unit_value,
+                source=field.get("source"),
+                unit_source=unit_source,
+            )
+        )
+    return result
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `uv run pytest tests/test_units.py tests/test_unit_integration.py -v`
+Expected: All PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: All PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/sunstone/lineage.py src/sunstone/datasets.py src/sunstone/units.py tests/test_units.py
+git commit -m "feat: add QUDT URI detection and unit_source round-tripping"
+```
+
+---
+
+### Task 8: Export Public API and Update CHANGELOG
+
+**Files:**
+- Modify: `src/sunstone/__init__.py` (export units API)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Write failing test for public API**
+
+Append to `tests/test_units.py`:
+
+```python
+class TestPublicAPI:
+    def test_unit_error_from_sunstone(self):
+        from sunstone import UnitError
+
+        assert UnitError is not None
+
+    def test_unit_series_from_sunstone_units(self):
+        from sunstone.units import UnitSeries
+
+        assert UnitSeries is not None
+
+    def test_set_unit_mode_from_sunstone_units(self):
+        from sunstone.units import set_unit_mode, get_unit_mode
+
+        assert callable(set_unit_mode)
+        assert callable(get_unit_mode)
+
+    def test_parse_unit_from_sunstone_units(self):
+        from sunstone.units import parse_unit
+
+        assert callable(parse_unit)
+```
+
+- [ ] **Step 2: Run test — should already pass**
+
+Run: `uv run pytest tests/test_units.py::TestPublicAPI -v`
+Expected: PASS (already exported from Task 1)
+
+- [ ] **Step 3: Ensure UnitError in __init__.py exports**
+
+Verify `UnitError` is in both the import and `__all__` in `src/sunstone/__init__.py`.
+
+- [ ] **Step 4: Update CHANGELOG.md**
+
+Add to the `[Unreleased]` section:
+
+```markdown
+- Added: Unit-aware arithmetic with Pint integration (`sunstone.units`)
+- Added: `UnitSeries` proxy for column-level unit tracking
+- Added: Unit handling modes — relaxed (default), strict, auto (`set_unit_mode()` / `SUNSTONE_UNIT_MODE`)
+- Added: QUDT URI detection and round-tripping via ontopint (`sunstone-py[qudt]`)
+- Added: Unit validation in `set_field_metadata(unit=...)`
+- Added: Unit resolution in `concat()`, `merge()`, `join()`
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/__init__.py CHANGELOG.md
+git commit -m "feat: export unit-aware arithmetic public API and update changelog"
+```

--- a/docs/superpowers/specs/2026-04-10-unit-aware-arithmetic-design.md
+++ b/docs/superpowers/specs/2026-04-10-unit-aware-arithmetic-design.md
@@ -1,0 +1,215 @@
+# Unit-Aware Arithmetic for Sunstone DataFrame
+
+**Date:** 2026-04-10
+**Status:** Approved
+
+## Overview
+
+Add unit-aware arithmetic to Sunstone's DataFrame wrapper. When columns have units declared in field metadata, arithmetic operations validate dimensional compatibility, convert between scales, and track result units automatically. Uses Pint as the unit engine, with ontopint for QUDT/RDF interop.
+
+## Design Decisions
+
+- **Unit library:** Pint (primary), with unyt available for performance-sensitive numpy paths later
+- **QUDT support:** via ontopint, optional dependency (`sunstone-py[qudt]`)
+- **Unit string format:** Auto-detect at parse time. If the string is a URI, resolve via ontopint. Otherwise parse as Pint string. Serialize back in the original format (QUDT URI stays QUDT, Pint string stays Pint string).
+- **Unit handling mode:** Global setting (`sunstone.units.set_unit_mode(mode)` and `SUNSTONE_UNIT_MODE` env var) with three modes:
+  - `relaxed` (default): Warn on incompatible operations via `warnings.warn()`, but proceed with pandas passthrough. Units tracked in metadata but never enforced.
+  - `strict`: Raise `UnitError` on incompatible operations. No automatic conversion — both operands must have the same unit for add/sub/concat.
+  - `auto`: Automatically convert compatible units (e.g. kWh→TWh), raise `UnitError` only when conversion is impossible (incompatible dimensions).
+- **Permissive when one side has no unit:** Both units set = enforce per mode rules. One unit set = treat the other as dimensionless. Neither set = pure pandas passthrough.
+- **Interception point:** UnitSeries proxy wrapping individual columns, not DataFrame-level or pint-pandas dtypes.
+- **Display:** Configurable via `unit_display` kwarg on DataFrame. `'transparent'` (default) hides units from repr. `'explicit'` shows them.
+- **Granularity on add/sub/concat:** Convert to the unit with smaller base-equivalent magnitude (finer granularity) to preserve precision.
+
+## Components
+
+### 1. `src/sunstone/units.py` — Unit Registry and Resolution
+
+**Shared UnitRegistry singleton:**
+
+A single `pint.UnitRegistry` instance used across the library. All unit parsing goes through this registry (Pint requires quantities from the same registry to interact).
+
+```python
+import pint
+
+ureg = pint.UnitRegistry()
+Q_ = ureg.Quantity
+```
+
+**`resolve_units()` function:**
+
+```python
+def resolve_units(
+    unit_a: pint.Unit | None,
+    unit_b: pint.Unit | None,
+    operation: Literal["add", "sub", "mul", "div", "mod", "concat"],
+    mode: Literal["relaxed", "strict", "auto"] = "relaxed",
+) -> ResolvedUnits:
+    ...
+```
+
+Returns a `ResolvedUnits` dataclass:
+
+```python
+@dataclass
+class ResolvedUnits:
+    result_unit: pint.Unit | None
+    convert_a: float | None  # multiply a's values by this (None = no conversion)
+    convert_b: float | None  # multiply b's values by this (None = no conversion)
+    warning: str | None       # non-None in relaxed mode when an issue is detected
+```
+
+**Resolution rules (common to all modes):**
+
+| unit_a | unit_b | Operation | Result |
+|--------|--------|-----------|--------|
+| None | None | any | None (pandas passthrough) |
+| None | set | mul/div/mod | treat None as dimensionless (result keeps the set unit for mul, inverse for div) |
+| set | None | mul/div/mod | treat None as dimensionless (result keeps the set unit for mul, inverse for div) |
+| None | set | add/sub/concat | no unit enforcement (result inherits the set unit, no conversion applied) |
+| set | None | add/sub/concat | no unit enforcement (result inherits the set unit, no conversion applied) |
+| set | set | mul | `unit_a * unit_b` |
+| set | set | div | `unit_a / unit_b` |
+| set | set | mod | `unit_a` (modulo preserves dividend's unit) |
+
+**Mode-specific behavior for add/sub/concat when both units are set:**
+
+| Scenario | `relaxed` | `strict` | `auto` |
+|----------|-----------|----------|--------|
+| Same unit (kWh + kWh) | passthrough, result_unit=unit_a | passthrough, result_unit=unit_a | passthrough, result_unit=unit_a |
+| Same dimension, different scale (kWh + TWh) | warn, passthrough (no conversion) | raise `UnitError` | convert to finer-granularity unit |
+| Incompatible dimensions (meter + second) | warn, passthrough (no conversion) | raise `UnitError` | raise `UnitError` |
+
+**Finer-granularity selection (auto mode only):** Compare conversion factors to shared SI base units. The unit with the smaller factor is finer (e.g. kWh = 3.6e6 J vs TWh = 3.6e15 J, kWh wins).
+
+**Global mode setting:**
+
+```python
+# Module-level in units.py
+_unit_mode: Literal["relaxed", "strict", "auto"] = "relaxed"
+
+def set_unit_mode(mode: Literal["relaxed", "strict", "auto"]) -> None: ...
+def get_unit_mode() -> Literal["relaxed", "strict", "auto"]: ...
+```
+
+At import time, reads `SUNSTONE_UNIT_MODE` env var if set. `set_unit_mode()` overrides for the process.
+
+### 2. `UnitSeries` Proxy
+
+Returned by `DataFrame.__getitem__` when the column has a unit in field metadata.
+
+**Properties:**
+- `.unit: pint.Unit` — the column's unit
+- `.series: pd.Series` — the underlying pandas Series
+- Delegates all non-overridden attribute access to the inner Series
+
+**Arithmetic dunders overridden:**
+- `__add__`, `__radd__`, `__sub__`, `__rsub__`
+- `__mul__`, `__rmul__`, `__truediv__`, `__rtruediv__`, `__mod__`, `__rmod__`
+
+Each dunder:
+1. Extracts the other operand's unit (from `UnitSeries.unit`, or None if plain Series/scalar)
+2. Calls `resolve_units(self.unit, other_unit, operation)`
+3. Applies conversion factors if needed
+4. Delegates numeric computation to pandas
+5. Returns a new `UnitSeries` with the result unit
+
+**Scalar operands:** Treated as dimensionless. `df['power'] * 1000` keeps the power unit for mul, raises on add/sub if the unit isn't dimensionless.
+
+**Display modes:**
+- `transparent` (default): Standard pandas repr. Unit only via `.unit`.
+- `explicit`: Appends footer line, e.g. `Unit: kilowatt_hour`.
+
+**Escape hatch:** `.values`, `.to_numpy()`, `.data` return raw arrays, dropping unit tracking.
+
+**Non-arithmetic operations** (comparison, boolean, string methods) pass through to the inner Series and return plain pandas results.
+
+### 3. DataFrame Integration
+
+**`__getitem__`:** After existing wrapping, check `self.metadata.field_metadata[col].unit`. If present, parse via `ureg` and return `UnitSeries`. Multi-column selection returns DataFrame as today.
+
+**`__setitem__`:** When assigning a `UnitSeries`, propagate its `.unit` into `field_metadata` for that column automatically.
+
+**`concat()`:** Before delegating to pandas, iterate shared columns. For each with units in multiple DataFrames, call `resolve_units(..., 'concat')`. Convert data as needed, then concat. Update result field metadata with the winning unit.
+
+**`merge()` / `join()`:** Same unit validation pattern on shared/join-key columns.
+
+**`set_field_metadata(unit=...)`:** Parse the string through `ureg` at set time to fail fast on invalid units.
+
+**New property:** `unit_display: str` — `'transparent'` (default) or `'explicit'`. Passed to `UnitSeries` on construction. Settable.
+
+### 4. QUDT / ontopint Integration
+
+**`FieldSchema` change:** Add `unit_source: str | None` to track the original format of the unit string (QUDT URI or Pint string).
+
+**Read path** (in `datasets.py` field parsing):
+1. If unit string looks like a URI → resolve via ontopint to Pint unit, store URI in `unit_source`
+2. Otherwise → parse as Pint string, `unit_source = None`
+
+**Write path** (in `_field_schema_to_dict()`):
+1. If `unit_source` is a QUDT URI → serialize as that URI
+2. If output column declared in datasets.yaml with a QUDT URI → use that
+3. Otherwise → serialize as Pint string
+
+**Dependencies:**
+- `pint` — core dependency
+- `ontopint` — optional extra via `sunstone-py[qudt]`
+- Missing ontopint with QUDT URI → clear error message
+
+**No network calls at arithmetic time.** QUDT resolution only at read/write boundaries.
+
+### 5. Error Handling
+
+New exception: `UnitError(SunstoneError)`
+
+**Errors (raised in `strict` and `auto` modes, warned in `relaxed`):**
+
+| Scenario | Message |
+|----------|---------|
+| Incompatible dimensions on add/sub/concat | `Cannot add 'meter' to 'second': incompatible dimensions [length] vs [time]` |
+| Same dimension, different scale (strict only) | `Cannot add 'kWh' to 'TWh': units differ. Use auto mode for automatic conversion.` |
+
+**Errors (raised in all modes — these are configuration errors, not data errors):**
+
+| Scenario | Message |
+|----------|---------|
+| Unparseable unit string | `Cannot parse unit 'flarbnitz': unknown unit` |
+| QUDT URI without ontopint | `Unit 'http://qudt.org/...' is a QUDT URI. Install sunstone-py[qudt] to resolve it.` |
+| QUDT URI ontopint can't resolve | `Cannot resolve QUDT unit 'http://qudt.org/.../Foo': no UCUM mapping found` |
+
+In `relaxed` mode, incompatible operations produce a `UserWarning` and proceed with pandas passthrough. Configuration errors always raise regardless of mode.
+
+## Testing
+
+**`tests/test_units.py` — Unit tests:**
+- `resolve_units()` — all rule table combinations
+- `UnitSeries` arithmetic — all dunders with unit+unit, unit+None, None+unit, unit+scalar
+- Reverse ops (`5 * df['power']`)
+- Display modes (transparent vs explicit repr)
+- `.unit` property access
+
+**`tests/test_unit_integration.py` — Integration tests:**
+- `__getitem__` returns `UnitSeries` when unit set, plain Series when not
+- `__setitem__` propagates unit to field metadata
+- `concat()` with matching, compatible-different, and incompatible units
+- `merge()` / `join()` unit validation
+- Round-trip: set units → arithmetic → write → read → units preserved
+- QUDT URI parsing and serialization
+
+**Error case tests:**
+- Incompatible dimensions raise `UnitError`
+- Bad unit strings raise `UnitError`
+- QUDT without ontopint raises helpful `UnitError`
+
+## Dependencies
+
+```toml
+# pyproject.toml
+dependencies = [
+    # ... existing ...
+    "pint>=0.24",
+]
+
+[project.optional-dependencies]
+qudt = ["ontopint>=0.1"]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,14 @@ dependencies = [
     "pyyaml>=6.0",
     "ruamel-yaml>=0.18",
     "pyarrow>=23.0.1",
+    "tomli-w>=1.2.0",
+    "pint>=0.24",
 ]
 
 [project.optional-dependencies]
 gcs = ["google-cloud-storage>=2.0"]
 s3 = ["boto3>=1.28"]
+qudt = ["ontopint>=0.1"]
 
 [project.license]
 text = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ exclude = [
 ]
 overrides = [
     { module = "tests.*", disallow_untyped_defs = false },
+    { module = "ontopint", ignore_missing_imports = true },
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/check-ruff-version.sh
+++ b/scripts/check-ruff-version.sh
@@ -1,26 +1,43 @@
 #!/usr/bin/env bash
-# Ensure ruff version in uv.lock matches .pre-commit-config.yaml
+# Ensure tool versions in uv.lock match .pre-commit-config.yaml
 
 set -euo pipefail
 
-lock_version=$(tomlq -r '.package[] | select(.name == "ruff") | .version' uv.lock)
-precommit_version=$(yq '.repos[] | select(.repo == "*ruff*") | .rev' .pre-commit-config.yaml | sed 's/^v//')
+status=0
 
-if [ -z "$lock_version" ]; then
-    echo "ERROR: Could not find ruff version in uv.lock"
-    exit 1
-fi
+check_version() {
+    local name=$1
+    local repo_pattern=$2
 
-if [ -z "$precommit_version" ]; then
-    echo "ERROR: Could not find ruff version in .pre-commit-config.yaml"
-    exit 1
-fi
+    local lock_version
+    lock_version=$(tomlq -r ".package[] | select(.name == \"$name\") | .version" uv.lock)
 
-if [ "$lock_version" != "$precommit_version" ]; then
-    echo "ERROR: ruff version mismatch!"
-    echo "  uv.lock:                 $lock_version"
-    echo "  .pre-commit-config.yaml: $precommit_version"
-    echo ""
-    echo "Update .pre-commit-config.yaml rev to v$lock_version"
-    exit 1
-fi
+    local precommit_version
+    precommit_version=$(yq ".repos[] | select(.repo == \"*${repo_pattern}*\") | .rev" .pre-commit-config.yaml | sed 's/^v//')
+
+    if [ -z "$lock_version" ]; then
+        echo "ERROR: Could not find $name version in uv.lock"
+        status=1
+        return
+    fi
+
+    if [ -z "$precommit_version" ]; then
+        echo "ERROR: Could not find $name version in .pre-commit-config.yaml"
+        status=1
+        return
+    fi
+
+    if [ "$lock_version" != "$precommit_version" ]; then
+        echo "ERROR: $name version mismatch!"
+        echo "  uv.lock:                 $lock_version"
+        echo "  .pre-commit-config.yaml: $precommit_version"
+        echo "  Update .pre-commit-config.yaml rev to v$lock_version"
+        echo ""
+        status=1
+    fi
+}
+
+check_version "ruff" "ruff-pre-commit"
+check_version "mypy" "mirrors-mypy"
+
+exit $status

--- a/scripts/check-ruff-version.sh
+++ b/scripts/check-ruff-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Ensure ruff version in uv.lock matches .pre-commit-config.yaml
+
+set -euo pipefail
+
+lock_version=$(tomlq -r '.package[] | select(.name == "ruff") | .version' uv.lock)
+precommit_version=$(yq '.repos[] | select(.repo == "*ruff*") | .rev' .pre-commit-config.yaml | sed 's/^v//')
+
+if [ -z "$lock_version" ]; then
+    echo "ERROR: Could not find ruff version in uv.lock"
+    exit 1
+fi
+
+if [ -z "$precommit_version" ]; then
+    echo "ERROR: Could not find ruff version in .pre-commit-config.yaml"
+    exit 1
+fi
+
+if [ "$lock_version" != "$precommit_version" ]; then
+    echo "ERROR: ruff version mismatch!"
+    echo "  uv.lock:                 $lock_version"
+    echo "  .pre-commit-config.yaml: $precommit_version"
+    echo ""
+    echo "Update .pre-commit-config.yaml rev to v$lock_version"
+    exit 1
+fi

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -33,6 +33,7 @@ from .exceptions import (
     LineageError,
     StrictModeError,
     SunstoneError,
+    UnitError,
 )
 from .lineage import (
     Contributor,
@@ -100,6 +101,7 @@ __all__ = [
     "DatasetValidationError",
     "StrictModeError",
     "LineageError",
+    "UnitError",
     # Context and session
     "ExecutionContext",
     "detect_execution_context",

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -171,10 +171,10 @@ class DataFrame:
             self, for method chaining.
         """
         if unit is not None:
-            from .units import get_unit_mode, parse_unit
+            from .units import get_unit_mode, parse_unit_string
 
             if get_unit_mode() != "relaxed":
-                parse_unit(unit)  # raises UnitError if invalid in strict/auto mode
+                parse_unit_string(unit)  # raises UnitError if invalid in strict/auto mode
 
         existing = self.metadata.field_metadata.get(column)
         if existing:

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -719,7 +719,7 @@ class DataFrame:
         Validates unit compatibility on overlapping value columns (not join keys)
         and brings in right-side field metadata for columns not already in left.
         """
-        from .units import parse_unit, resolve_units
+        from .units import resolve_units, try_parse_unit
 
         merged_data = pd.merge(self.data, right.data, **kwargs)
         merged_lineage = self.metadata.lineage.merge(right.metadata.lineage)
@@ -744,8 +744,10 @@ class DataFrame:
             left_field = self.metadata.field_metadata.get(col)
             right_field = right.metadata.field_metadata.get(col)
             if left_field and left_field.unit and right_field and right_field.unit:
-                left_unit = parse_unit(left_field.unit)
-                right_unit = parse_unit(right_field.unit)
+                left_unit = try_parse_unit(left_field.unit)
+                right_unit = try_parse_unit(right_field.unit)
+                if left_unit is None or right_unit is None:
+                    continue
                 resolved = resolve_units(left_unit, right_unit, "add")
                 if resolved.warning:
                     warnings.warn(resolved.warning, stacklevel=2)
@@ -773,7 +775,7 @@ class DataFrame:
         Validates unit compatibility on overlapping columns and brings in
         right-side field metadata for columns not already in left.
         """
-        from .units import parse_unit, resolve_units
+        from .units import resolve_units, try_parse_unit
 
         joined_data = self.data.join(other.data, **kwargs)
         joined_lineage = self.metadata.lineage.merge(other.metadata.lineage)
@@ -784,8 +786,10 @@ class DataFrame:
             left_field = self.metadata.field_metadata.get(col)
             right_field = other.metadata.field_metadata.get(col)
             if left_field and left_field.unit and right_field and right_field.unit:
-                left_unit = parse_unit(left_field.unit)
-                right_unit = parse_unit(right_field.unit)
+                left_unit = try_parse_unit(left_field.unit)
+                right_unit = try_parse_unit(right_field.unit)
+                if left_unit is None or right_unit is None:
+                    continue
                 resolved = resolve_units(left_unit, right_unit, "add")
                 if resolved.warning:
                     warnings.warn(resolved.warning, stacklevel=2)
@@ -814,7 +818,7 @@ class DataFrame:
         with units in multiple DataFrames, calls resolve_units to check
         compatibility and apply conversions in auto mode.
         """
-        from .units import parse_unit, resolve_units
+        from .units import resolve_units, try_parse_unit
 
         all_frames = [self] + others
 
@@ -829,7 +833,7 @@ class DataFrame:
         resolved_units_map: dict[str, str] = {}  # col -> winning unit string
 
         for col in all_columns:
-            # Find the first frame with a unit for this column
+            # Find the first frame with a parseable unit for this column
             ref_unit = None
             ref_unit_str: str | None = None
             ref_idx = None
@@ -837,10 +841,12 @@ class DataFrame:
                 if col in frame.data.columns:
                     field = frame.metadata.field_metadata.get(col)
                     if field and field.unit:
-                        ref_unit = parse_unit(field.unit)
-                        ref_unit_str = field.unit
-                        ref_idx = i
-                        break
+                        parsed = try_parse_unit(field.unit)
+                        if parsed is not None:
+                            ref_unit = parsed
+                            ref_unit_str = field.unit
+                            ref_idx = i
+                            break
 
             if ref_unit is None:
                 continue
@@ -856,7 +862,9 @@ class DataFrame:
                 if not (field and field.unit):
                     continue
 
-                other_unit = parse_unit(field.unit)
+                other_unit = try_parse_unit(field.unit)
+                if other_unit is None:
+                    continue
                 resolved = resolve_units(winner_unit, other_unit, "concat")
 
                 if resolved.warning:
@@ -902,6 +910,7 @@ class DataFrame:
         for col, unit_str in resolved_units_map.items():
             if col in new_field_meta:
                 new_field_meta[col].unit = unit_str
+                new_field_meta[col].unit_source = None  # clear stale QUDT URI
             elif col in concatenated_data.columns:
                 new_field_meta[col] = FieldSchema(name=col, unit=unit_str)
 
@@ -982,11 +991,12 @@ class DataFrame:
         if isinstance(result, pd.Series) and isinstance(key, str):
             field = self.metadata.field_metadata.get(key)
             if field and field.unit:
-                from .units import UnitSeries, parse_unit
+                from .units import UnitSeries, try_parse_unit
 
-                unit = parse_unit(field.unit)
-                display: str = getattr(self, "_unit_display", "transparent")
-                return UnitSeries(result, unit, unit_display=display)  # type: ignore[arg-type]
+                unit = try_parse_unit(field.unit)
+                if unit is not None:
+                    display: str = getattr(self, "_unit_display", "transparent")
+                    return UnitSeries(result, unit, unit_display=display)  # type: ignore[arg-type]
         return self._wrap_result(result)
 
     def __setitem__(self, key: Any, value: Any) -> None:
@@ -1005,6 +1015,7 @@ class DataFrame:
             existing = self.metadata.field_metadata.get(key)
             if existing:
                 existing.unit = unit_str
+                existing.unit_source = None  # clear stale QUDT URI
             else:
                 self.metadata.field_metadata[key] = FieldSchema(name=key, unit=unit_str)
         else:

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -137,6 +137,15 @@ class DataFrame:
     def custom_properties(self, value: Optional[Dict[str, Any]]) -> None:
         self.metadata.custom_properties = value
 
+    @property
+    def unit_display(self) -> str:
+        """Unit display mode: 'transparent' (default) or 'explicit'."""
+        return getattr(self, "_unit_display", "transparent")
+
+    @unit_display.setter
+    def unit_display(self, value: str) -> None:
+        self._unit_display = value
+
     def set_field_metadata(
         self,
         column: str,
@@ -160,6 +169,12 @@ class DataFrame:
         Returns:
             self, for method chaining.
         """
+        if unit is not None:
+            from .units import get_unit_mode, parse_unit
+
+            if get_unit_mode() != "relaxed":
+                parse_unit(unit)  # raises UnitError if invalid in strict/auto mode
+
         existing = self.metadata.field_metadata.get(column)
         if existing:
             if description is not None:
@@ -815,6 +830,14 @@ class DataFrame:
             The item from the underlying DataFrame, wrapped if it's a DataFrame.
         """
         result = self.data[key]
+        if isinstance(result, pd.Series) and isinstance(key, str):
+            field = self.metadata.field_metadata.get(key)
+            if field and field.unit:
+                from .units import UnitSeries, parse_unit
+
+                unit = parse_unit(field.unit)
+                display: str = getattr(self, "_unit_display", "transparent")
+                return UnitSeries(result, unit, unit_display=display)  # type: ignore[arg-type]
         return self._wrap_result(result)
 
     def __setitem__(self, key: Any, value: Any) -> None:
@@ -825,7 +848,18 @@ class DataFrame:
             key: Index key.
             value: Value to assign.
         """
-        self.data[key] = value
+        from .units import UnitSeries
+
+        if isinstance(value, UnitSeries):
+            self.data[key] = value.series
+            unit_str = str(value.unit)
+            existing = self.metadata.field_metadata.get(key)
+            if existing:
+                existing.unit = unit_str
+            else:
+                self.metadata.field_metadata[key] = FieldSchema(name=key, unit=unit_str)
+        else:
+            self.data[key] = value
         # Don't track column assignments automatically
         # Users should use add_operation() for meaningful transformations
 

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -713,11 +713,48 @@ class DataFrame:
         return fields
 
     def merge(self, right: "DataFrame", **kwargs: Any) -> "DataFrame":
-        """Merge with another Sunstone DataFrame, combining lineage."""
+        """Merge with another Sunstone DataFrame, combining lineage.
+
+        Validates unit compatibility on overlapping value columns (not join keys)
+        and brings in right-side field metadata for columns not already in left.
+        """
+        from .units import parse_unit, resolve_units
+
         merged_data = pd.merge(self.data, right.data, **kwargs)
         merged_lineage = self.metadata.lineage.merge(right.metadata.lineage)
 
+        # Determine join keys to exclude from unit validation
+        on = kwargs.get("on")
+        left_on = kwargs.get("left_on")
+        right_on = kwargs.get("right_on")
+        join_keys: set[str] = set()
+        if on is not None:
+            join_keys = {on} if isinstance(on, str) else set(on)
+        if left_on is not None:
+            join_keys |= {left_on} if isinstance(left_on, str) else set(left_on)
+        if right_on is not None:
+            join_keys |= {right_on} if isinstance(right_on, str) else set(right_on)
+
+        # Validate units on overlapping value columns
+        left_cols = set(self.data.columns) - join_keys
+        right_cols = set(right.data.columns) - join_keys
+        overlap = left_cols & right_cols
+        for col in overlap:
+            left_field = self.metadata.field_metadata.get(col)
+            right_field = right.metadata.field_metadata.get(col)
+            if left_field and left_field.unit and right_field and right_field.unit:
+                left_unit = parse_unit(left_field.unit)
+                right_unit = parse_unit(right_field.unit)
+                resolved = resolve_units(left_unit, right_unit, "add")
+                if resolved.warning:
+                    warnings.warn(resolved.warning, stacklevel=2)
+
+        # Build field metadata: left first, then right for columns not in left
         new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in merged_data.columns}
+        for k, v in right.metadata.field_metadata.items():
+            if k in merged_data.columns and k not in new_field_meta:
+                new_field_meta[k] = v
+
         new_metadata = Metadata(
             lineage=merged_lineage,
             description=self.metadata.description,
@@ -730,11 +767,34 @@ class DataFrame:
         return DataFrame(data=merged_data, metadata=new_metadata, strict=self.strict_mode)
 
     def join(self, other: "DataFrame", **kwargs: Any) -> "DataFrame":
-        """Join with another Sunstone DataFrame, combining lineage."""
+        """Join with another Sunstone DataFrame, combining lineage.
+
+        Validates unit compatibility on overlapping columns and brings in
+        right-side field metadata for columns not already in left.
+        """
+        from .units import parse_unit, resolve_units
+
         joined_data = self.data.join(other.data, **kwargs)
         joined_lineage = self.metadata.lineage.merge(other.metadata.lineage)
 
+        # Validate units on overlapping columns
+        overlap = set(self.data.columns) & set(other.data.columns)
+        for col in overlap:
+            left_field = self.metadata.field_metadata.get(col)
+            right_field = other.metadata.field_metadata.get(col)
+            if left_field and left_field.unit and right_field and right_field.unit:
+                left_unit = parse_unit(left_field.unit)
+                right_unit = parse_unit(right_field.unit)
+                resolved = resolve_units(left_unit, right_unit, "add")
+                if resolved.warning:
+                    warnings.warn(resolved.warning, stacklevel=2)
+
+        # Build field metadata: left first, then right for columns not in left
         new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in joined_data.columns}
+        for k, v in other.metadata.field_metadata.items():
+            if k in joined_data.columns and k not in new_field_meta:
+                new_field_meta[k] = v
+
         new_metadata = Metadata(
             lineage=joined_lineage,
             description=self.metadata.description,
@@ -747,15 +807,101 @@ class DataFrame:
         return DataFrame(data=joined_data, metadata=new_metadata, strict=self.strict_mode)
 
     def concat(self, others: List["DataFrame"], **kwargs: Any) -> "DataFrame":
-        """Concatenate with other Sunstone DataFrames, combining lineage."""
-        all_dfs = [self.data] + [df.data for df in others]
-        concatenated_data = pd.concat(all_dfs, **kwargs)
+        """Concatenate with other Sunstone DataFrames, combining lineage.
+
+        Before delegating to pandas, iterates shared columns. For each column
+        with units in multiple DataFrames, calls resolve_units to check
+        compatibility and apply conversions in auto mode.
+        """
+        from .units import parse_unit, resolve_units
+
+        all_frames = [self] + others
+
+        # Collect all column names across frames
+        all_columns: set[str] = set()
+        for frame in all_frames:
+            all_columns |= set(frame.data.columns)
+
+        # Track resolved units and conversion factors per frame per column
+        # We work on copies of the data to avoid mutating originals
+        data_copies = [frame.data.copy() for frame in all_frames]
+        resolved_units_map: dict[str, str] = {}  # col -> winning unit string
+
+        for col in all_columns:
+            # Find the first frame with a unit for this column
+            ref_unit = None
+            ref_unit_str: str | None = None
+            ref_idx = None
+            for i, frame in enumerate(all_frames):
+                if col in frame.data.columns:
+                    field = frame.metadata.field_metadata.get(col)
+                    if field and field.unit:
+                        ref_unit = parse_unit(field.unit)
+                        ref_unit_str = field.unit
+                        ref_idx = i
+                        break
+
+            if ref_unit is None:
+                continue
+
+            # Resolve against all subsequent frames with units for this column
+            winner_unit = ref_unit
+            winner_unit_str = ref_unit_str
+            conversion_happened = False
+            for i, frame in enumerate(all_frames):
+                if i == ref_idx or col not in frame.data.columns:
+                    continue
+                field = frame.metadata.field_metadata.get(col)
+                if not (field and field.unit):
+                    continue
+
+                other_unit = parse_unit(field.unit)
+                resolved = resolve_units(winner_unit, other_unit, "concat")
+
+                if resolved.warning:
+                    warnings.warn(resolved.warning, stacklevel=2)
+
+                # Apply conversions if auto mode produced them
+                if resolved.convert_a is not None:
+                    conversion_happened = True
+                    # Convert all previous frames that used winner_unit
+                    for j in range(i):
+                        if col in data_copies[j].columns:
+                            f = all_frames[j].metadata.field_metadata.get(col)
+                            if f and f.unit:
+                                data_copies[j][col] = data_copies[j][col] * resolved.convert_a
+
+                if resolved.convert_b is not None:
+                    conversion_happened = True
+                    data_copies[i][col] = data_copies[i][col] * resolved.convert_b
+
+                if resolved.result_unit is not None:
+                    if resolved.result_unit != winner_unit:
+                        conversion_happened = True
+                        winner_unit_str = field.unit
+                    winner_unit = resolved.result_unit
+
+            # Use original string if no conversion happened, otherwise pint's canonical form
+            if conversion_happened:
+                resolved_units_map[col] = str(winner_unit)
+            else:
+                assert winner_unit_str is not None
+                resolved_units_map[col] = winner_unit_str
+
+        concatenated_data = pd.concat(data_copies, **kwargs)
 
         combined_lineage = self.metadata.lineage
         for other in others:
             combined_lineage = combined_lineage.merge(other.metadata.lineage)
 
+        # Build field metadata, updating units to resolved values
         new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in concatenated_data.columns}
+        for col, unit_str in resolved_units_map.items():
+            if col in new_field_meta:
+                new_field_meta[col].unit = unit_str
+            elif col in concatenated_data.columns:
+                new_field_meta[col] = FieldSchema(name=col, unit=unit_str)
+
         new_metadata = Metadata(
             lineage=combined_lineage,
             description=self.metadata.description,

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -4,6 +4,7 @@ DataFrame wrapper with lineage tracking for Sunstone projects.
 
 import os
 import warnings
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -750,10 +751,10 @@ class DataFrame:
                     warnings.warn(resolved.warning, stacklevel=2)
 
         # Build field metadata: left first, then right for columns not in left
-        new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in merged_data.columns}
+        new_field_meta = {k: replace(v) for k, v in self.metadata.field_metadata.items() if k in merged_data.columns}
         for k, v in right.metadata.field_metadata.items():
             if k in merged_data.columns and k not in new_field_meta:
-                new_field_meta[k] = v
+                new_field_meta[k] = replace(v)
 
         new_metadata = Metadata(
             lineage=merged_lineage,
@@ -790,10 +791,10 @@ class DataFrame:
                     warnings.warn(resolved.warning, stacklevel=2)
 
         # Build field metadata: left first, then right for columns not in left
-        new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in joined_data.columns}
+        new_field_meta = {k: replace(v) for k, v in self.metadata.field_metadata.items() if k in joined_data.columns}
         for k, v in other.metadata.field_metadata.items():
             if k in joined_data.columns and k not in new_field_meta:
-                new_field_meta[k] = v
+                new_field_meta[k] = replace(v)
 
         new_metadata = Metadata(
             lineage=joined_lineage,
@@ -895,7 +896,9 @@ class DataFrame:
             combined_lineage = combined_lineage.merge(other.metadata.lineage)
 
         # Build field metadata, updating units to resolved values
-        new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in concatenated_data.columns}
+        new_field_meta = {
+            k: replace(v) for k, v in self.metadata.field_metadata.items() if k in concatenated_data.columns
+        }
         for col, unit_str in resolved_units_map.items():
             if col in new_field_meta:
                 new_field_meta[col].unit = unit_str
@@ -919,7 +922,7 @@ class DataFrame:
         Copies all metadata, dropping field_metadata for columns no longer present.
         """
         if isinstance(result, pd.DataFrame):
-            new_field_meta = {k: v for k, v in self.metadata.field_metadata.items() if k in result.columns}
+            new_field_meta = {k: replace(v) for k, v in self.metadata.field_metadata.items() if k in result.columns}
             new_metadata = Metadata(
                 lineage=LineageMetadata(
                     sources=self.metadata.lineage.sources.copy(),

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -42,7 +42,7 @@ def _field_schema_to_dict(field: FieldSchema) -> dict:
     if field.description:
         d["description"] = field.description
     if field.unit:
-        d["unit"] = field.unit
+        d["unit"] = field.unit_source if field.unit_source else field.unit
     if field.source:
         d["source"] = field.source
     return d
@@ -119,17 +119,34 @@ class DatasetsManager:
 
     def _parse_fields(self, fields_data: List[Dict[str, Any]]) -> List[FieldSchema]:
         """Parse field schema data from YAML."""
-        return [
-            FieldSchema(
-                name=field["name"],
-                type=field["type"],
-                constraints=field.get("constraints"),
-                description=field.get("description"),
-                unit=field.get("unit"),
-                source=field.get("source"),
+        from .units import is_qudt_uri, parse_unit_string
+
+        result = []
+        for field in fields_data:
+            unit_str = field.get("unit")
+            unit_value = unit_str
+            unit_source = None
+
+            if unit_str and is_qudt_uri(unit_str):
+                try:
+                    pint_unit, unit_source = parse_unit_string(unit_str)
+                    unit_value = str(pint_unit)
+                except Exception:
+                    unit_value = unit_str
+                    unit_source = unit_str
+
+            result.append(
+                FieldSchema(
+                    name=field["name"],
+                    type=field["type"],
+                    constraints=field.get("constraints"),
+                    description=field.get("description"),
+                    unit=unit_value,
+                    source=field.get("source"),
+                    unit_source=unit_source,
+                )
             )
-            for field in fields_data
-        ]
+        return result
 
     def _parse_publish(self, publish_data: Any) -> Optional[PublishConfig]:
         """

--- a/src/sunstone/exceptions.py
+++ b/src/sunstone/exceptions.py
@@ -31,3 +31,9 @@ class LineageError(SunstoneError):
     """Raised when there's an issue with lineage tracking."""
 
     pass
+
+
+class UnitError(SunstoneError):
+    """Raised when a unit operation fails (incompatible dimensions, unparseable unit, etc.)."""
+
+    pass

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -74,6 +74,9 @@ class FieldSchema:
     source: Optional[str] = None
     """Slug of the input dataset this field's data comes from."""
 
+    unit_source: Optional[str] = None
+    """Original unit string format for round-tripping (e.g. QUDT URI). None means Pint string."""
+
 
 @dataclass
 class Contributor:

--- a/src/sunstone/units.py
+++ b/src/sunstone/units.py
@@ -332,23 +332,46 @@ class UnitSeries:
     # Comparison operators — return plain Series (boolean masks)
     # ------------------------------------------------------------------
 
+    def _compare(self, other: Any, op: str) -> pd.Series:
+        """Core comparison handler with unit checking."""
+        if not isinstance(other, type(self)):
+            result: pd.Series = getattr(self._series, op)(other)
+            return result
+
+        # Both are UnitSeries — resolve units like addition
+        resolved = resolve_units(self._unit, other._unit, "add")
+
+        if resolved.warning:
+            warnings.warn(resolved.warning, stacklevel=3)
+
+        self_values = self._series
+        other_values = other._series
+
+        if resolved.convert_a is not None:
+            self_values = self_values * resolved.convert_a
+        if resolved.convert_b is not None:
+            other_values = other_values * resolved.convert_b
+
+        result = getattr(self_values, op)(other_values)
+        return result  # type: ignore[no-any-return]
+
     def __gt__(self, other: Any) -> pd.Series:
-        return self._series > (other._series if isinstance(other, type(self)) else other)
+        return self._compare(other, "__gt__")
 
     def __ge__(self, other: Any) -> pd.Series:
-        return self._series >= (other._series if isinstance(other, type(self)) else other)
+        return self._compare(other, "__ge__")
 
     def __lt__(self, other: Any) -> pd.Series:
-        return self._series < (other._series if isinstance(other, type(self)) else other)
+        return self._compare(other, "__lt__")
 
     def __le__(self, other: Any) -> pd.Series:
-        return self._series <= (other._series if isinstance(other, type(self)) else other)
+        return self._compare(other, "__le__")
 
     def __eq__(self, other: Any) -> pd.Series:  # type: ignore[override]
-        return self._series == (other._series if isinstance(other, type(self)) else other)
+        return self._compare(other, "__eq__")
 
     def __ne__(self, other: Any) -> pd.Series:  # type: ignore[override]
-        return self._series != (other._series if isinstance(other, type(self)) else other)
+        return self._compare(other, "__ne__")
 
     # Pandas-internal attributes that should NOT be delegated — if pandas
     # finds these, it treats UnitSeries as a Series subtype and bypasses __radd__.

--- a/src/sunstone/units.py
+++ b/src/sunstone/units.py
@@ -68,6 +68,26 @@ def parse_unit(unit_str: str) -> pint.Unit:
         raise UnitError(f"Cannot parse unit '{unit_str}': {e}") from e
 
 
+def try_parse_unit(unit_str: str) -> pint.Unit | None:
+    """Try to parse a unit string, returning None if it fails.
+
+    Uses parse_unit_string so QUDT URIs are also handled. Domain-specific
+    units (e.g. 'people', 'students') that are valid in relaxed mode but
+    not parseable by Pint will return None instead of raising.
+
+    Args:
+        unit_str: A unit string (Pint, QUDT URI, or domain-specific).
+
+    Returns:
+        A pint.Unit if parseable, None otherwise.
+    """
+    try:
+        unit, _ = parse_unit_string(unit_str)
+        return unit
+    except (UnitError, Exception):
+        return None
+
+
 @dataclass
 class ResolvedUnits:
     """Result of unit resolution for an arithmetic operation."""

--- a/src/sunstone/units.py
+++ b/src/sunstone/units.py
@@ -198,6 +198,40 @@ _OP_NAME = {
 }
 
 
+def is_qudt_uri(unit_str: str) -> bool:
+    """Check if a unit string looks like a QUDT URI or prefixed name."""
+    return (
+        unit_str.startswith("http://qudt.org/")
+        or unit_str.startswith("https://qudt.org/")
+        or unit_str.startswith("qudt:")
+    )
+
+
+def parse_unit_string(unit_str: str) -> tuple[pint.Unit, str | None]:
+    """Parse a unit string that may be a Pint string or QUDT URI.
+
+    Returns:
+        Tuple of (pint.Unit, unit_source). unit_source is the QUDT URI
+        if the input was a URI, or None if it was a plain Pint string.
+
+    Raises:
+        UnitError: If the unit cannot be parsed or QUDT resolution fails.
+    """
+    if is_qudt_uri(unit_str):
+        try:
+            import ontopint
+        except ImportError:
+            raise UnitError(f"Unit '{unit_str}' is a QUDT URI. " f"Install sunstone-py[qudt] to resolve QUDT units.")
+        try:
+            ucum_code = ontopint.get_ucum_code_from_unit_iri(unit_str)
+            unit = ontopint.ureg.Unit(ucum_code)
+            return unit, unit_str
+        except Exception as e:
+            raise UnitError(f"Cannot resolve QUDT unit '{unit_str}': {e}") from e
+
+    return parse_unit(unit_str), None
+
+
 class UnitSeries:
     """A pandas Series proxy that carries a Pint unit."""
 

--- a/src/sunstone/units.py
+++ b/src/sunstone/units.py
@@ -18,7 +18,7 @@ from .exceptions import UnitError
 UnitMode = Literal["relaxed", "strict", "auto"]
 
 # Shared registry — all Pint units in Sunstone must come from this instance.
-ureg = pint.UnitRegistry()
+ureg: pint.UnitRegistry = pint.UnitRegistry()
 Q_ = ureg.Quantity
 
 # Global mode setting
@@ -155,7 +155,8 @@ def resolve_units(
             return ResolvedUnits(result_unit=unit_a * unit_b)
         if operation == "div":
             if unit_a is None:
-                return ResolvedUnits(result_unit=1 / unit_b)  # type: ignore[operator]
+                result = 1 / unit_b  # type: ignore[operator]
+                return ResolvedUnits(result_unit=result)  # type: ignore[arg-type]
             if unit_b is None:
                 return ResolvedUnits(result_unit=unit_a)
             return ResolvedUnits(result_unit=unit_a / unit_b)
@@ -331,6 +332,7 @@ class UnitSeries:
         # Perform the pandas operation
         result_values = getattr(self_values, op)(other_values)
 
+        assert resolved.result_unit is not None
         return type(self)(result_values, resolved.result_unit, self._unit_display)
 
     # ------------------------------------------------------------------

--- a/src/sunstone/units.py
+++ b/src/sunstone/units.py
@@ -196,7 +196,7 @@ def resolve_units(
 
     if mode == "strict":
         raise UnitError(
-            f"Cannot {operation} '{unit_a}' and '{unit_b}': " f"units differ. Use auto mode for automatic conversion."
+            f"Cannot {operation} '{unit_a}' and '{unit_b}': units differ. Use auto mode for automatic conversion."
         )
 
     # Auto mode — convert to finer granularity
@@ -241,7 +241,7 @@ def parse_unit_string(unit_str: str) -> tuple[pint.Unit, str | None]:
         try:
             import ontopint
         except ImportError:
-            raise UnitError(f"Unit '{unit_str}' is a QUDT URI. " f"Install sunstone-py[qudt] to resolve QUDT units.")
+            raise UnitError(f"Unit '{unit_str}' is a QUDT URI. Install sunstone-py[qudt] to resolve QUDT units.")
         try:
             ucum_code = ontopint.get_ucum_code_from_unit_iri(unit_str)
             unit = ontopint.ureg.Unit(ucum_code)

--- a/src/sunstone/units.py
+++ b/src/sunstone/units.py
@@ -1,0 +1,364 @@
+"""
+Unit handling for Sunstone DataFrames.
+
+Provides a shared Pint UnitRegistry, unit mode management (relaxed/strict/auto),
+unit parsing, and unit resolution for arithmetic operations.
+"""
+
+import os
+import warnings
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import pandas as pd
+import pint
+
+from .exceptions import UnitError
+
+UnitMode = Literal["relaxed", "strict", "auto"]
+
+# Shared registry — all Pint units in Sunstone must come from this instance.
+ureg = pint.UnitRegistry()
+Q_ = ureg.Quantity
+
+# Global mode setting
+_VALID_MODES: set[UnitMode] = {"relaxed", "strict", "auto"}
+_unit_mode: UnitMode = "relaxed"
+
+_env_mode = os.environ.get("SUNSTONE_UNIT_MODE", "").lower()
+if _env_mode in _VALID_MODES:
+    _unit_mode = _env_mode  # type: ignore[assignment]
+
+
+def get_unit_mode() -> UnitMode:
+    """Return the current unit handling mode."""
+    return _unit_mode
+
+
+def set_unit_mode(mode: UnitMode) -> None:
+    """Set the global unit handling mode.
+
+    Args:
+        mode: One of 'relaxed', 'strict', or 'auto'.
+
+    Raises:
+        ValueError: If mode is not valid.
+    """
+    global _unit_mode
+    if mode not in _VALID_MODES:
+        raise ValueError(f"Invalid unit mode '{mode}'. Must be one of: {', '.join(sorted(_VALID_MODES))}")
+    _unit_mode = mode
+
+
+def parse_unit(unit_str: str) -> pint.Unit:
+    """Parse a unit string into a Pint Unit.
+
+    Args:
+        unit_str: A Pint-compatible unit string (e.g. 'kWh', 'meter / second').
+
+    Returns:
+        A pint.Unit instance.
+
+    Raises:
+        UnitError: If the string cannot be parsed.
+    """
+    try:
+        return ureg.Unit(unit_str)
+    except (pint.UndefinedUnitError, pint.errors.UndefinedUnitError) as e:
+        raise UnitError(f"Cannot parse unit '{unit_str}': {e}") from e
+
+
+@dataclass
+class ResolvedUnits:
+    """Result of unit resolution for an arithmetic operation."""
+
+    result_unit: pint.Unit | None
+    convert_a: float | None = None
+    convert_b: float | None = None
+    warning: str | None = None
+
+
+def _finer_granularity(unit_a: pint.Unit, unit_b: pint.Unit) -> tuple[pint.Unit, float | None, float | None]:
+    """Pick the unit with smaller base-equivalent magnitude.
+
+    Returns (winner_unit, convert_a, convert_b) where convert_a/b
+    is the multiplication factor to apply to the operand's values,
+    or None if that operand is already in the winner unit.
+    """
+    mag_a = Q_(1, unit_a).to_base_units().magnitude
+    mag_b = Q_(1, unit_b).to_base_units().magnitude
+
+    if abs(mag_a) <= abs(mag_b):
+        # a is finer, convert b to a
+        factor = Q_(1, unit_b).to(unit_a).magnitude
+        return unit_a, None, float(factor)
+    else:
+        # b is finer, convert a to b
+        factor = Q_(1, unit_a).to(unit_b).magnitude
+        return unit_b, float(factor), None
+
+
+def resolve_units(
+    unit_a: pint.Unit | None,
+    unit_b: pint.Unit | None,
+    operation: Literal["add", "sub", "mul", "div", "mod", "concat"],
+    mode: UnitMode | None = None,
+) -> ResolvedUnits:
+    """Resolve unit compatibility for an arithmetic operation.
+
+    Args:
+        unit_a: Unit of the left operand, or None.
+        unit_b: Unit of the right operand, or None.
+        operation: The kind of operation being performed.
+        mode: Override the global unit mode. If None, uses get_unit_mode().
+
+    Returns:
+        ResolvedUnits with the result unit and any conversion factors.
+
+    Raises:
+        UnitError: In strict/auto mode when units are incompatible.
+    """
+    if mode is None:
+        mode = get_unit_mode()
+
+    # Both None → passthrough
+    if unit_a is None and unit_b is None:
+        return ResolvedUnits(result_unit=None)
+
+    # Multiplicative ops (mul/div/mod) — always allowed
+    if operation in ("mul", "div", "mod"):
+        if operation == "mul":
+            if unit_a is None:
+                return ResolvedUnits(result_unit=unit_b)
+            if unit_b is None:
+                return ResolvedUnits(result_unit=unit_a)
+            return ResolvedUnits(result_unit=unit_a * unit_b)
+        if operation == "div":
+            if unit_a is None:
+                return ResolvedUnits(result_unit=1 / unit_b)  # type: ignore[operator]
+            if unit_b is None:
+                return ResolvedUnits(result_unit=unit_a)
+            return ResolvedUnits(result_unit=unit_a / unit_b)
+        # mod
+        if unit_a is None:
+            return ResolvedUnits(result_unit=unit_b)
+        return ResolvedUnits(result_unit=unit_a)
+
+    # Additive ops (add/sub/concat) — one side None
+    if unit_a is None:
+        return ResolvedUnits(result_unit=unit_b)
+    if unit_b is None:
+        return ResolvedUnits(result_unit=unit_a)
+
+    # Both set — check compatibility
+    if unit_a == unit_b:
+        return ResolvedUnits(result_unit=unit_a)
+
+    # Check dimensional compatibility
+    dim_compatible = unit_a.dimensionality == unit_b.dimensionality
+
+    if not dim_compatible:
+        msg = (
+            f"Cannot {operation} '{unit_a}' and '{unit_b}': "
+            f"incompatible dimensions {unit_a.dimensionality} vs {unit_b.dimensionality}"
+        )
+        if mode == "relaxed":
+            return ResolvedUnits(result_unit=unit_a, warning=msg)
+        raise UnitError(msg)
+
+    # Same dimension, different scale
+    if mode == "relaxed":
+        msg = (
+            f"Adding '{unit_a}' and '{unit_b}': units have same dimension but different scale. "
+            f"No conversion applied. Use auto mode for automatic conversion."
+        )
+        return ResolvedUnits(result_unit=unit_a, warning=msg)
+
+    if mode == "strict":
+        raise UnitError(
+            f"Cannot {operation} '{unit_a}' and '{unit_b}': " f"units differ. Use auto mode for automatic conversion."
+        )
+
+    # Auto mode — convert to finer granularity
+    winner, conv_a, conv_b = _finer_granularity(unit_a, unit_b)
+    return ResolvedUnits(result_unit=winner, convert_a=conv_a, convert_b=conv_b)
+
+
+_OP_NAME = {
+    "__add__": "add",
+    "__radd__": "add",
+    "__sub__": "sub",
+    "__rsub__": "sub",
+    "__mul__": "mul",
+    "__rmul__": "mul",
+    "__truediv__": "div",
+    "__rtruediv__": "div",
+    "__mod__": "mod",
+    "__rmod__": "mod",
+}
+
+
+class UnitSeries:
+    """A pandas Series proxy that carries a Pint unit."""
+
+    __slots__ = ("_series", "_unit", "_unit_display")
+
+    # Tell numpy/pandas to defer to UnitSeries for arithmetic operations.
+    # __pandas_priority__ > 0 causes pandas to call our __radd__ etc. instead
+    # of processing us as a generic array-like via __getattr__ delegation.
+    __array_ufunc__ = None  # opt out of numpy ufuncs entirely
+    __pandas_priority__ = 5000
+
+    def __init__(
+        self,
+        series: pd.Series,
+        unit: pint.Unit,
+        unit_display: Literal["transparent", "explicit"] = "transparent",
+    ) -> None:
+        self._series = series
+        self._unit = unit
+        self._unit_display = unit_display
+
+    @property
+    def series(self) -> pd.Series:
+        return self._series
+
+    @property
+    def unit(self) -> pint.Unit:
+        return self._unit
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _extract_other(self, other: Any) -> tuple[Any, pint.Unit | None]:
+        """Return (values, unit_or_None) for the other operand."""
+        # Use type(self) so this works correctly after module reloads — isinstance
+        # checks against the same class that self belongs to, not a potentially
+        # stale module-level reference.
+        if isinstance(other, type(self)):
+            return other._series, other._unit
+        if isinstance(other, pd.Series):
+            return other, None
+        # scalar or array-like
+        return other, None
+
+    def _arith(self, other: Any, op: str, reverse: bool = False) -> "UnitSeries":
+        """Core arithmetic handler."""
+        other_values, other_unit = self._extract_other(other)
+        operation = _OP_NAME[op]
+
+        if reverse:
+            resolved = resolve_units(other_unit, self._unit, operation)  # type: ignore[arg-type]
+        else:
+            resolved = resolve_units(self._unit, other_unit, operation)  # type: ignore[arg-type]
+
+        if resolved.warning:
+            warnings.warn(resolved.warning, stacklevel=3)
+
+        self_values = self._series
+
+        # Apply conversion factors
+        if reverse:
+            # resolved was called as (other_unit, self_unit)
+            # convert_a applies to other_values, convert_b applies to self_values
+            if resolved.convert_a is not None:
+                other_values = other_values * resolved.convert_a
+            if resolved.convert_b is not None:
+                self_values = self_values * resolved.convert_b
+        else:
+            # resolved was called as (self_unit, other_unit)
+            # convert_a applies to self_values, convert_b applies to other_values
+            if resolved.convert_a is not None:
+                self_values = self_values * resolved.convert_a
+            if resolved.convert_b is not None:
+                other_values = other_values * resolved.convert_b
+
+        # Perform the pandas operation
+        result_values = getattr(self_values, op)(other_values)
+
+        return type(self)(result_values, resolved.result_unit, self._unit_display)
+
+    # ------------------------------------------------------------------
+    # Arithmetic operators
+    # ------------------------------------------------------------------
+
+    def __add__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__add__")
+
+    def __radd__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__radd__", reverse=True)
+
+    def __sub__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__sub__")
+
+    def __rsub__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__rsub__", reverse=True)
+
+    def __mul__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__mul__")
+
+    def __rmul__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__rmul__", reverse=True)
+
+    def __truediv__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__truediv__")
+
+    def __rtruediv__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__rtruediv__", reverse=True)
+
+    def __mod__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__mod__")
+
+    def __rmod__(self, other: Any) -> "UnitSeries":
+        return self._arith(other, "__rmod__", reverse=True)
+
+    # ------------------------------------------------------------------
+    # Sequence / display
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._series)
+
+    def __repr__(self) -> str:
+        if self._unit_display == "explicit":
+            return repr(self._series) + "\nUnit: " + str(self._unit)
+        return repr(self._series)
+
+    def __str__(self) -> str:
+        return str(self._series)
+
+    # ------------------------------------------------------------------
+    # Comparison operators — return plain Series (boolean masks)
+    # ------------------------------------------------------------------
+
+    def __gt__(self, other: Any) -> pd.Series:
+        return self._series > (other._series if isinstance(other, type(self)) else other)
+
+    def __ge__(self, other: Any) -> pd.Series:
+        return self._series >= (other._series if isinstance(other, type(self)) else other)
+
+    def __lt__(self, other: Any) -> pd.Series:
+        return self._series < (other._series if isinstance(other, type(self)) else other)
+
+    def __le__(self, other: Any) -> pd.Series:
+        return self._series <= (other._series if isinstance(other, type(self)) else other)
+
+    def __eq__(self, other: Any) -> pd.Series:  # type: ignore[override]
+        return self._series == (other._series if isinstance(other, type(self)) else other)
+
+    def __ne__(self, other: Any) -> pd.Series:  # type: ignore[override]
+        return self._series != (other._series if isinstance(other, type(self)) else other)
+
+    # Pandas-internal attributes that should NOT be delegated — if pandas
+    # finds these, it treats UnitSeries as a Series subtype and bypasses __radd__.
+    _PANDAS_INTERNAL = frozenset({"_typ", "_values", "input_objs"})
+
+    def __getattr__(self, name: str) -> Any:
+        # Block pandas-internal attributes so that pandas arithmetic defers to
+        # our __radd__ / __rmul__ etc. instead of treating us as a Series.
+        if name in UnitSeries._PANDAS_INTERNAL:
+            raise AttributeError(name)
+        # Delegate everything else to the underlying Series.
+        # __slots__ prevents infinite recursion for _series itself.
+        return getattr(self._series, name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1562,8 +1562,8 @@ class TestParquetResourceSupport:
 
         # Create a minimal valid Parquet file
         try:
-            import pyarrow as pa
-            import pyarrow.parquet as pq
+            import pyarrow as pa  # type: ignore[import-untyped]
+            import pyarrow.parquet as pq  # type: ignore[import-untyped]
 
             table = pa.table(
                 {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -826,9 +826,9 @@ class TestPackagePushCommand:
             assert result.exit_code == 0
 
             # Verify methodology file was uploaded
-            assert any(
-                "DATA_METHODOLOGY.md" in b for b in handler.uploaded_blobs
-            ), f"Methodology file not uploaded. Uploaded blobs: {handler.uploaded_blobs}"
+            assert any("DATA_METHODOLOGY.md" in b for b in handler.uploaded_blobs), (
+                f"Methodology file not uploaded. Uploaded blobs: {handler.uploaded_blobs}"
+            )
 
             # Verify datapackage.json contains expanded methodology key
             dp_path = [b for b in handler.uploaded_text if "datapackage.json" in b][0]

--- a/tests/test_dataframe_coverage.py
+++ b/tests/test_dataframe_coverage.py
@@ -27,13 +27,13 @@ from sunstone.exceptions import DatasetNotFoundError
 def _has_parquet_engine() -> bool:
     """Check if a parquet engine (pyarrow or fastparquet) is available."""
     try:
-        import pyarrow  # noqa: F401
+        import pyarrow  # type: ignore[import-untyped]  # noqa: F401
 
         return True
     except ImportError:
         pass
     try:
-        import fastparquet  # noqa: F401
+        import fastparquet  # type: ignore[import-not-found]  # noqa: F401
 
         return True
     except ImportError:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -39,9 +39,9 @@ class TestErrorsReExport:
         """Re-exported objects should be the exact same objects, not copies."""
         ss_names = _star_import_names("sunstone.errors")
         for name in ss_names:
-            assert getattr(ss_errors, name) is getattr(
-                pd_errors, name
-            ), f"sunstone.errors.{name} is not identical to pandas.errors.{name}"
+            assert getattr(ss_errors, name) is getattr(pd_errors, name), (
+                f"sunstone.errors.{name} is not identical to pandas.errors.{name}"
+            )
 
     def test_import_specific_error(self):
         """Commonly used errors should be directly importable."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -241,7 +241,7 @@ class TestMetadataPropagation:
         result = left.merge(right, on="key")
         assert result.metadata.description == "left data"
         assert result.metadata.field_metadata["val_l"].unit == "m"
-        assert "val_r" not in result.metadata.field_metadata
+        assert result.metadata.field_metadata["val_r"].unit == "kg"
 
     def test_concat_uses_first_metadata(self):
         df1 = sunstone.DataFrame({"a": [1]})
@@ -316,13 +316,13 @@ class TestConflictingMetadata:
         slugs = {s.slug for s in result.metadata.lineage.sources}
         assert slugs == {"source-a", "source-b"}
 
-        # Field metadata: left's fields survive, right's do not
+        # Field metadata: left's fields survive, right's brought in for new columns
         assert "key" in result.metadata.field_metadata
         assert result.metadata.field_metadata["key"].description == "Join key"
         assert result.metadata.field_metadata["key"].type == "integer"  # not "string" from right
         assert "value" in result.metadata.field_metadata
         assert result.metadata.field_metadata["value"].unit == "meters"
-        assert "score" not in result.metadata.field_metadata  # right's field metadata lost
+        assert result.metadata.field_metadata["score"].unit == "ratio"  # right's field metadata brought in
 
     def test_join_conflicting_metadata(self):
         """Join: left wins for dataset-level, lineage combined."""
@@ -348,9 +348,9 @@ class TestConflictingMetadata:
         slugs = {s.slug for s in result.metadata.lineage.sources}
         assert slugs == {"source-a", "source-b"}
 
-        # Field metadata: left's survives, right's lost
+        # Field metadata: left's survives, right's brought in
         assert result.metadata.field_metadata["val_l"].unit == "kg"
-        assert "val_r" not in result.metadata.field_metadata
+        assert result.metadata.field_metadata["val_r"].unit == "lbs"
 
     def test_concat_conflicting_metadata(self):
         """Concat: first DataFrame wins for dataset-level, lineage combined."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -150,11 +150,11 @@ class TestSetFieldMetadata:
     def test_set_field_metadata_creates_entry(self):
         """Setting metadata for a new column creates a FieldSchema."""
         df = sunstone.DataFrame({"enrollment": [100, 200]})
-        df.set_field_metadata("enrollment", description="Total students", unit="students")
+        df.set_field_metadata("enrollment", description="Total students", unit="count")
         fm = df.metadata.field_metadata["enrollment"]
         assert fm.name == "enrollment"
         assert fm.description == "Total students"
-        assert fm.unit == "students"
+        assert fm.unit == "count"
         assert fm.type is None  # not set, will be inferred at write time
 
     def test_set_field_metadata_updates_existing(self):

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -478,9 +478,9 @@ outputs:
 
             # Top-level si:methodology should be expanded
             methodology_key = f"{STANDARD_RDF_PREFIXES['si']}methodology"
-            assert (
-                methodology_key in datapackage
-            ), f"Expected {methodology_key} in datapackage, got keys: {list(datapackage.keys())}"
+            assert methodology_key in datapackage, (
+                f"Expected {methodology_key} in datapackage, got keys: {list(datapackage.keys())}"
+            )
 
             # Per-resource si:monitorsThreat should be expanded
             resource = datapackage["resources"][0]

--- a/tests/test_unit_integration.py
+++ b/tests/test_unit_integration.py
@@ -187,3 +187,20 @@ class TestJoinUnits:
         result = df1.join(df2)
         assert result.metadata.field_metadata.get("a") is not None
         assert result.metadata.field_metadata.get("b") is not None
+
+
+class TestMetadataIsolation:
+    def test_concat_does_not_mutate_source_metadata(self):
+        set_unit_mode("auto")
+        try:
+            df1 = DataFrame(data=pd.DataFrame({"dist": [1.0]}))
+            df1.set_field_metadata("dist", unit="km")
+            df2 = DataFrame(data=pd.DataFrame({"dist": [500.0]}))
+            df2.set_field_metadata("dist", unit="meter")
+            result = df1.concat([df2], ignore_index=True)
+            # df1's metadata should still say "km"
+            assert df1.metadata.field_metadata["dist"].unit == "km"
+            # result should say "meter"
+            assert result.metadata.field_metadata["dist"].unit == "meter"
+        finally:
+            set_unit_mode("relaxed")

--- a/tests/test_unit_integration.py
+++ b/tests/test_unit_integration.py
@@ -85,6 +85,24 @@ class TestSetFieldMetadataValidation:
         df.set_field_metadata("x", unit="kWh")
         assert df.metadata.field_metadata["x"].unit == "kWh"
 
+    def test_qudt_uri_accepted_in_strict_mode(self):
+        """QUDT URIs should be validated via parse_unit_string, not parse_unit."""
+        import unittest.mock
+
+        mock_ontopint = unittest.mock.MagicMock()
+        mock_ontopint.get_ucum_code_from_unit_iri.return_value = "kW.h"
+        mock_ontopint.ureg.Unit.return_value = unittest.mock.MagicMock()
+
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        original = get_unit_mode()
+        set_unit_mode("strict")
+        try:
+            with unittest.mock.patch.dict("sys.modules", {"ontopint": mock_ontopint}):
+                df.set_field_metadata("x", unit="http://qudt.org/vocab/unit/KiloW-HR")
+            assert df.metadata.field_metadata["x"].unit == "http://qudt.org/vocab/unit/KiloW-HR"
+        finally:
+            set_unit_mode(original)
+
 
 class TestUnitDisplayProperty:
     def test_default_is_transparent(self):

--- a/tests/test_unit_integration.py
+++ b/tests/test_unit_integration.py
@@ -1,0 +1,95 @@
+import pandas as pd
+import pytest
+
+from sunstone.dataframe import DataFrame
+from sunstone.exceptions import UnitError
+from sunstone.units import UnitSeries, parse_unit, set_unit_mode, get_unit_mode
+
+
+class TestGetitemReturnsUnitSeries:
+    def test_column_with_unit_returns_unit_series(self):
+        df = DataFrame(data=pd.DataFrame({"power": [1.0, 2.0, 3.0]}))
+        df.set_field_metadata("power", unit="kW")
+        result = df["power"]
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kW")
+
+    def test_column_without_unit_returns_plain_series(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1, 2, 3]}))
+        result = df["x"]
+        assert not isinstance(result, UnitSeries)
+        assert isinstance(result, pd.Series)
+
+    def test_multi_column_returns_dataframe(self):
+        df = DataFrame(data=pd.DataFrame({"a": [1.0], "b": [2.0]}))
+        df.set_field_metadata("a", unit="kW")
+        result = df[["a", "b"]]
+        assert isinstance(result, DataFrame)
+
+    def test_unit_display_passed_through(self):
+        df = DataFrame(data=pd.DataFrame({"power": [1.0]}))
+        df.unit_display = "explicit"
+        df.set_field_metadata("power", unit="kW")
+        result = df["power"]
+        assert isinstance(result, UnitSeries)
+        assert "kilowatt" in repr(result)
+
+
+class TestSetitemPropagatesUnit:
+    def test_assign_unit_series_sets_field_metadata(self):
+        df = DataFrame(data=pd.DataFrame({"a": [1.0], "b": [2.0]}))
+        df.set_field_metadata("a", unit="watt")
+        df.set_field_metadata("b", unit="hour")
+        original = get_unit_mode()
+        set_unit_mode("auto")
+        try:
+            df["energy"] = df["a"] * df["b"]
+        finally:
+            set_unit_mode(original)
+        assert "energy" in df.metadata.field_metadata
+        assert df.metadata.field_metadata["energy"].unit is not None
+
+    def test_assign_plain_series_no_unit(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1, 2]}))
+        df["y"] = pd.Series([3, 4])
+        # Either no entry, or entry with no unit
+        field = df.metadata.field_metadata.get("y")
+        assert field is None or field.unit is None
+
+
+class TestSetFieldMetadataValidation:
+    def test_invalid_unit_raises_in_strict_mode(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        original = get_unit_mode()
+        set_unit_mode("strict")
+        try:
+            with pytest.raises(UnitError, match="Cannot parse unit"):
+                df.set_field_metadata("x", unit="flarbnitz")
+        finally:
+            set_unit_mode(original)
+
+    def test_invalid_unit_accepted_in_relaxed_mode(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        original = get_unit_mode()
+        set_unit_mode("relaxed")
+        try:
+            df.set_field_metadata("x", unit="people")
+            assert df.metadata.field_metadata["x"].unit == "people"
+        finally:
+            set_unit_mode(original)
+
+    def test_valid_unit_accepted(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        df.set_field_metadata("x", unit="kWh")
+        assert df.metadata.field_metadata["x"].unit == "kWh"
+
+
+class TestUnitDisplayProperty:
+    def test_default_is_transparent(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        assert df.unit_display == "transparent"
+
+    def test_settable(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1]}))
+        df.unit_display = "explicit"
+        assert df.unit_display == "explicit"

--- a/tests/test_unit_integration.py
+++ b/tests/test_unit_integration.py
@@ -5,6 +5,7 @@ import pytest
 
 from sunstone.dataframe import DataFrame
 from sunstone.exceptions import UnitError
+from sunstone.lineage import FieldSchema
 from sunstone.units import UnitSeries, parse_unit, set_unit_mode, get_unit_mode
 
 
@@ -220,5 +221,78 @@ class TestMetadataIsolation:
             assert df1.metadata.field_metadata["dist"].unit == "km"
             # result should say "meter"
             assert result.metadata.field_metadata["dist"].unit == "meter"
+        finally:
+            set_unit_mode("relaxed")
+
+
+class TestRelaxedDomainUnits:
+    """Domain-specific units (e.g. 'people') must not cause hard failures."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("relaxed")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_getitem_with_domain_unit_returns_plain_series(self):
+        df = DataFrame(data=pd.DataFrame({"x": [1, 2, 3]}))
+        df.set_field_metadata("x", unit="people")
+        result = df["x"]
+        assert isinstance(result, pd.Series)
+        assert not isinstance(result, UnitSeries)
+
+    def test_concat_with_domain_units_preserves_metadata(self):
+        df1 = DataFrame(data=pd.DataFrame({"x": [1]}))
+        df1.set_field_metadata("x", unit="students")
+        df2 = DataFrame(data=pd.DataFrame({"x": [2]}))
+        df2.set_field_metadata("x", unit="students")
+        result = df1.concat([df2], ignore_index=True)
+        assert result.metadata.field_metadata["x"].unit == "students"
+
+    def test_merge_with_domain_units_does_not_raise(self):
+        df1 = DataFrame(data=pd.DataFrame({"id": [1], "x": [1.0]}))
+        df1.set_field_metadata("x", unit="people")
+        df2 = DataFrame(data=pd.DataFrame({"id": [1], "x": [2.0]}))
+        df2.set_field_metadata("x", unit="people")
+        result = df1.merge(df2, on="id", suffixes=("_l", "_r"))
+        assert result is not None
+
+    def test_join_with_domain_units_does_not_raise(self):
+        df1 = DataFrame(data=pd.DataFrame({"a": [1.0]}, index=[0]))
+        df1.set_field_metadata("a", unit="people")
+        df2 = DataFrame(data=pd.DataFrame({"a": [2.0]}, index=[0]))
+        df2.set_field_metadata("a", unit="people")
+        result = df1.join(df2, lsuffix="_l", rsuffix="_r")
+        assert result is not None
+
+
+class TestUnitSourceStaleness:
+    """unit_source must be cleared when unit changes to prevent stale QUDT URIs."""
+
+    def test_setitem_clears_unit_source(self):
+        df = DataFrame(data=pd.DataFrame({"power": [1.0, 2.0]}))
+        df.metadata.field_metadata["power"] = FieldSchema(
+            name="power", unit="kW", unit_source="http://qudt.org/vocab/unit/KiloW"
+        )
+        us = UnitSeries(pd.Series([10.0, 20.0]), parse_unit("watt"))
+        df["power"] = us
+        field = df.metadata.field_metadata["power"]
+        assert field.unit == "watt"
+        assert field.unit_source is None
+
+    def test_concat_clears_unit_source_on_conversion(self):
+        set_unit_mode("auto")
+        try:
+            df1 = DataFrame(data=pd.DataFrame({"dist": [1.0]}))
+            df1.metadata.field_metadata["dist"] = FieldSchema(
+                name="dist", unit="km", unit_source="http://qudt.org/vocab/unit/KiloM"
+            )
+            df2 = DataFrame(data=pd.DataFrame({"dist": [500.0]}))
+            df2.set_field_metadata("dist", unit="meter")
+            result = df1.concat([df2], ignore_index=True)
+            field = result.metadata.field_metadata["dist"]
+            assert field.unit == "meter"
+            assert field.unit_source is None
         finally:
             set_unit_mode("relaxed")

--- a/tests/test_unit_integration.py
+++ b/tests/test_unit_integration.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -93,3 +95,95 @@ class TestUnitDisplayProperty:
         df = DataFrame(data=pd.DataFrame({"x": [1]}))
         df.unit_display = "explicit"
         assert df.unit_display == "explicit"
+
+
+class TestConcatUnits:
+    def setup_method(self):
+        self._original = get_unit_mode()
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_concat_same_units(self):
+        set_unit_mode("auto")
+        df1 = DataFrame(data=pd.DataFrame({"energy": [1.0, 2.0]}))
+        df1.set_field_metadata("energy", unit="kWh")
+        df2 = DataFrame(data=pd.DataFrame({"energy": [3.0, 4.0]}))
+        df2.set_field_metadata("energy", unit="kWh")
+        result = df1.concat([df2], ignore_index=True)
+        assert result.metadata.field_metadata["energy"].unit == "kWh"
+        assert list(result.data["energy"]) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_concat_compatible_units_auto_converts(self):
+        set_unit_mode("auto")
+        df1 = DataFrame(data=pd.DataFrame({"dist": [1.0]}))
+        df1.set_field_metadata("dist", unit="km")
+        df2 = DataFrame(data=pd.DataFrame({"dist": [500.0]}))
+        df2.set_field_metadata("dist", unit="meter")
+        result = df1.concat([df2], ignore_index=True)
+        assert result.metadata.field_metadata["dist"].unit == "meter"
+        assert result.data["dist"].iloc[0] == pytest.approx(1000.0)
+        assert result.data["dist"].iloc[1] == pytest.approx(500.0)
+
+    def test_concat_incompatible_units_auto_raises(self):
+        set_unit_mode("auto")
+        df1 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df1.set_field_metadata("x", unit="meter")
+        df2 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df2.set_field_metadata("x", unit="second")
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            df1.concat([df2])
+
+    def test_concat_relaxed_warns(self):
+        set_unit_mode("relaxed")
+        df1 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df1.set_field_metadata("x", unit="meter")
+        df2 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df2.set_field_metadata("x", unit="second")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            df1.concat([df2], ignore_index=True)
+            assert len(w) >= 1
+
+    def test_concat_no_units_passthrough(self):
+        df1 = DataFrame(data=pd.DataFrame({"x": [1.0]}))
+        df2 = DataFrame(data=pd.DataFrame({"x": [2.0]}))
+        result = df1.concat([df2], ignore_index=True)
+        assert list(result.data["x"]) == [1.0, 2.0]
+
+
+class TestMergeUnits:
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_merge_preserves_both_side_units(self):
+        df1 = DataFrame(data=pd.DataFrame({"id": [1], "val": [1.0]}))
+        df1.set_field_metadata("val", unit="km")
+        df2 = DataFrame(data=pd.DataFrame({"id": [1], "val2": [500.0]}))
+        df2.set_field_metadata("val2", unit="meter")
+        result = df1.merge(df2, on="id")
+        assert "val" in result.data.columns
+        assert "val2" in result.data.columns
+        assert result.metadata.field_metadata.get("val2") is not None
+
+
+class TestJoinUnits:
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_join_preserves_units(self):
+        df1 = DataFrame(data=pd.DataFrame({"a": [1.0]}, index=[0]))
+        df1.set_field_metadata("a", unit="kW")
+        df2 = DataFrame(data=pd.DataFrame({"b": [2.0]}, index=[0]))
+        df2.set_field_metadata("b", unit="hour")
+        result = df1.join(df2)
+        assert result.metadata.field_metadata.get("a") is not None
+        assert result.metadata.field_metadata.get("b") is not None

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -525,3 +525,26 @@ class TestFieldSchemaUnitSource:
 
         f = FieldSchema(name="x", unit="kWh", unit_source="http://qudt.org/vocab/unit/KiloW-HR")
         assert f.unit_source == "http://qudt.org/vocab/unit/KiloW-HR"
+
+
+class TestPublicAPI:
+    def test_unit_error_from_sunstone(self):
+        from sunstone import UnitError
+
+        assert UnitError is not None
+
+    def test_unit_series_from_sunstone_units(self):
+        from sunstone.units import UnitSeries
+
+        assert UnitSeries is not None
+
+    def test_set_unit_mode_from_sunstone_units(self):
+        from sunstone.units import set_unit_mode, get_unit_mode
+
+        assert callable(set_unit_mode)
+        assert callable(get_unit_mode)
+
+    def test_parse_unit_from_sunstone_units(self):
+        from sunstone.units import parse_unit
+
+        assert callable(parse_unit)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -426,3 +426,50 @@ class TestUnitSeriesRelaxed:
             assert len(w) == 1
             assert "different scale" in str(w[0].message)
         assert isinstance(result, UnitSeries)
+
+
+class TestUnitSeriesComparison:
+    def setup_method(self):
+        self._original = get_unit_mode()
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_gt_same_unit(self):
+        a = UnitSeries(pd.Series([1, 2, 3]), parse_unit("kW"))
+        b = UnitSeries(pd.Series([2, 1, 2]), parse_unit("kW"))
+        result = a > b
+        assert isinstance(result, pd.Series)
+        assert list(result) == [False, True, True]
+
+    def test_gt_compatible_auto_converts(self):
+        set_unit_mode("auto")
+        a = UnitSeries(pd.Series([1.0]), parse_unit("km"))
+        b = UnitSeries(pd.Series([500.0]), parse_unit("meter"))
+        result = a > b
+        assert isinstance(result, pd.Series)
+        assert list(result) == [True]
+
+    def test_gt_incompatible_strict_raises(self):
+        set_unit_mode("strict")
+        a = UnitSeries(pd.Series([1.0]), parse_unit("meter"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("second"))
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            a > b
+
+    def test_gt_incompatible_relaxed_warns(self):
+        set_unit_mode("relaxed")
+        a = UnitSeries(pd.Series([1.0]), parse_unit("meter"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("second"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = a > b
+            assert len(w) >= 1
+            assert "incompatible dimensions" in str(w[0].message)
+        assert isinstance(result, pd.Series)
+
+    def test_gt_scalar(self):
+        a = UnitSeries(pd.Series([1, 2, 3]), parse_unit("kW"))
+        result = a > 1.5
+        assert isinstance(result, pd.Series)
+        assert list(result) == [False, True, True]

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,428 @@
+import os
+import warnings
+
+import pandas as pd
+import pytest
+from sunstone.exceptions import UnitError
+from sunstone.units import UnitSeries, get_unit_mode, parse_unit, resolve_units, set_unit_mode
+
+
+def test_unit_error_is_sunstone_error():
+    from sunstone.exceptions import SunstoneError
+
+    err = UnitError("test")
+    assert isinstance(err, SunstoneError)
+
+
+def test_unit_error_importable_from_sunstone():
+    from sunstone import UnitError as UE
+
+    assert UE is UnitError
+
+
+def test_ureg_is_pint_registry():
+    from sunstone.units import ureg
+    import pint
+
+    assert isinstance(ureg, pint.UnitRegistry)
+
+
+def test_ureg_singleton():
+    from sunstone.units import ureg as ureg1
+    from sunstone.units import ureg as ureg2
+
+    assert ureg1 is ureg2
+
+
+def test_default_mode_is_relaxed():
+    from sunstone.units import get_unit_mode
+
+    assert get_unit_mode() == "relaxed"
+
+
+def test_set_unit_mode():
+    from sunstone.units import get_unit_mode, set_unit_mode
+
+    original = get_unit_mode()
+    try:
+        set_unit_mode("strict")
+        assert get_unit_mode() == "strict"
+        set_unit_mode("auto")
+        assert get_unit_mode() == "auto"
+    finally:
+        set_unit_mode(original)
+
+
+def test_set_unit_mode_invalid():
+    from sunstone.units import set_unit_mode
+
+    with pytest.raises(ValueError, match="Invalid unit mode"):
+        set_unit_mode("bogus")  # type: ignore[arg-type]
+
+
+def test_env_var_sets_mode(monkeypatch):
+    monkeypatch.setenv("SUNSTONE_UNIT_MODE", "strict")
+    # Test the env var parsing logic directly instead of reloading the module
+    # (reloading replaces class objects, breaking isinstance checks in other tests)
+    import sunstone.units
+
+    original = sunstone.units._unit_mode
+    try:
+        env_mode = os.environ.get("SUNSTONE_UNIT_MODE", "").lower()
+        assert env_mode == "strict"
+        sunstone.units._unit_mode = env_mode  # type: ignore[assignment]
+        assert sunstone.units.get_unit_mode() == "strict"
+    finally:
+        sunstone.units._unit_mode = original
+
+
+def test_parse_unit_string():
+    from sunstone.units import parse_unit
+
+    unit = parse_unit("kWh")
+    assert str(unit) == "kilowatt_hour"
+
+
+def test_parse_unit_invalid():
+    from sunstone.units import parse_unit
+    from sunstone.exceptions import UnitError
+
+    with pytest.raises(UnitError, match="Cannot parse unit"):
+        parse_unit("flarbnitz")
+
+
+class TestResolveUnitsCommon:
+    """Rules common to all modes."""
+
+    def test_both_none_any_op(self):
+        result = resolve_units(None, None, "add")
+        assert result.result_unit is None
+        assert result.convert_a is None
+        assert result.convert_b is None
+        assert result.warning is None
+
+    def test_none_and_set_mul(self):
+        kw = parse_unit("kW")
+        result = resolve_units(None, kw, "mul")
+        assert result.result_unit == kw
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+    def test_set_and_none_mul(self):
+        kw = parse_unit("kW")
+        result = resolve_units(kw, None, "mul")
+        assert result.result_unit == kw
+
+    def test_none_and_set_div(self):
+        kw = parse_unit("kW")
+        result = resolve_units(None, kw, "div")
+        assert result.result_unit == 1 / kw
+
+    def test_set_and_none_div(self):
+        kw = parse_unit("kW")
+        result = resolve_units(kw, None, "div")
+        assert result.result_unit == kw
+
+    def test_none_and_set_add(self):
+        kw = parse_unit("kW")
+        result = resolve_units(None, kw, "add")
+        assert result.result_unit == kw
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+    def test_set_and_none_add(self):
+        kw = parse_unit("kW")
+        result = resolve_units(kw, None, "add")
+        assert result.result_unit == kw
+
+    def test_both_set_mul(self):
+        w = parse_unit("watt")
+        hr = parse_unit("hour")
+        result = resolve_units(w, hr, "mul")
+        assert result.result_unit == w * hr
+
+    def test_both_set_div(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        result = resolve_units(m, s, "div")
+        assert result.result_unit == m / s
+
+    def test_both_set_mod(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "mod")
+        assert result.result_unit == kwh
+
+
+class TestResolveUnitsRelaxed:
+    """Relaxed mode: warn but proceed."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("relaxed")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_same_unit_add(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "add")
+        assert result.result_unit == kwh
+        assert result.warning is None
+
+    def test_same_dimension_different_scale_warns(self):
+        kwh = parse_unit("kWh")
+        twh = parse_unit("TWh")
+        result = resolve_units(kwh, twh, "add")
+        assert result.warning is not None
+        assert result.convert_a is None  # no conversion in relaxed
+        assert result.convert_b is None
+
+    def test_incompatible_dimensions_warns(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        result = resolve_units(m, s, "add")
+        assert result.warning is not None
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+
+class TestResolveUnitsStrict:
+    """Strict mode: raise on mismatch."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("strict")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_same_unit_add_ok(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "add")
+        assert result.result_unit == kwh
+
+    def test_same_dimension_different_scale_raises(self):
+        kwh = parse_unit("kWh")
+        twh = parse_unit("TWh")
+        with pytest.raises(UnitError, match="units differ"):
+            resolve_units(kwh, twh, "add")
+
+    def test_incompatible_dimensions_raises(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            resolve_units(m, s, "add")
+
+
+class TestResolveUnitsAuto:
+    """Auto mode: convert when possible, raise otherwise."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_same_unit_add(self):
+        kwh = parse_unit("kWh")
+        result = resolve_units(kwh, kwh, "add")
+        assert result.result_unit == kwh
+        assert result.convert_a is None
+        assert result.convert_b is None
+
+    def test_same_dimension_converts_to_finer(self):
+        kwh = parse_unit("kWh")
+        twh = parse_unit("TWh")
+        result = resolve_units(kwh, twh, "add")
+        # kWh is finer granularity
+        assert result.result_unit == kwh
+        # b (TWh) needs conversion to kWh
+        assert result.convert_a is None
+        assert result.convert_b is not None
+        assert result.convert_b == pytest.approx(1e9)  # 1 TWh = 1e9 kWh
+
+    def test_finer_granularity_picks_smaller_factor(self):
+        mm = parse_unit("millimeter")
+        m = parse_unit("meter")
+        result = resolve_units(m, mm, "add")
+        assert result.result_unit == mm
+        # a (meter) needs conversion to mm
+        assert result.convert_a == pytest.approx(1000.0)
+        assert result.convert_b is None
+
+    def test_incompatible_dimensions_raises(self):
+        m = parse_unit("meter")
+        s = parse_unit("second")
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            resolve_units(m, s, "add")
+
+    def test_concat_same_dimension_converts(self):
+        kwh = parse_unit("kWh")
+        mwh = parse_unit("MWh")
+        result = resolve_units(kwh, mwh, "concat")
+        assert result.result_unit == kwh
+
+
+class TestUnitSeriesBasic:
+    def test_construction(self):
+        s = pd.Series([1.0, 2.0, 3.0], name="power")
+        us = UnitSeries(s, parse_unit("kW"))
+        assert us.unit == parse_unit("kW")
+        assert len(us) == 3
+
+    def test_unit_property(self):
+        s = pd.Series([100.0], name="energy")
+        us = UnitSeries(s, parse_unit("kWh"))
+        assert str(us.unit) == "kilowatt_hour"
+
+    def test_delegates_to_series(self):
+        s = pd.Series([1.0, 2.0, 3.0], name="power")
+        us = UnitSeries(s, parse_unit("kW"))
+        assert us.name == "power"
+        assert us.mean() == 2.0
+        assert list(us.values) == [1.0, 2.0, 3.0]
+
+    def test_transparent_repr(self):
+        s = pd.Series([1.0, 2.0], name="x")
+        us = UnitSeries(s, parse_unit("meter"), unit_display="transparent")
+        r = repr(us)
+        assert "meter" not in r  # unit not in repr
+
+    def test_explicit_repr(self):
+        s = pd.Series([1.0, 2.0], name="x")
+        us = UnitSeries(s, parse_unit("meter"), unit_display="explicit")
+        r = repr(us)
+        assert "meter" in r
+
+
+class TestUnitSeriesArithmeticAuto:
+    """Test arithmetic in auto mode where conversions happen."""
+
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("auto")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_add_same_unit(self):
+        a = UnitSeries(pd.Series([1.0, 2.0]), parse_unit("kWh"))
+        b = UnitSeries(pd.Series([3.0, 4.0]), parse_unit("kWh"))
+        result = a + b
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kWh")
+        assert list(result.series) == [4.0, 6.0]
+
+    def test_add_compatible_units_converts(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("km"))
+        b = UnitSeries(pd.Series([500.0]), parse_unit("meter"))
+        result = a + b
+        assert result.unit == parse_unit("meter")
+        assert result.series.iloc[0] == pytest.approx(1500.0)
+
+    def test_mul_units_combine(self):
+        power = UnitSeries(pd.Series([100.0]), parse_unit("watt"))
+        time = UnitSeries(pd.Series([2.0]), parse_unit("hour"))
+        result = power * time
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("watt") * parse_unit("hour")
+        assert result.series.iloc[0] == pytest.approx(200.0)
+
+    def test_div_units_combine(self):
+        dist = UnitSeries(pd.Series([100.0]), parse_unit("meter"))
+        time = UnitSeries(pd.Series([10.0]), parse_unit("second"))
+        result = dist / time
+        assert result.unit == parse_unit("meter") / parse_unit("second")
+        assert result.series.iloc[0] == pytest.approx(10.0)
+
+    def test_mul_scalar(self):
+        us = UnitSeries(pd.Series([2.0, 3.0]), parse_unit("kW"))
+        result = us * 1000
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kW")
+        assert list(result.series) == [2000.0, 3000.0]
+
+    def test_rmul_scalar(self):
+        us = UnitSeries(pd.Series([2.0, 3.0]), parse_unit("kW"))
+        result = 5 * us
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("kW")
+        assert list(result.series) == [10.0, 15.0]
+
+    def test_sub_compatible(self):
+        a = UnitSeries(pd.Series([10.0]), parse_unit("km"))
+        b = UnitSeries(pd.Series([3000.0]), parse_unit("meter"))
+        result = a - b
+        assert result.unit == parse_unit("meter")
+        assert result.series.iloc[0] == pytest.approx(7000.0)
+
+    def test_add_incompatible_raises(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("meter"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("second"))
+        with pytest.raises(UnitError, match="incompatible dimensions"):
+            a + b
+
+    def test_mod_preserves_dividend_unit(self):
+        a = UnitSeries(pd.Series([10.0]), parse_unit("kWh"))
+        b = UnitSeries(pd.Series([3.0]), parse_unit("kWh"))
+        result = a % b
+        assert result.unit == parse_unit("kWh")
+        assert result.series.iloc[0] == pytest.approx(1.0)
+
+    def test_add_plain_series(self):
+        us = UnitSeries(pd.Series([1.0, 2.0]), parse_unit("meter"))
+        plain = pd.Series([10.0, 20.0])
+        result = us + plain
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("meter")
+        assert list(result.series) == [11.0, 22.0]
+
+    def test_radd_plain_series(self):
+        us = UnitSeries(pd.Series([1.0, 2.0]), parse_unit("meter"))
+        plain = pd.Series([10.0, 20.0])
+        result = plain + us
+        assert isinstance(result, UnitSeries)
+        assert result.unit == parse_unit("meter")
+
+    def test_rsub_scalar(self):
+        us = UnitSeries(pd.Series([2.0, 3.0]), parse_unit("kW"))
+        result = 10 - us
+        assert isinstance(result, UnitSeries)
+        assert list(result.series) == [8.0, 7.0]
+
+    def test_rtruediv_scalar(self):
+        us = UnitSeries(pd.Series([2.0, 5.0]), parse_unit("second"))
+        result = 10 / us
+        assert isinstance(result, UnitSeries)
+        assert list(result.series) == [5.0, 2.0]
+
+
+class TestUnitSeriesRelaxed:
+    def setup_method(self):
+        self._original = get_unit_mode()
+        set_unit_mode("relaxed")
+
+    def teardown_method(self):
+        set_unit_mode(self._original)
+
+    def test_incompatible_add_warns(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("meter"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("second"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = a + b
+            assert len(w) == 1
+            assert "incompatible dimensions" in str(w[0].message)
+        assert isinstance(result, UnitSeries)
+        assert list(result.series) == [2.0]  # pandas just added them
+
+    def test_different_scale_warns(self):
+        a = UnitSeries(pd.Series([1.0]), parse_unit("kWh"))
+        b = UnitSeries(pd.Series([1.0]), parse_unit("TWh"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = a + b
+            assert len(w) == 1
+            assert "different scale" in str(w[0].message)
+        assert isinstance(result, UnitSeries)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -473,3 +473,55 @@ class TestUnitSeriesComparison:
         result = a > 1.5
         assert isinstance(result, pd.Series)
         assert list(result) == [False, True, True]
+
+
+class TestQUDTDetection:
+    def test_is_qudt_uri_http(self):
+        from sunstone.units import is_qudt_uri
+
+        assert is_qudt_uri("http://qudt.org/vocab/unit/KiloW-HR") is True
+
+    def test_is_qudt_uri_https(self):
+        from sunstone.units import is_qudt_uri
+
+        assert is_qudt_uri("https://qudt.org/vocab/unit/M") is True
+
+    def test_is_qudt_uri_prefix(self):
+        from sunstone.units import is_qudt_uri
+
+        assert is_qudt_uri("qudt:KiloW-HR") is True
+
+    def test_is_not_qudt_uri(self):
+        from sunstone.units import is_qudt_uri
+
+        assert is_qudt_uri("kWh") is False
+        assert is_qudt_uri("meter / second") is False
+
+    def test_parse_unit_string_pint(self):
+        from sunstone.units import parse_unit_string
+
+        unit, source = parse_unit_string("kWh")
+        assert str(unit) == "kilowatt_hour"
+        assert source is None
+
+    def test_parse_unit_string_qudt_without_ontopint_raises(self):
+        from sunstone.units import parse_unit_string
+        import unittest.mock
+
+        with unittest.mock.patch.dict("sys.modules", {"ontopint": None}):
+            with pytest.raises(UnitError, match="QUDT URI.*Install sunstone-py\\[qudt\\]"):
+                parse_unit_string("http://qudt.org/vocab/unit/KiloW-HR")
+
+
+class TestFieldSchemaUnitSource:
+    def test_unit_source_default_none(self):
+        from sunstone.lineage import FieldSchema
+
+        f = FieldSchema(name="x", unit="kWh")
+        assert f.unit_source is None
+
+    def test_unit_source_set(self):
+        from sunstone.lineage import FieldSchema
+
+        f = FieldSchema(name="x", unit="kWh", unit_source="http://qudt.org/vocab/unit/KiloW-HR")
+        assert f.unit_source == "http://qudt.org/vocab/unit/KiloW-HR"

--- a/uv.lock
+++ b/uv.lock
@@ -92,6 +92,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +434,30 @@ wheels = [
 ]
 
 [[package]]
+name = "flexcache"
+version = "0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/b0/8a21e330561c65653d010ef112bf38f60890051d244ede197ddaa08e50c1/flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656", size = 15816, upload-time = "2024-03-09T03:21:07.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32", size = 13263, upload-time = "2024-03-09T03:21:05.635Z" },
+]
+
+[[package]]
+name = "flexparser"
+version = "0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/99/b4de7e39e8eaf8207ba1a8fa2241dd98b2ba72ae6e16960d8351736d8702/flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2", size = 31799, upload-time = "2024-11-07T02:00:56.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846", size = 27625, upload-time = "2024-11-07T02:00:54.523Z" },
+]
+
+[[package]]
 name = "frictionless"
 version = "5.18.1"
 source = { registry = "https://pypi.org/simple" }
@@ -452,6 +485,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/d0/c94675a1c1b8c12fd68489e2b4a924f80a2b122199cd986c58a5136197d2/frictionless-5.18.1.tar.gz", hash = "sha256:daeaf55f896eeb52b43e62600466af9528fe0aeeebd28b1b917e13322f370a8b", size = 74372478, upload-time = "2025-03-25T21:32:50.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/7a/dac76d31584bb4f874ae860490c9465f5b59bd8c110f68fbbb07aba48845/frictionless-5.18.1-py3-none-any.whl", hash = "sha256:3f4c87469a89bdb88e9cc318088553a26f3d14839098f95c183ea01fc89628dd", size = 531615, upload-time = "2025-03-25T21:32:45.534Z" },
+]
+
+[[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
 ]
 
 [[package]]
@@ -657,6 +699,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -714,6 +765,86 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/42/149c7747977db9d68faee960c1a3391eb25e94d4bb677f8e2df8328e4098/lxml-6.0.3.tar.gz", hash = "sha256:a1664c5139755df44cab3834f4400b331b02205d62d3fdcb1554f63439bf3372", size = 4237567, upload-time = "2026-04-09T14:39:09.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/4c/552571c619edd607432cbbf25e312a5d02859f2a7de421494a644b48451e/lxml-6.0.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ad6952810349cbfb843fe15e8afc580b2712359ae42b1d2b05d097bd48c4aea4", size = 8570109, upload-time = "2026-04-09T14:34:50.969Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/49/cf08843a6a923cd1eef40797a31e61424ac257c43634b5c9cff3bee93696/lxml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b81ec1ecac3be8c1ff1e00ca1c1baf8122e87db9000cd2549963847bd5e3b41", size = 4623404, upload-time = "2026-04-09T14:34:53.79Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/59/ffde0037a781b10c854abdf9e34fbf60d8f375ce8026551982b9f26695cc/lxml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:448e69211e59c39f398990753d15ba49f7218ec128f64ac8012ef16762e509a3", size = 4929662, upload-time = "2026-04-09T14:34:55.763Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/c468055e45954a93e1bc043a964d327d6784552d6551dc2364a1f83c53a1/lxml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6289cb9145fbbc5b0e159c9fcd7fc09446dadc6b60b72c4d1012e80c7c727970", size = 5092106, upload-time = "2026-04-09T14:34:58.522Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a3/8400c79a6defe609e24ce7b580f48d53f08acbf4c998eede0083a89f16f0/lxml-6.0.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b68c29aac4788438b07d768057836de47589c7deaa3ad8dc4af488dfc27be388", size = 5004214, upload-time = "2026-04-09T14:35:00.531Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b5/797246619cd0831c8d239f91fd4683683abbe7144854c6f33c68a6ea9f42/lxml-6.0.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:50293e024afe5e2c25da2be68c8ceca8618912a0701a73f75b488317c8081aa6", size = 5630889, upload-time = "2026-04-09T14:35:02.89Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/fa/b86302385dc896d02ebb2803e4522a923acaa30e6cb35223492257ee24ab/lxml-6.0.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac65c08ba1bd90f662cb1d5c79f7ae4c53b1c100f0bb6ec5df1f40ac29028a7e", size = 5237728, upload-time = "2026-04-09T14:35:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/7d/812c054b7d15f4dfb3a6fc877c2936023fcd8ac8b53807f996c8c60c4f57/lxml-6.0.3-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:16fbcf06ae534b2fa5bcdc19fcf6abd9df2e74fe8563147d1c5a687a130efed4", size = 5349527, upload-time = "2026-04-09T14:35:08.121Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4a/33a572874924809928747cd156b172b04cd19c1ec1d10925fc77dfeb676d/lxml-6.0.3-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:3a0484bd1e84f82766befcbd71cccd7307dacfe08071e4dbc1d9a9b498d321e8", size = 4693177, upload-time = "2026-04-09T14:35:10.4Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d5/71842813ca0c43718f641e770195e278832f8c01870eaac857a3de34448a/lxml-6.0.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c137f8c8419c3de93e2998131d94628805f148e52b34da6d7533454e4d78bc2a", size = 5243928, upload-time = "2026-04-09T14:35:12.393Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a7/330845ae467c6086ef35977c335bb252fa11490082335f9ccfd0465bdfb7/lxml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:775266571f7027b1d77f5fce18a247b24f51a4404bdc1b90ec56be9b1e3801b9", size = 5046937, upload-time = "2026-04-09T14:35:15.209Z" },
+    { url = "https://files.pythonhosted.org/packages/02/3d/b58b0aee0cf7e0b7eb5d24795a129c634c6d07f032d8b902bb0859319d13/lxml-6.0.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:aa18653b795d2c273b8676f7ad2ca916d846d15864e335f746658e4c28eb5168", size = 4776758, upload-time = "2026-04-09T14:35:17.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4c/f421b50f08c1b724a24c4a778db8888d0a2d948b4dd08b80f4f05a0804ff/lxml-6.0.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:cbffd22fc8e4d80454efa968b0c93440a00b8b8a817ce0c29d2c6cb5ad324362", size = 5644912, upload-time = "2026-04-09T14:35:20.438Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/99/eabfedb111ca1f26c8fe890413eabc7e2b0010f075fdf5bceb42737c3894/lxml-6.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7373ede7ccb89e6f6e39c1423b3a4d4ee48035d3b4619a6addced5c8b48d0ecc", size = 5233509, upload-time = "2026-04-09T14:35:23.137Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/17/050a105ca1154025b68c19901d45292cbdcee6f25bd056c178ad6b55e534/lxml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e759ff1b244725fef428c6b54f3dab4954c293b2d242a5f2e79db5cc3873de51", size = 5260150, upload-time = "2026-04-09T14:35:25.385Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a0/ed83517d12e9fe00101a21fe08a168fd69f57875d9416353e2a38c401df7/lxml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:f179bae37ad673f57756b59f26833b7922230bef471fdb29492428f152bae8c6", size = 3595160, upload-time = "2026-04-09T14:35:27.519Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d3/101726831f45951fe3ddd03cffbd2a4ac6261fc63ada399e6f7051d43af6/lxml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:8eeec925ad7f81886d413b3a1f8715551f75543519229a9b35e957771e1826d5", size = 3996108, upload-time = "2026-04-09T14:35:29.608Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/ab1c58ad55bfcd4b55bafd98f19ff24f34315441f13aa787d5220def0702/lxml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:f96bba9a26a064ce9e11099bad12fb08384b64d3acc0acf94bf386ca5cf4f95f", size = 3658906, upload-time = "2026-04-09T14:35:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/2cdc9c5a634b1b890927f968febc2474fa3eb6fed99db82ea3c008bbbda4/lxml-6.0.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:83c1d75e9d124ab82a4ddaf59135112f0dc49526b47355e5928ae6126a68e236", size = 8559579, upload-time = "2026-04-09T14:35:35.644Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3c/adfbcdab17f89f72e069c5df5661c81e0511e3cdb353550f778e9ffaa08e/lxml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b683665d0287308adafc90a5617a51a508d8af8c7040693693bb333b5f4474fe", size = 4617332, upload-time = "2026-04-09T14:35:38.901Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d4/ee1a5c734a5ad79024fa85808f3efc18d5733813141e2bb2726a7d9d8bea/lxml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ed31e5852cd938704bc6c7a3822cbf84c7fa00ebfa914a1b4e2392d44f45bdfb", size = 4922821, upload-time = "2026-04-09T14:35:41.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1f/87efcc0b93ba4f95303ec8f80164f3c50db20a3a5612a285133f9ad6cb7e/lxml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8922a30704a4421d69a19e0499db5861da686c0bccc3a79cf3946e3155cf25f9", size = 5081226, upload-time = "2026-04-09T14:35:44.02Z" },
+    { url = "https://files.pythonhosted.org/packages/65/8b/fd0fadd9ec8a6ac9d694014ccdb9504e28705abb2e08c9ca23c609020325/lxml-6.0.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a1adb0e220cb8691202ba9d97646a06292657a122df4b92733861d42f7cf4d2", size = 4992884, upload-time = "2026-04-09T14:35:46.769Z" },
+    { url = "https://files.pythonhosted.org/packages/68/75/2fb0e534225214c6386496b7847195d7297b913cf563c5ccea394afc346b/lxml-6.0.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:821fd53699eb498990c915ba955a392d07246454c9405e6c1d0692362503013d", size = 5613383, upload-time = "2026-04-09T14:35:49.303Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/8f560f8fb2f5f092e18ac7a13a94b77e0e5213fe7c424d12e98393dcc7d8/lxml-6.0.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04b7cedf52e125f86d0d426635e7fbe8e353d4cc272a1757888e3c072424381d", size = 5228398, upload-time = "2026-04-09T14:35:51.611Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d5/6bf993c02a0173eb5883ace61958c55c245d3daf7753fb5f931a9691b440/lxml-6.0.3-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:9d98063e6ae0da5084ec46952bb0a5ccb5e2cad168e32b4d65d1ec84e4b4ebd4", size = 5342198, upload-time = "2026-04-09T14:35:54.311Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/18/637130349ca6aa33b6dc4796732835ede5017a811c5f55763a1c468f7971/lxml-6.0.3-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:ce01ab3449015358f766a1950b3d818eedf9d4cdec3fa87e4eecaad10c0784db", size = 4699178, upload-time = "2026-04-09T14:35:56.647Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/19/239daafcc1cfa42b8aa6384509a9fd2cb1aa281679c6e8395adf9ccbc189/lxml-6.0.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d38c25bad123d6ce30bb37931d90a4e8a167cd796eeae9cd16c2bfce52718f8e", size = 5231869, upload-time = "2026-04-09T14:36:00.41Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/74/db7fcadc651b988502bed00d48acfd8b997ecb5dd52ebcc05f39bf946d9e/lxml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9b8e0779780026979f217603385995202f364adc9807bd21210d81b9f562fc4e", size = 5043669, upload-time = "2026-04-09T14:36:02.463Z" },
+    { url = "https://files.pythonhosted.org/packages/55/99/af795b579182fa04aa87fcb0bd112e22705d982f71eb53874a8d356b4091/lxml-6.0.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8c082ad2398664213a4bb5d133e2eb8bf239220b7d6688f8c8ffa9050057501f", size = 4769745, upload-time = "2026-04-09T14:36:04.716Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4d/10e652edc55d206188a1b738d1033aad3497886d34cb7f5fc753e67ecb49/lxml-6.0.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfc80c74233fe01157ab550fb12b9d07a2f1fa7c5900cefb484e3bf02e856fbc", size = 5635496, upload-time = "2026-04-09T14:36:06.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/68/95371835ec15bb46feee27b090bcabbe579f4ad04efbef08e2713bcfea16/lxml-6.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5c45bdcdc2ca6cf26fddff3faa5de7a2ed7c7f6016b3de80125313a37f972378", size = 5223564, upload-time = "2026-04-09T14:36:09.057Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a6/0a9e5b63e8959487551be5d5496bb758ed2424c77ed7b25a9b8aae3b60c6/lxml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:99457524afd384c330dc51e527976653d543ccadfa815d9f2d92c5911626e536", size = 5250124, upload-time = "2026-04-09T14:36:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/80/de3d3a790edf6d026c829fe8ccf54845058f57f8bb788e420c3b227eecef/lxml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:c8e3b8a54e65393ce1d5c7d9753fe756f0d96089e7163b20ddec3e5bb56a963e", size = 3596004, upload-time = "2026-04-09T14:36:13.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cf/43c9a5926060e39d99593921f37d7e88f129bc32ab6266b8460483abd613/lxml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:724b26a38cef98d6869d00a33cb66083bee967598e44f6a8e53f1dd283c851b0", size = 3994750, upload-time = "2026-04-09T14:36:15.686Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/b224dbc282bfef52d2e05645e405b5ed89c6391144dc09864229fe9ce88c/lxml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:f27373113fda6621e4201f529908a24c8a190c2af355aed4711dadca44db4673", size = 3657620, upload-time = "2026-04-09T14:36:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/40/b637359bacf3813f1174d15b08516020ba5beb355e04377105d561e6e00a/lxml-6.0.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8c08926678852a233bf1ef645c4d683d56107f814482f8f41b21ef2c7659790e", size = 8575318, upload-time = "2026-04-09T14:36:20.608Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/91/d5286a45202ed91f1e428e68c6e1c11bcb2b42715c48424871fc73485b05/lxml-6.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2ce76d113a7c3bf42761ec1de7ca615b0cbf9d8ae478eb1d6c20111d9c9fc098", size = 4623084, upload-time = "2026-04-09T14:36:24.015Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5f/7ea1af571ee13ed1e5fba007fd83cd0794723ca76a51eed0ef9513363b1f/lxml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83eca62141314d641ebe8089ffa532bbf572ea07dd6255b58c40130d06bb2509", size = 4948797, upload-time = "2026-04-09T14:36:26.662Z" },
+    { url = "https://files.pythonhosted.org/packages/82/be/3a9b8d787d9877cbe17e02ef5af2523bd14ecc177ce308397c485c56fe18/lxml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d8781d812bb8efd47c35651639da38980383ff0d0c1f3269ade23e3a90799079", size = 5085983, upload-time = "2026-04-09T14:36:29.486Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2b/645abaef837b11414c81513c31b308a001fb8cd370f665c3ebc854be5ba5/lxml-6.0.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19b079e81aa3a31b523a224b0dd46da4f56e1b1e248eef9a599e5c885c788813", size = 5031039, upload-time = "2026-04-09T14:36:31.735Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/561f30b77e9edbb373e2b6b7203a7d6ab219c495abca219536c66f3a44b2/lxml-6.0.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6c055bafdcb53e7f9f75e22c009cd183dd410475e21c296d599531d7f03d1bf5", size = 5646718, upload-time = "2026-04-09T14:36:34.127Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ba/2a72e673d109b563c2ab77097f2f4ca64e2927d2f04836ba07aaabe1da0e/lxml-6.0.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f1594a183cee73f9a1dbfd35871c4e04b461f47eeb9bcf80f7d7856b1b136d", size = 5239360, upload-time = "2026-04-09T14:36:37.195Z" },
+    { url = "https://files.pythonhosted.org/packages/52/98/4e5a4ef87d846af90cc9c1ee2f8af2af34c221e620aad317b3a535361b93/lxml-6.0.3-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:a6380c5035598e4665272ad3fc86c96ddb2a220d4059cce5ba4b660f78346ad9", size = 5351233, upload-time = "2026-04-09T14:36:39.634Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b8/cff0af5fe48ede6b1949dc2e14171470c0c68a15789037c1fed90602b89d/lxml-6.0.3-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:143ac903fb6c9be6da613390825c8e8bb8c8d71517d43882031f6b9bc89770ef", size = 4696677, upload-time = "2026-04-09T14:36:42.037Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/6e/0b2a918fb15c30b00ff112df16c548df011db37b58d764bd17f47db74905/lxml-6.0.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4fff7d77f440378cd841e340398edf5dbefee334816efbf521bb6e31651e54e", size = 5250503, upload-time = "2026-04-09T14:36:44.417Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1b/4697918f9d4c2e643e2c59cedb37c2f3a9f76fb1217d767f6dff476813d8/lxml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:631567ffc3ddb989ccdcd28f6b9fa5aab1ec7fc0e99fe65572b006a6aad347e2", size = 5084563, upload-time = "2026-04-09T14:36:46.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8c/d7ec96246f0632773912c6556288d3b6bb6580f3a967441ca4636ddc3f73/lxml-6.0.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:38acf7171535ffa7fff1fcec8b82ebd4e55cd02e581efe776928108421accaa1", size = 4737407, upload-time = "2026-04-09T14:36:49.826Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0c/603e35bf77aeb28c972f39eece35e7c0f6579ff33a7bed095cc2f7f942d9/lxml-6.0.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:06b9f3ac459b4565bbaa97aa5512aa7f9a1188c662f0108364f288f6daf35773", size = 5670919, upload-time = "2026-04-09T14:36:52.231Z" },
+    { url = "https://files.pythonhosted.org/packages/92/08/6d3f188e6705cf0bfd8b5788055c7381bb3ffa786dfba9fa0b0ed5778506/lxml-6.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2773dbe2cedee81f2769bd5d24ceb4037706cf032e1703513dd0e9476cd9375f", size = 5237771, upload-time = "2026-04-09T14:36:55.286Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4c/01639533b90e9ff622909c113df2ab2dbdd1d78540eb153d13b66a9c96ba/lxml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:30c437d8bb9a9a9edff27e85b694342e47a26a6abc249abe00584a4824f9d80d", size = 5263862, upload-time = "2026-04-09T14:36:58.247Z" },
+    { url = "https://files.pythonhosted.org/packages/06/0e/bd1157d7b09d1f5e1d580c124203cee656130a3f8908365760a593b21daf/lxml-6.0.3-cp314-cp314-win32.whl", hash = "sha256:1b60a3a1205f869bd47874787c792087174453b1a869db4837bf5b3ff92be017", size = 3656378, upload-time = "2026-04-09T14:37:47.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cc/d50cbce8cd5687670868bea33bbeefa0866c5e5d02c5e11c4a04c79fc45e/lxml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:5b6913a68d98c58c673667c864500ba31bc9b0f462effac98914e9a92ebacd2e", size = 4062518, upload-time = "2026-04-09T14:37:49.911Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c7/ece11a1e51390502894838aa384e9f98af7bef4d6806a927197153a16972/lxml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:1b36a3c73f2a6d9c2bfae78089ca7aedae5c2ee5fd5214a15f00b2f89e558ba7", size = 3741064, upload-time = "2026-04-09T14:37:52.185Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ae/918d7f89635fb6456cd732c12246c0e504dd9c49e8006f3593c9ecdb90ff/lxml-6.0.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:239e9a6be3a79c03ec200d26f7bb17a4414704a208059e20050bf161e2d8848a", size = 8826590, upload-time = "2026-04-09T14:37:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cf/bda0ae583758704719976b9ea69c8b089fa5f92e49683e517386539b21cf/lxml-6.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:16e5cbaa1a6351f2abefa4072e9aac1f09103b47fe7ab4496d54e5995b065162", size = 4735028, upload-time = "2026-04-09T14:37:03.602Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0e/3bfb18778c6f73c7ead2d49a256501fa3052888b899826f5d1df1fbdf83b/lxml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89f8746c206d8cf2c167221831645d6cc2b24464afd9c428a5eb3fd34c584eb1", size = 4969184, upload-time = "2026-04-09T14:37:05.914Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e6/796c77751a682d6d1bb9aa3fe43851b41a21b0377100e246a4a83a81d668/lxml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5d559a84b2fd583e5bcf8ec4af1ec895f98811684d5fbd6524ea31a04f92d4ad", size = 5103548, upload-time = "2026-04-09T14:37:08.605Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/a02aee214f657f29d4690d88161de8ffb8f1b5139e792bae313b9479e317/lxml-6.0.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7966fbce2d18fde579d5593933d36ad98cc7c8dc7f2b1916d127057ce0415062", size = 5027775, upload-time = "2026-04-09T14:37:11.283Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e5/65dd25f2c366879d696d1c720af9a96fa0969d2d135a27b6140222fc6f68/lxml-6.0.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a1f258e6aa0e6eda2c1199f5582c062c96c7d4a28d96d0c4daa79e39b3f2a764", size = 5595348, upload-time = "2026-04-09T14:37:13.618Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/1f/2f0e80d7fd2ad9755d771af4ad46ea14bf871bc5a1d2d365a3f948940ddf/lxml-6.0.3-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:738aef404c862d2c3cd951364ee7175c9d50e8290f5726611c4208c0fba8d186", size = 5224217, upload-time = "2026-04-09T14:37:16.519Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/28/e1aaeee7d6a4c9f24a3e4535a4e19ce64b99eefbe7437d325b61623b1817/lxml-6.0.3-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:5c35e5c3ed300990a46a144d3514465713f812b35dacfa83e928c60db7c90af7", size = 5312245, upload-time = "2026-04-09T14:37:19.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ac/9633cb919124473e03c62862b0494bf0e1705f902fbd9627be4f648bddfb/lxml-6.0.3-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:4ff774b43712b0cf40d9888a5494ca39aefe990c946511cc947b9fddcf74a29b", size = 4637952, upload-time = "2026-04-09T14:37:21.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/aa/135baeea457d41989bafa78e437fe3a370c793aab0d8fb3da73ccae10095/lxml-6.0.3-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d20af2784c763928d0d0879cbc5a3739e4d81eefa0d68962d3478bff4c13e644", size = 5232782, upload-time = "2026-04-09T14:37:24.6Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/d05183ac8440cbc4c6fa386edb7ba9718bee4f097e58485b1cd1f9479d56/lxml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fdb7786ebefaa0dad0d399dfeaf146b370a14591af2f3aea59e06f931a426678", size = 5083889, upload-time = "2026-04-09T14:37:27.432Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/58/e9fda8fb82775491ad0290c7b17252f944b6c3a6974cd820d65910690351/lxml-6.0.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c71a387ea133481e725079cff22de45593bf0b834824de22829365ab1d2386c9", size = 4758658, upload-time = "2026-04-09T14:37:29.81Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/32/4aae9f004f79f9d200efd8343809cfe46077f8e5bd58f08708c320a20fcd/lxml-6.0.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:841b89fc3d910d61c7c267db6bb7dc3a8b3dac240edb66220fcdf96fe70a0552", size = 5619494, upload-time = "2026-04-09T14:37:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/49/407fa9e3c91e7c6d0762eaeedd50d4695bcd26db817e933ca689eb1f3df4/lxml-6.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:ac2d6cdafa29672d6a604c641bf67ace3fd0735ec6885501a94943379219ddbf", size = 5228386, upload-time = "2026-04-09T14:37:36.058Z" },
+    { url = "https://files.pythonhosted.org/packages/99/92/39982f818acbb1dd67dd5d20c2a06bcb9f1f3b9a8ff0021e367904f82417/lxml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:609bf136a7339aeca2bd4268c7cd190f33d13118975fe9964eda8e5138f42802", size = 5247973, upload-time = "2026-04-09T14:37:38.836Z" },
+    { url = "https://files.pythonhosted.org/packages/66/68/fcdbb78c8cda81a86e17b31abf103b7e474e474a09fb291a99e7a9b43eb8/lxml-6.0.3-cp314-cp314t-win32.whl", hash = "sha256:bf98f5f87f6484302e7cce4e2ca5af43562902852063d916c3e2f1c115fdce60", size = 3896249, upload-time = "2026-04-09T14:37:41.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/6292681ac4a4223b700569ce98f71662cb07c5a3ade4f346f5f0d5c574cf/lxml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d3d65e511e4e656ec67b472110f7a72cbf8547ca15f76fe74cffa4e97412a064", size = 4391091, upload-time = "2026-04-09T14:37:43.357Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/a0f486360a6f1b36fd2f5eb62d037652bef503d82b6f853aee6664cdfcac/lxml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:cbc7ce67f85b92db97c92219985432be84dc1ba9a028e68c6933e89551234df2", size = 3816374, upload-time = "2026-04-09T14:37:45.532Z" },
 ]
 
 [[package]]
@@ -1017,6 +1148,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ontopint"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pint" },
+    { name = "pyld" },
+    { name = "rdflib" },
+    { name = "sparqlwrapper" },
+    { name = "ucumvert" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/bb/a53324842775cfb7866bff5bb56b0453a37051db4b1e76cec6d913c7af07/ontopint-0.1.1.tar.gz", hash = "sha256:712a8888984197c4d4fff99170560ec6c62183b459780f7e585ea62e1099a8e7", size = 9764, upload-time = "2024-04-30T04:46:44.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f1/0fff492b6e4049d8bc0d0f20751814550cd5ba735f0ca45095fbf85a1df4/ontopint-0.1.1-py3-none-any.whl", hash = "sha256:b12ac8ec4701f9f77d3908cecdd35751ddc9ce1e36dc509ca43712a42236fa9b", size = 6054, upload-time = "2024-04-30T04:46:42.999Z" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1126,6 +1273,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/07/16a40e30700f7c6975e62cba01c2f94afbb347dd8ed224a5918c686a47fe/petl-1.7.17.tar.gz", hash = "sha256:802696187c2ef35894c4acf3c0ff9fecff6035cb335944c194416b9a18e8390b", size = 424376, upload-time = "2025-07-10T20:47:13.523Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/5c/ea831abc18dd3268046d7d9a0119f1f8ddc69642e0a5245f839602b8114d/petl-1.7.17-py3-none-any.whl", hash = "sha256:53785128bcdf46eb4472638ad572acc6d87cc83f80b567fed06ee4a947eea5d1", size = 233093, upload-time = "2025-07-10T20:47:12.03Z" },
+]
+
+[[package]]
+name = "pint"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flexcache" },
+    { name = "flexparser" },
+    { name = "platformdirs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/9d/b1379cdbd33a49d17d627bc24e2b63cca06a1c5343b38072d2889499e82e/pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee", size = 255106, upload-time = "2026-03-19T21:57:08.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl", hash = "sha256:27eb25143bd5de9fcc4d5a4b484f16faf6b4615aa93ece6b3373a8c1a3c1b97d", size = 307488, upload-time = "2026-03-19T21:57:07.022Z" },
 ]
 
 [[package]]
@@ -1342,6 +1504,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyld"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "frozendict" },
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/67/2c69359f671f50b551821dcdf6b85beb52f2b0115da933ae0c179f90092b/pyld-3.0.0.tar.gz", hash = "sha256:b1913a06054f35a31e4d9916d184852909b2a3c5fea55c341bd00917cf8b22ef", size = 85056, upload-time = "2026-04-02T09:10:16.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/68/51a87c1bdf9beb0fdda6bbff67d32a1689d399e2fc74fe8fb9ada08f1f90/pyld-3.0.0-py3-none-any.whl", hash = "sha256:bfe0f5a476c67d8766d47c445ef2170b868a72654e535dbebc89c8e040b1fe88", size = 76837, upload-time = "2026-04-02T09:10:14.457Z" },
+]
+
+[[package]]
 name = "pymdown-extensions"
 version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1473,6 +1649,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
 ]
 
 [[package]]
@@ -1681,6 +1869,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sparqlwrapper"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rdflib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/cc/453752fffa759ef41a3ceadb3f167e13dae1a74c1db057d9f6a7affa9240/SPARQLWrapper-2.0.0.tar.gz", hash = "sha256:3fed3ebcc77617a4a74d2644b86fd88e0f32e7f7003ac7b2b334c026201731f1", size = 98429, upload-time = "2022-03-13T23:14:00.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/89/176e3db96e31e795d7dfd91dd67749d3d1f0316bb30c6931a6140e1a0477/SPARQLWrapper-2.0.0-py3-none-any.whl", hash = "sha256:c99a7204fff676ee28e6acef327dc1ff8451c6f7217dcd8d49e8872f324a8a20", size = 28620, upload-time = "2022-03-13T23:13:58.969Z" },
+]
+
+[[package]]
 name = "sunstone-py"
 version = "1.3.1"
 source = { editable = "." }
@@ -1689,15 +1889,20 @@ dependencies = [
     { name = "google-auth" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "pint" },
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
+    { name = "tomli-w" },
     { name = "typer" },
 ]
 
 [package.optional-dependencies]
 gcs = [
     { name = "google-cloud-storage" },
+]
+qudt = [
+    { name = "ontopint" },
 ]
 s3 = [
     { name = "boto3" },
@@ -1725,14 +1930,17 @@ requires-dist = [
     { name = "frictionless", specifier = ">=5.18.1" },
     { name = "google-auth", specifier = ">=2.43.0" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.0" },
+    { name = "ontopint", marker = "extra == 'qudt'", specifier = ">=0.1" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pint", specifier = ">=0.24" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "typer", specifier = ">=0.15" },
 ]
-provides-extras = ["gcs", "s3"]
+provides-extras = ["gcs", "s3", "qudt"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1829,6 +2037,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "ucumvert"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+    { name = "pint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/4c/b0e949900f3b5c1e84bc8aa63d0c6687726985a58abda1a68146a4997dd1/ucumvert-0.3.1.tar.gz", hash = "sha256:8c287a71e453f79c822213239cf6873407b7363c6bca42f7418a1d56282c90c6", size = 52256, upload-time = "2025-12-04T09:42:01.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/f7/44633e6317c569fa448aeed3a64c20482d7c802e2d4f18a1adf3826374b8/ucumvert-0.3.1-py3-none-any.whl", hash = "sha256:503b3cc3dfba7ec0c1b53a9692e74163e6d9dc5119422f8ff57f5a044fed0231", size = 53180, upload-time = "2025-12-04T09:42:00.288Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add unit-aware arithmetic to Sunstone DataFrames using Pint as the unit engine
- New `UnitSeries` proxy returned by `DataFrame.__getitem__` for columns with units in field metadata
- Three unit handling modes: **relaxed** (default, warn-only), **strict** (raise on mismatch), **auto** (convert automatically)
- Unit resolution in `concat()`, `merge()`, and `join()` operations
- QUDT URI detection and round-tripping via optional `ontopint` dependency (`sunstone-py[qudt]`)
- Unit-aware comparison operators with mode-specific behavior

## Key design decisions

- **Relaxed by default**: Data scientists aren't forced into unit strictness — `set_unit_mode("auto")` opts in to conversions
- **Domain-specific units allowed**: In relaxed mode, non-Pint units like "students" or "people" are accepted as metadata labels
- **Finer-granularity wins**: When auto-converting compatible units (e.g. kWh + TWh), the finer unit (kWh) is chosen to preserve precision
- **QUDT at boundaries only**: QUDT URI resolution happens at read/write time, never during arithmetic — no network calls in hot paths

## New files

- `src/sunstone/units.py` — Pint registry, mode management, `resolve_units()`, `UnitSeries` proxy, QUDT helpers
- `tests/test_units.py` — 68 tests for unit logic
- `tests/test_unit_integration.py` — 19 tests for DataFrame integration

## Test plan

- [x] `uv run pytest tests/test_units.py` — unit resolution, UnitSeries arithmetic, comparison operators, QUDT detection
- [x] `uv run pytest tests/test_unit_integration.py` — DataFrame getitem/setitem, concat/merge/join, metadata isolation
- [x] `uv run pytest` — full suite (658 tests, 93% coverage)