### PR TITLE
fix: prevent package push path exfiltration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Security: Reject dataset and methodology paths that escape the project root during package push
 
 ## [1.4.1] - 2026-04-11
 - Added: `to_parquet()`

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -203,14 +203,18 @@ def collect_methodology_files(
     seen: dict[Path, str] = {}
 
     def _consider(value: str) -> None:
+        from .packaging import validate_path_containment
+
         if is_uri(value):
             # If the URI starts with our base_url, it's a project file we should upload
             if base_url and value.startswith(base_url.rstrip("/") + "/"):
                 rel_path = value[len(base_url.rstrip("/") + "/") :]
+                validate_path_containment(rel_path, manager.project_path, label="methodology file")
                 candidate = manager.get_absolute_path(rel_path)
                 if candidate.exists() and candidate not in seen:
                     seen[candidate] = value
             return
+        validate_path_containment(value, manager.project_path, label="methodology file")
         candidate = manager.get_absolute_path(value)
         if candidate.exists() and candidate not in seen:
             resolved = resolve_methodology_value(value, base_url)

--- a/src/sunstone/exceptions.py
+++ b/src/sunstone/exceptions.py
@@ -37,3 +37,9 @@ class UnitError(SunstoneError):
     """Raised when a unit operation fails (incompatible dimensions, unparseable unit, etc.)."""
 
     pass
+
+
+class PathContainmentError(SunstoneError):
+    """Raised when a path escapes the project root during package build/push."""
+
+    pass

--- a/src/sunstone/packaging.py
+++ b/src/sunstone/packaging.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Optional
 from urllib.parse import urlparse
 
 from .datasets import DatasetsManager
+from .exceptions import PathContainmentError
 from .lineage import DatasetMetadata, PublishConfig
 from .plugins import PluginRegistry
 
@@ -39,6 +40,42 @@ def is_lfs_pointer(file_path: Path) -> bool:
         return content.startswith("version https://git-lfs.github.com/spec/v1\n")
     except (OSError, UnicodeDecodeError):
         return False
+
+
+def validate_path_containment(
+    location: str,
+    project_path: Path,
+    label: str = "dataset",
+) -> None:
+    """Verify that a location resolves to a path inside the project root.
+
+    This prevents untrusted ``datasets.yaml`` entries from reading files
+    outside the project directory during ``package push``.
+
+    Args:
+        location: The raw location string from datasets.yaml.
+        project_path: Resolved project root directory.
+        label: Human-readable label for error messages (e.g. "dataset", "methodology file").
+
+    Raises:
+        PathContainmentError: If the path is absolute or escapes the project root.
+    """
+    loc = Path(location)
+
+    if loc.is_absolute():
+        raise PathContainmentError(
+            f"Refusing to package {label} with absolute path. "
+            f"All {label} locations must be relative to the project root."
+        )
+
+    resolved = (project_path / loc).resolve()
+    try:
+        resolved.relative_to(project_path)
+    except ValueError:
+        raise PathContainmentError(
+            f"Refusing to package {label} whose path escapes the project root. "
+            f"All {label} locations must resolve to a path inside the project directory."
+        )
 
 
 def push_group(
@@ -106,6 +143,9 @@ def push_group(
         if not resource_dict:
             continue
 
+        # Guard: reject paths that escape the project root
+        validate_path_containment(ds.location, manager.project_path, label="dataset")
+
         data_path = manager.get_absolute_path(ds.location)
         if publish_config.flatten:
             remote_path = base_dir + data_path.name
@@ -171,6 +211,14 @@ def push_group(
 
     # Upload methodology files
     for abs_path, _resolved_uri in methodology_files:
+        # Guard: reject methodology files that escape the project root
+        try:
+            abs_path.resolve().relative_to(manager.project_path)
+        except ValueError:
+            raise PathContainmentError(
+                "Refusing to package methodology file whose path escapes the project root. "
+                "All methodology file locations must resolve to a path inside the project directory."
+            )
         if publish_config.flatten:
             methodology_remote = base_dir + abs_path.name
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,15 @@ import pytest
 import typer as _typer
 from typer.testing import CliRunner
 
-from sunstone.cli import _contributor_to_dict, _package_metadata_to_dict, app, expand_env_vars, is_lfs_pointer
+from sunstone.cli import (
+    _contributor_to_dict,
+    _package_metadata_to_dict,
+    app,
+    collect_methodology_files,
+    expand_env_vars,
+    is_lfs_pointer,
+)
+from sunstone.exceptions import PathContainmentError
 from sunstone.lineage import Contributor, PackageMetadata
 
 
@@ -912,6 +920,72 @@ class TestPackagePushCommand:
             methodology_key = "https://sunstone.institute/rdf/vocab#methodology"
             assert methodology_key in datapackage
             assert datapackage[methodology_key] == "https://data.example.com/un-members/DATA_METHODOLOGY.md"
+
+
+class TestMethodologyPathContainment:
+    """Tests that methodology files with escaping paths are rejected."""
+
+    def test_absolute_methodology_path_rejected(self, tmp_path: Path) -> None:
+        """Methodology value pointing to an absolute path is rejected."""
+        manager = MagicMock()
+        manager.project_path = tmp_path
+        manager.get_absolute_path.side_effect = lambda v: (tmp_path / v).resolve()
+
+        top_level_props = {
+            "https://sunstone.institute/rdf/vocab#methodology": "/etc/passwd",
+        }
+
+        with pytest.raises(PathContainmentError, match="absolute path"):
+            collect_methodology_files(
+                datasets=[],
+                top_level_props=top_level_props,
+                rdf_prefixes={},
+                manager=manager,
+            )
+
+    def test_dotdot_methodology_path_rejected(self, tmp_path: Path) -> None:
+        """Methodology value with .. escape is rejected."""
+        # Create the file so the _consider function would find it
+        outside_file = tmp_path.parent / "secret.md"
+        outside_file.write_text("secret")
+
+        manager = MagicMock()
+        manager.project_path = tmp_path
+        manager.get_absolute_path.side_effect = lambda v: (tmp_path / v).resolve()
+
+        top_level_props = {
+            "https://sunstone.institute/rdf/vocab#methodology": "../secret.md",
+        }
+
+        with pytest.raises(PathContainmentError, match="escapes the project root"):
+            collect_methodology_files(
+                datasets=[],
+                top_level_props=top_level_props,
+                rdf_prefixes={},
+                manager=manager,
+            )
+
+    def test_normal_methodology_path_allowed(self, tmp_path: Path) -> None:
+        """Normal in-project methodology paths work fine."""
+        meth_file = tmp_path / "report" / "methodology.md"
+        meth_file.parent.mkdir()
+        meth_file.write_text("# Methodology")
+
+        manager = MagicMock()
+        manager.project_path = tmp_path
+        manager.get_absolute_path.side_effect = lambda v: (tmp_path / v).resolve()
+
+        top_level_props = {
+            "https://sunstone.institute/rdf/vocab#methodology": "report/methodology.md",
+        }
+
+        result = collect_methodology_files(
+            datasets=[],
+            top_level_props=top_level_props,
+            rdf_prefixes={},
+            manager=manager,
+        )
+        assert len(result) == 1
 
 
 class TestIsLfsPointer:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,8 +10,9 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from sunstone.exceptions import PathContainmentError
 from sunstone.lineage import DatasetMetadata, PublishConfig
-from sunstone.packaging import is_lfs_pointer, push_group
+from sunstone.packaging import is_lfs_pointer, push_group, validate_path_containment
 
 
 @pytest.fixture
@@ -338,3 +339,147 @@ def test_push_group_flatten_mode(tmp_path: Path) -> None:
 
     # With flatten, the data file name (not full path) is the resource path
     assert uploaded[1] == "result.csv"
+
+
+# ---------------------------------------------------------------------------
+# Path containment checks
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePathContainment:
+    """Tests for validate_path_containment."""
+
+    def test_absolute_path_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(PathContainmentError, match="absolute path"):
+            validate_path_containment("/etc/passwd", tmp_path, label="dataset")
+
+    def test_dotdot_escape_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(PathContainmentError, match="escapes the project root"):
+            validate_path_containment("../secret.csv", tmp_path, label="dataset")
+
+    def test_nested_dotdot_escape_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(PathContainmentError, match="escapes the project root"):
+            validate_path_containment("outputs/../../secret.csv", tmp_path, label="dataset")
+
+    def test_normal_relative_path_allowed(self, tmp_path: Path) -> None:
+        # Should not raise
+        validate_path_containment("outputs/data.csv", tmp_path, label="dataset")
+
+    def test_simple_filename_allowed(self, tmp_path: Path) -> None:
+        # Should not raise
+        validate_path_containment("data.csv", tmp_path, label="dataset")
+
+
+class TestPushGroupPathContainment:
+    """Integration tests: push_group rejects escaping paths."""
+
+    def test_absolute_dataset_location_rejected(self, tmp_path: Path) -> None:
+        ds = DatasetMetadata(slug="evil", name="Evil", location="/etc/passwd", dataset_type="output")
+        manager = MagicMock()
+        manager.project_path = tmp_path
+
+        with pytest.raises(PathContainmentError, match="absolute path"):
+            push_group(
+                dest_url="gs://bucket/pkg/",
+                datasets=[ds],
+                manager=manager,
+                project_slug="p",
+                publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+                build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+                package_metadata_fn=lambda: None,
+                rdf_prefixes={},
+                top_level_props={},
+                methodology_files=[],
+            )
+
+    def test_dotdot_dataset_location_rejected(self, tmp_path: Path) -> None:
+        ds = DatasetMetadata(slug="evil", name="Evil", location="../secret.csv", dataset_type="output")
+        manager = MagicMock()
+        manager.project_path = tmp_path
+
+        with pytest.raises(PathContainmentError, match="escapes the project root"):
+            push_group(
+                dest_url="gs://bucket/pkg/",
+                datasets=[ds],
+                manager=manager,
+                project_slug="p",
+                publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+                build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+                package_metadata_fn=lambda: None,
+                rdf_prefixes={},
+                top_level_props={},
+                methodology_files=[],
+            )
+
+    def test_methodology_outside_project_rejected(self, tmp_path: Path) -> None:
+        """Methodology files with paths outside the project are rejected."""
+        data_file = tmp_path / "data.csv"
+        data_file.write_text("a\n1\n")
+
+        ds = DatasetMetadata(slug="d", name="D", location="data.csv", dataset_type="output")
+        manager = MagicMock()
+        manager.get_absolute_path.return_value = data_file
+        manager.project_path = tmp_path
+
+        # A methodology file that is outside the project root
+        outside_path = tmp_path.parent / "outside_methodology.pdf"
+
+        streams: dict[str, io.IOBase] = {}
+        mock_handler = _make_handler(streams)
+        mock_registry = MagicMock()
+        mock_registry.find_url_handler.return_value = mock_handler
+
+        with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+            MockPluginRegistry.get.return_value = mock_registry
+
+            with pytest.raises(PathContainmentError, match="methodology file"):
+                push_group(
+                    dest_url="gs://bucket/pkg/",
+                    datasets=[ds],
+                    manager=manager,
+                    project_slug="p",
+                    publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+                    build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+                    package_metadata_fn=lambda: None,
+                    rdf_prefixes={},
+                    top_level_props={},
+                    methodology_files=[(outside_path, "https://example.com/methodology.pdf")],
+                )
+
+    def test_normal_paths_still_work(self, tmp_path: Path) -> None:
+        """Normal in-project paths should still build and push fine."""
+        data_dir = tmp_path / "outputs"
+        data_dir.mkdir()
+        data_file = data_dir / "result.csv"
+        data_file.write_bytes(b"x,y\n3,4\n")
+
+        meth_file = tmp_path / "methodology.pdf"
+        meth_file.write_bytes(b"PDF content")
+
+        ds = DatasetMetadata(slug="result", name="Result", location="outputs/result.csv", dataset_type="output")
+        manager = MagicMock()
+        manager.get_absolute_path.return_value = data_file
+        manager.project_path = tmp_path
+
+        streams: dict[str, io.IOBase] = {}
+        mock_handler = _make_handler(streams)
+        mock_registry = MagicMock()
+        mock_registry.find_url_handler.return_value = mock_handler
+
+        with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+            MockPluginRegistry.get.return_value = mock_registry
+
+            uploaded = push_group(
+                dest_url="gs://bucket/pkg/",
+                datasets=[ds],
+                manager=manager,
+                project_slug="test-project",
+                publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+                build_resource_dict_fn=lambda d, m, pc: {"path": d.location, "name": d.slug},
+                package_metadata_fn=lambda: None,
+                rdf_prefixes={},
+                top_level_props={},
+                methodology_files=[(meth_file, "https://example.com/methodology.pdf")],
+            )
+
+        assert len(uploaded) == 3


### PR DESCRIPTION
## Summary

- Add `PathContainmentError` exception and `validate_path_containment()` helper that rejects absolute paths and `..` escapes
- Enforce containment in `push_group()` for dataset locations and methodology files before upload
- Enforce containment in `collect_methodology_files()` for methodology values from datasets.yaml
- Error messages are actionable without leaking sensitive absolute paths

Refs: GHSA-85m4-5f4j-mrr5

## Test plan

- [x] `/etc/passwd` location rejected by package build/push
- [x] `../secret.csv` rejected by package build/push  
- [x] Methodology with absolute paths or `..` escapes rejected
- [x] Normal in-project paths still work
- [x] All 770 existing tests pass
- [x] ruff check clean
- [x] mypy clean