### PR TITLE
security: prevent package push path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Security: Prevent package push from publishing files outside the project root (GHSA-85m4-5f4j-mrr5)
 
 ## [1.4.2] - 2026-04-13
 

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -17,6 +17,7 @@ import typer
 from ruamel.yaml import YAML
 
 from .datasets import DatasetsManager
+from .packaging import PathTraversalError
 from .exceptions import DatasetNotFoundError
 from .lineage import Contributor, DatasetMetadata, PackageMetadata, PublishConfig
 
@@ -1175,6 +1176,8 @@ def push_group_to_gcs(
     manager: DatasetsManager,
     project_slug: str,
     publish_config: PublishConfig,
+    *,
+    allow_outside_project: bool = False,
 ) -> None:
     """
     Push a group of datasets to a remote destination.
@@ -1224,8 +1227,9 @@ def push_group_to_gcs(
             rdf_prefixes=rdf_prefixes,
             top_level_props=top_level_props or {},
             methodology_files=methodology_files,
+            allow_outside_project=allow_outside_project,
         )
-    except ValueError as e:
+    except (ValueError, PathTraversalError) as e:
         typer.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
@@ -1254,6 +1258,11 @@ def package_push(
     datasets_file: str = typer.Option("datasets.yaml", "-f", "--file", help="Path to datasets.yaml"),
     destination: Optional[str] = typer.Option(
         None, "--destination", "-d", help="Override destination gs:// URL for all datasets"
+    ),
+    allow_outside_project: bool = typer.Option(
+        False,
+        "--allow-outside-project",
+        help="Allow publishing files outside the project root (use with caution)",
     ),
 ) -> None:
     """Push data packages to Google Cloud Storage.
