### PR TITLE
security: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
     - name: Set up Python
       run: uv python install 3.12
@@ -21,7 +21,7 @@ jobs:
       run: uv build
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: dist
         path: dist/
@@ -34,13 +34,13 @@ jobs:
       id-token: write
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: dist
         path: dist/
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
   docs:
     needs: publish
@@ -48,12 +48,12 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
     - name: Set up Python
       run: uv python install 3.12
@@ -77,10 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
     - name: Send Google Chat notification
       run: |
@@ -115,7 +115,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Extract version from tag
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       should_skip: ${{ steps.check.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 2
 
@@ -38,10 +38,10 @@ jobs:
     if: needs.check-skip.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
     - name: Set up Python
       run: uv python install 3.12
@@ -71,10 +71,10 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}
@@ -89,7 +89,7 @@ jobs:
         uv run pytest --cov=sunstone --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
       with:
         files: ./coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 - Security: Prevent package push from publishing files outside the project root (GHSA-85m4-5f4j-mrr5)
+- Security: Pin all third-party GitHub Actions to full commit SHAs (GHSA-499q-3p86-jj3c)
 
 ## [1.4.2] - 2026-04-13
 
 - Added: `datasets_file` parameter to DatasetsManager and DataFrame for custom datasets.yaml paths
 - Changed: Refactored and improved SSRF validation code
 - Changed: Moved release script to scripts/ directory and streamlined release workflow
-
 - Added: `sunstone.ssrf` module with comprehensive SSRF protection (CGNAT, cloud metadata, IPv4-mapped IPv6, multicast, reserved ranges)
 
 ## [1.4.1] - 2026-04-11


### PR DESCRIPTION
## Summary

- Pin all third-party GitHub Actions in `release.yml` and `test.yml` to immutable full commit SHAs instead of mutable version tags
- Adds trailing version comments (e.g. `# v5`) for human readability
- Resolves security advisory GHSA-499q-3p86-jj3c

## Actions pinned

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v5 | `93cb6efe1820...` |
| `astral-sh/setup-uv` | v5 | `d4b2f3b6ecc6...` |
| `actions/upload-artifact` | v7 | `043fb46d1a93...` |
| `actions/download-artifact` | v8 | `3e5f45b2cfb9...` |
| `pypa/gh-action-pypi-publish` | release/v1 | `cef221092ed1...` |
| `codecov/codecov-action` | v5 | `75cd11691c0f...` |

## Test plan

- [ ] Verify `release.yml` and `test.yml` pass YAML lint
- [ ] Confirm CI test workflow runs successfully on this PR
- [ ] Verify no mutable refs remain: `rg 'uses: [^@]+@v' .github/workflows/`