@@ -1308,7 +1317,14 @@ def package_push(
 
         dest_url = expand_env_vars(destination)
         try:
-            push_group_to_gcs(dest_url, publishable, manager, project_slug, override_config)
+            push_group_to_gcs(
+                dest_url,
+                publishable,
+                manager,
+                project_slug,
+                override_config,
+                allow_outside_project=allow_outside_project,
+            )
         except ImportError:
             typer.echo("Error: google-cloud-storage is required for push", err=True)
             typer.echo("Install with: pip install google-cloud-storage", err=True)
@@ -1325,7 +1341,9 @@ def package_push(
 
         try:
             for dest_url, (pub_config, datasets) in groups.items():
-                push_group_to_gcs(dest_url, datasets, manager, project_slug, pub_config)
+                push_group_to_gcs(
+                    dest_url, datasets, manager, project_slug, pub_config, allow_outside_project=allow_outside_project
+                )
                 typer.echo()
 
             typer.echo(f"✓ Pushed to {len(groups)} destination(s)")

--- a/src/sunstone/packaging.py
+++ b/src/sunstone/packaging.py
@@ -22,6 +22,52 @@ _RDF_TYPE_URI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 _DCAT_DATASET_URI = "http://www.w3.org/ns/dcat#Dataset"
 
 
+class PathTraversalError(ValueError):
+    """Raised when a file path escapes the project root directory."""
+
+
+def _validate_path_containment(
+    path: str,
+    project_root: Path,
+    *,
+    context: str = "file",
+) -> None:
+    """Validate that a path resolves to within the project root.
+
+    Rejects absolute paths and paths that escape the project root via ``..``
+    traversal. This prevents package build/push from accessing files outside
+    the project directory.
+
+    Args:
+        path: The relative path string to validate (e.g. dataset location).
+        project_root: The resolved project root directory.
+        context: Human-readable label for error messages (e.g. "dataset location").
+
+    Raises:
+        PathTraversalError: If the path is absolute or resolves outside the
+            project root.
+    """
+    from pathlib import PurePosixPath as _PP
+
+    # Reject absolute paths (Unix and Windows-style)
+    if _PP(path).is_absolute() or (len(path) >= 2 and path[1] == ":"):
+        raise PathTraversalError(
+            f"Refusing to publish {context} with absolute path. All paths must be relative to the project root."
+        )
+
+    resolved = (project_root / path).resolve()
+    resolved_root = project_root.resolve()
+
+    # Check that resolved path is under project root
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError:
+        raise PathTraversalError(
+            f"Refusing to publish {context} that resolves outside the project root. "
+            f"Path traversal via '..' is not allowed."
+        )
+
+
 def is_lfs_pointer(file_path: Path) -> bool:
     """Check if a file is a Git LFS pointer file instead of actual content.
 
@@ -54,6 +100,8 @@ def push_group(
     rdf_prefixes: dict[str, str],
     top_level_props: dict[str, Any],
     methodology_files: list[tuple[Path, str]],
+    *,
+    allow_outside_project: bool = False,
 ) -> list[str]:
     """Push a group of datasets to a remote destination via URLHandler plugins.
 
@@ -68,14 +116,40 @@ def push_group(
         rdf_prefixes: Merged RDF prefix dict for property expansion.
         top_level_props: Expanded top-level custom properties to merge into the datapackage.
         methodology_files: List of (absolute_path, resolved_uri) tuples to upload.
+        allow_outside_project: If True, skip path containment checks (use with
+            caution; intended for explicit CLI override only).
 
     Returns:
         List of uploaded path strings (for the caller to report).
 
     Raises:
+        PathTraversalError: If any dataset location or methodology file
+            resolves outside the project root (unless *allow_outside_project*
+            is True).
         ValueError: If any data files are Git LFS pointers, or no URL handler
             is found for the destination.
     """
+    project_root = manager.project_path.resolve()
+
+    # --- Path containment checks ---
+    if not allow_outside_project:
+        for ds in datasets:
+            _validate_path_containment(
+                ds.location,
+                project_root,
+                context=f"dataset '{ds.slug}' location",
+            )
+
+        for abs_path, _uri in methodology_files:
+            resolved_abs = abs_path.resolve()
+            try:
+                resolved_abs.relative_to(project_root)
+            except ValueError:
+                raise PathTraversalError(
+                    "Refusing to publish methodology file that resolves outside "
+                    "the project root. Path traversal is not allowed."
+                )
+
     # Resolve datapackage.json path and base directory
     if not dest_url.endswith(".json"):
         if not dest_url.endswith("/"):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from sunstone.lineage import DatasetMetadata, PublishConfig
-from sunstone.packaging import is_lfs_pointer, push_group
+from sunstone.packaging import PathTraversalError, _validate_path_containment, is_lfs_pointer, push_group
 
 
 @pytest.fixture
@@ -54,6 +54,45 @@ def test_is_lfs_pointer_large_file(tmp_path: Path) -> None:
     p = tmp_path / "big.bin"
     p.write_bytes(b"x" * 2000)
     assert is_lfs_pointer(p) is False
+
+
+# ---------------------------------------------------------------------------
+# _validate_path_containment
+# ---------------------------------------------------------------------------
+
+
+def test_validate_path_containment_rejects_absolute_path(tmp_path: Path) -> None:
+    """Absolute paths must be rejected."""
+    with pytest.raises(PathTraversalError, match="absolute path"):
+        _validate_path_containment("/etc/passwd", tmp_path)
+
+
+def test_validate_path_containment_rejects_dotdot_escape(tmp_path: Path) -> None:
+    """Paths escaping project root via .. must be rejected."""
+    with pytest.raises(PathTraversalError, match="outside the project root"):
+        _validate_path_containment("../secret.csv", tmp_path)
+
+
+def test_validate_path_containment_rejects_deep_dotdot_escape(tmp_path: Path) -> None:
+    """Paths with nested .. that escape the root must be rejected."""
+    with pytest.raises(PathTraversalError, match="outside the project root"):
+        _validate_path_containment("outputs/../../secret.csv", tmp_path)
+
+
+def test_validate_path_containment_allows_normal_path(tmp_path: Path) -> None:
+    """Normal relative paths within the project should pass."""
+    _validate_path_containment("outputs/data.csv", tmp_path)
+
+
+def test_validate_path_containment_allows_safe_dotdot(tmp_path: Path) -> None:
+    """Paths with .. that still resolve inside the project are OK."""
+    _validate_path_containment("outputs/../inputs/data.csv", tmp_path)
+
+
+def test_validate_path_containment_rejects_windows_absolute(tmp_path: Path) -> None:
+    """Windows-style absolute paths should be rejected."""
+    with pytest.raises(PathTraversalError, match="absolute path"):
+        _validate_path_containment("C:\\Users\\secret.csv", tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +226,7 @@ def test_push_group_returns_empty_when_no_resources(tmp_path: Path) -> None:
     """push_group returns empty list when build_resource_dict_fn returns None for all."""
     ds = DatasetMetadata(slug="s", name="S", location="x.csv", dataset_type="output")
     manager = MagicMock()
+    manager.project_path = tmp_path
 
     uploaded = push_group(
         dest_url="gs://bucket/pkg/",
@@ -212,6 +252,7 @@ def test_push_group_raises_on_lfs_pointers(tmp_path: Path) -> None:
     ds = DatasetMetadata(slug="big", name="Big", location="outputs/big.csv", dataset_type="output")
     manager = MagicMock()
     manager.get_absolute_path.return_value = lfs_file
+    manager.project_path = tmp_path
 
     with pytest.raises(ValueError, match="LFS pointers"):
         push_group(
@@ -236,6 +277,7 @@ def test_push_group_no_handler_raises(tmp_path: Path) -> None:
     ds = DatasetMetadata(slug="d", name="D", location="data.csv", dataset_type="output")
     manager = MagicMock()
     manager.get_absolute_path.return_value = data_file
+    manager.project_path = tmp_path
 
     mock_registry = MagicMock()
     mock_registry.find_url_handler.return_value = None
@@ -338,3 +380,160 @@ def test_push_group_flatten_mode(tmp_path: Path) -> None:
 
     # With flatten, the data file name (not full path) is the resource path
     assert uploaded[1] == "result.csv"
+
+
+# ---------------------------------------------------------------------------
+# Path containment in push_group
+# ---------------------------------------------------------------------------
+
+
+def test_push_group_rejects_absolute_location(tmp_path: Path) -> None:
+    """push_group rejects dataset locations with absolute paths."""
+    ds = DatasetMetadata(slug="evil", name="Evil", location="/etc/passwd", dataset_type="output")
+    manager = MagicMock()
+    manager.project_path = tmp_path
+
+    with pytest.raises(PathTraversalError, match="absolute path"):
+        push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[],
+        )
+
+
+def test_push_group_rejects_dotdot_escape(tmp_path: Path) -> None:
+    """push_group rejects dataset locations that escape via .."""
+    ds = DatasetMetadata(slug="evil", name="Evil", location="../secret.csv", dataset_type="output")
+    manager = MagicMock()
+    manager.project_path = tmp_path
+
+    with pytest.raises(PathTraversalError, match="outside the project root"):
+        push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[],
+        )
+
+
+def test_push_group_rejects_methodology_outside_project(tmp_path: Path) -> None:
+    """push_group rejects methodology files outside the project root."""
+    data_file = tmp_path / "data.csv"
+    data_file.write_text("a\n1\n")
+
+    ds = DatasetMetadata(slug="d", name="D", location="data.csv", dataset_type="output")
+    manager = MagicMock()
+    manager.project_path = tmp_path
+
+    # Methodology file outside project root
+    outside_meth = tmp_path.parent / "outside_methodology.pdf"
+
+    with pytest.raises(PathTraversalError, match="methodology file.*outside"):
+        push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[(outside_meth, "https://example.com/meth.pdf")],
+        )
+
+
+def test_push_group_allows_outside_project_with_flag(tmp_path: Path) -> None:
+    """push_group skips containment checks when allow_outside_project=True."""
+    # Create the data file outside the "project"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    outside_file = tmp_path / "outside.csv"
+    outside_file.write_text("a\n1\n")
+
+    ds = DatasetMetadata(slug="out", name="Out", location="../outside.csv", dataset_type="output")
+    manager = MagicMock()
+    manager.get_absolute_path.return_value = outside_file
+    manager.project_path = project_dir
+
+    streams: dict[str, io.IOBase] = {}
+    mock_handler = _make_handler(streams)
+    mock_registry = MagicMock()
+    mock_registry.find_url_handler.return_value = mock_handler
+
+    with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+        MockPluginRegistry.get.return_value = mock_registry
+
+        # Should NOT raise with allow_outside_project=True
+        uploaded = push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[],
+            allow_outside_project=True,
+        )
+
+    assert len(uploaded) == 2
+
+
+def test_push_group_allows_normal_in_project_paths(tmp_path: Path) -> None:
+    """push_group allows normal relative paths within the project."""
+    data_dir = tmp_path / "outputs"
+    data_dir.mkdir()
+    data_file = data_dir / "result.csv"
+    data_file.write_bytes(b"a,b\n1,2\n")
+
+    ds = DatasetMetadata(
+        slug="result",
+        name="Result",
+        location="outputs/result.csv",
+        dataset_type="output",
+    )
+
+    manager = MagicMock()
+    manager.get_absolute_path.return_value = data_file
+    manager.project_path = tmp_path
+
+    streams: dict[str, io.IOBase] = {}
+    mock_handler = _make_handler(streams)
+    mock_registry = MagicMock()
+    mock_registry.find_url_handler.return_value = mock_handler
+
+    with patch("sunstone.packaging.PluginRegistry") as MockPluginRegistry:
+        MockPluginRegistry.get.return_value = mock_registry
+
+        # Should work fine with normal in-project paths
+        uploaded = push_group(
+            dest_url="gs://bucket/pkg/",
+            datasets=[ds],
+            manager=manager,
+            project_slug="p",
+            publish_config=PublishConfig(enabled=True, to="gs://bucket/pkg/", flatten=False),
+            build_resource_dict_fn=lambda d, m, pc: {"path": d.location},
+            package_metadata_fn=lambda: None,
+            rdf_prefixes={},
+            top_level_props={},
+            methodology_files=[],
+        )
+
+    assert len(uploaded) == 2
+    assert uploaded[1] == "outputs/result.csv"


### PR DESCRIPTION
## Summary

- Add path containment validation to `push_group()` in `packaging.py` that rejects absolute paths and `../` traversal in dataset locations and methodology files
- Add `PathTraversalError` exception class for clear, actionable error messages that do not leak full filesystem paths
- Add `--allow-outside-project` flag to `sunstone package push` CLI for explicit override when needed
- Add comprehensive test coverage for path traversal attack vectors and the override flag

Fixes GHSA-85m4-5f4j-mrr5

## Test plan

- [x] `location: /etc/passwd` rejected by package push
- [x] `location: ../secret.csv` rejected by package push
- [x] Methodology files outside project root rejected
- [x] Normal in-project paths still work
- [x] `--allow-outside-project` override bypasses checks
- [x] Windows-style absolute paths rejected
- [x] Full test suite passes (769 tests)
- [x] ruff, mypy clean