### PR TITLE
feat: align lineage with W3C PROV-O and auto-populate field derivations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: PROV-O aligned provenance types (Agent, Activity, FieldDerivation, UsageRecord, EntityRef)
+- Added: Activity tracking on dataset write (agents, timestamps, usage records persisted to datasets.yaml)
+- Added: Field-level derivation tracking (prov:qualifiedDerivation) propagated through DataFrame operations
+- Added: Source.agent property for backwards-compatible Agent access from string attributed_to
+
 ## [1.4.3] - 2026-04-13
 
 - Security: harden HTTP handler against DNS rebinding and large responses

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -36,14 +36,21 @@ from .exceptions import (
     UnitError,
 )
 from .lineage import (
+    Activity,
+    ActivityRef,
+    Agent,
+    AgentType,
     Contributor,
     DatasetMetadata,
+    EntityRef,
+    FieldDerivation,
     FieldSchema,
     LineageMetadata,
     Metadata,
     PackageMetadata,
     Source,
     SourceLocation,
+    UsageRecord,
 )
 
 # Plugin system
@@ -98,6 +105,14 @@ __all__ = [
     "PackageMetadata",
     "Source",
     "SourceLocation",
+    # PROV-O types
+    "Activity",
+    "ActivityRef",
+    "Agent",
+    "AgentType",
+    "EntityRef",
+    "FieldDerivation",
+    "UsageRecord",
     # Exceptions
     "SunstoneError",
     "DatasetNotFoundError",

--- a/src/sunstone/context.py
+++ b/src/sunstone/context.py
@@ -5,13 +5,18 @@ Captures information about the execution environment (git state, user,
 notebook/script path, timestamp) for inclusion in lineage metadata.
 """
 
+from __future__ import annotations
+
 import getpass
 import os
 import subprocess
 import sys
 from dataclasses import dataclass, fields
 from datetime import datetime, timezone
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .lineage import Agent
 
 
 @dataclass(frozen=True)
@@ -49,6 +54,36 @@ class ExecutionContext:
             Dictionary with only non-None field values.
         """
         return {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}
+
+    def to_agents(self) -> list[Agent]:
+        """Return PROV-O Agent objects for this execution context.
+
+        Produces a Person agent for the user (if known) and a SoftwareAgent
+        for the sunstone-py library.
+        """
+        from .lineage import Agent, AgentType
+
+        agents: list[Agent] = []
+        if self.user:
+            agents.append(Agent(id=self.user, type=AgentType.PERSON))
+
+        # Import version at call time to avoid circular imports
+        try:
+            from importlib.metadata import version as pkg_version
+
+            sunstone_version = pkg_version("sunstone-py")
+        except Exception:
+            sunstone_version = None
+
+        agents.append(
+            Agent(
+                id="sunstone-py",
+                type=AgentType.SOFTWARE,
+                label="Sunstone Projects Library",
+                version=sunstone_version,
+            )
+        )
+        return agents
 
 
 def _detect_notebook_path() -> Optional[str]:

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -203,6 +203,20 @@ class DataFrame:
                 source=source,
                 constraints=constraints,
             )
+
+        # When source is set, also create a FieldDerivation entry
+        if source is not None:
+            from .lineage import FieldDerivation
+
+            fd = FieldDerivation(output_field=column, source_entity=source)
+            if self.metadata.lineage.field_derivations is None:
+                self.metadata.lineage.field_derivations = []
+            # Replace existing derivation for this column if present
+            self.metadata.lineage.field_derivations = [
+                d for d in self.metadata.lineage.field_derivations if d.output_field != column
+            ]
+            self.metadata.lineage.field_derivations.append(fd)
+
         return self
 
     def _get_datasets_manager(self) -> DatasetsManager:
@@ -683,6 +697,7 @@ class DataFrame:
             strict=self.strict_mode,
             context=lineage_data.get("context"),
             transformation_params=lineage_data.get("transformation_params"),
+            activity=lineage_data.get("_activity"),
         )
 
     def to_parquet(
@@ -809,6 +824,7 @@ class DataFrame:
             strict=self.strict_mode,
             context=lineage_data.get("context"),
             transformation_params=lineage_data.get("transformation_params"),
+            activity=lineage_data.get("_activity"),
         )
 
     def _infer_dtype(self, col: str) -> str:
@@ -1063,14 +1079,25 @@ class DataFrame:
     def _wrap_result(self, result: Any) -> Any:
         """Wrap a pandas result in a Sunstone DataFrame if applicable.
 
-        Copies all metadata, dropping field_metadata for columns no longer present.
+        Copies all metadata, dropping field_metadata and field_derivations
+        for columns no longer present.
         """
         if isinstance(result, pd.DataFrame):
             new_field_meta = {k: replace(v) for k, v in self.metadata.field_metadata.items() if k in result.columns}
+
+            # Filter field_derivations to surviving columns
+            src_derivations = self.metadata.lineage.field_derivations
+            new_derivations = None
+            if src_derivations:
+                new_derivations = [fd for fd in src_derivations if fd.output_field in result.columns]
+                if not new_derivations:
+                    new_derivations = None
+
             new_metadata = Metadata(
                 lineage=LineageMetadata(
                     sources=self.metadata.lineage.sources.copy(),
                     project_path=self.metadata.lineage.project_path,
+                    field_derivations=new_derivations,
                 ),
                 description=self.metadata.description,
                 rdf_prefixes=self.metadata.rdf_prefixes,

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -327,6 +327,7 @@ class DataFrame:
         # Create lineage metadata
         metadata = Metadata(lineage=LineageMetadata(project_path=str(manager.project_path)))
         metadata.lineage.add_source(dataset)
+        metadata.lineage.populate_field_derivations(list(df.columns), slug)
 
         # Record read in lineage session
         from .session import DatasetRead, get_session
@@ -442,6 +443,7 @@ class DataFrame:
         # Create lineage metadata
         metadata = Metadata(lineage=LineageMetadata(project_path=str(manager.project_path)))
         metadata.lineage.add_source(dataset)
+        metadata.lineage.populate_field_derivations(list(df.columns), dataset.slug)
 
         # Record read in lineage session
         from .session import DatasetRead, get_session
@@ -555,6 +557,7 @@ class DataFrame:
         # Create lineage metadata
         metadata = Metadata(lineage=LineageMetadata(project_path=str(manager.project_path)))
         metadata.lineage.add_source(dataset)
+        metadata.lineage.populate_field_derivations(list(df.columns), dataset.slug)
 
         # Record read in lineage session
         from .session import DatasetRead, get_session

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -13,14 +13,21 @@ from ruamel.yaml import YAML
 
 from .exceptions import DatasetNotFoundError, DatasetValidationError
 from .lineage import (
+    Activity,
+    ActivityRef,
+    Agent,
+    AgentType,
     Contributor,
     DatasetMetadata,
+    EntityRef,
+    FieldDerivation,
     FieldSchema,
     LineageMetadata,
     PackageMetadata,
     PublishConfig,
     Source,
     SourceLocation,
+    UsageRecord,
 )
 
 logger = logging.getLogger(__name__)
@@ -117,10 +124,21 @@ class DatasetsManager:
 
     def _parse_source(self, source_data: Dict[str, Any]) -> Source:
         """Parse source attribution data from YAML."""
+        attributed_to_raw = source_data["attributedTo"]
+        if isinstance(attributed_to_raw, dict):
+            attributed_to: str | Agent = Agent(
+                id=attributed_to_raw["id"],
+                type=AgentType(attributed_to_raw.get("type", "prov:Organization")),
+                label=attributed_to_raw.get("label"),
+                version=attributed_to_raw.get("version"),
+            )
+        else:
+            attributed_to = str(attributed_to_raw)
+
         return Source(
             name=source_data["name"],
             location=self._parse_source_location(source_data["location"]),
-            attributed_to=source_data["attributedTo"],
+            attributed_to=attributed_to,
             acquired_at=source_data["acquiredAt"],
             acquisition_method=source_data["acquisitionMethod"],
             license=source_data["license"],
@@ -180,6 +198,126 @@ class DatasetsManager:
                 as_url=publish_data.get("as"),
             )
         return None
+
+    def _parse_activity(self, activity_data: Dict[str, Any]) -> Activity:
+        """Parse a PROV-O Activity from YAML lineage data."""
+        from datetime import datetime
+
+        agents = []
+        for agent_data in activity_data.get("agents", []):
+            agents.append(
+                Agent(
+                    id=agent_data["id"],
+                    type=AgentType(agent_data.get("type", "prov:Person")),
+                    label=agent_data.get("label"),
+                    version=agent_data.get("version"),
+                )
+            )
+
+        used = []
+        for usage_data in activity_data.get("used", []):
+            entity_val = usage_data.get("entity", "")
+            if isinstance(entity_val, dict):
+                entity_ref = EntityRef(slug=entity_val["slug"], namespace=entity_val.get("namespace"))
+            else:
+                entity_ref = EntityRef(slug=str(entity_val))
+            used.append(
+                UsageRecord(
+                    entity=entity_ref,
+                    columns=usage_data.get("columns"),
+                    filters=usage_data.get("filters"),
+                )
+            )
+
+        started_at = None
+        if "started_at" in activity_data:
+            started_at = datetime.fromisoformat(activity_data["started_at"])
+        ended_at = None
+        if "ended_at" in activity_data:
+            ended_at = datetime.fromisoformat(activity_data["ended_at"])
+
+        return Activity(
+            id=activity_data["id"],
+            used=used,
+            was_associated_with=agents,
+            started_at=started_at,
+            ended_at=ended_at,
+            script_path=activity_data.get("script_path"),
+            notebook_path=activity_data.get("notebook_path"),
+            git_commit=activity_data.get("git_commit"),
+            git_dirty=activity_data.get("git_dirty"),
+            transformation_params=activity_data.get("transformation_params"),
+        )
+
+    def _parse_field_derivations(self, derivations_data: List[Dict[str, Any]]) -> List[FieldDerivation]:
+        """Parse field derivation data from YAML."""
+        return [
+            FieldDerivation(
+                output_field=d["output_field"],
+                source_entity=d["source_entity"],
+                source_field=d.get("source_field"),
+            )
+            for d in derivations_data
+        ]
+
+    @staticmethod
+    def _activity_to_dict(activity: Activity) -> Dict[str, Any]:
+        """Serialize an Activity to a dict for YAML output."""
+        result: Dict[str, Any] = {"id": activity.id}
+
+        if activity.started_at:
+            result["started_at"] = activity.started_at.isoformat()
+        if activity.ended_at:
+            result["ended_at"] = activity.ended_at.isoformat()
+        if activity.script_path:
+            result["script_path"] = activity.script_path
+        if activity.notebook_path:
+            result["notebook_path"] = activity.notebook_path
+        if activity.git_commit:
+            result["git_commit"] = activity.git_commit
+        if activity.git_dirty is not None:
+            result["git_dirty"] = activity.git_dirty
+
+        if activity.was_associated_with:
+            agents_list = []
+            for agent in activity.was_associated_with:
+                agent_dict: Dict[str, Any] = {"id": agent.id, "type": agent.type.value}
+                if agent.label:
+                    agent_dict["label"] = agent.label
+                if agent.version:
+                    agent_dict["version"] = agent.version
+                agents_list.append(agent_dict)
+            result["agents"] = agents_list
+
+        if activity.used:
+            used_list = []
+            for usage in activity.used:
+                usage_dict: Dict[str, Any] = {"entity": usage.entity.slug}
+                if usage.columns:
+                    usage_dict["columns"] = usage.columns
+                if usage.filters:
+                    usage_dict["filters"] = usage.filters
+                used_list.append(usage_dict)
+            result["used"] = used_list
+
+        if activity.transformation_params:
+            result["transformation_params"] = activity.transformation_params
+
+        return result
+
+    @staticmethod
+    def _field_derivations_to_list(derivations: List[FieldDerivation]) -> List[Dict[str, Any]]:
+        """Serialize FieldDerivations to a list of dicts for YAML output."""
+        result = []
+        for d in derivations:
+            entry: Dict[str, Any] = {
+                "output_field": d.output_field,
+                "source_entity": d.source_entity,
+            }
+            if d.source_field:
+                entry["source_field"] = d.source_field
+            result.append(entry)
+        return result
 
     def _parse_contributor(self, contrib_data: Dict[str, Any]) -> Contributor:
         """Parse contributor data from YAML."""
@@ -288,6 +426,39 @@ class DatasetsManager:
 
         publish = self._parse_publish(dataset_data.get("publish"))
 
+        # Parse PROV-O fields from lineage section (outputs only)
+        lineage_raw = dataset_data.get("lineage", {})
+        was_derived_from = None
+        was_generated_by = None
+        generated_at_time = None
+        field_derivations_parsed = None
+
+        if lineage_raw:
+            from datetime import datetime as _dt
+
+            # was_derived_from from sources list
+            sources_raw = lineage_raw.get("sources", [])
+            if sources_raw:
+                was_derived_from = [EntityRef(slug=s["slug"] if isinstance(s, dict) else str(s)) for s in sources_raw]
+
+            # generated_at_time from created_at
+            created_at_raw = lineage_raw.get("created_at")
+            if created_at_raw:
+                try:
+                    generated_at_time = _dt.fromisoformat(str(created_at_raw))
+                except (ValueError, TypeError):
+                    pass
+
+            # activity → was_generated_by ref
+            activity_raw = lineage_raw.get("activity")
+            if activity_raw:
+                was_generated_by = ActivityRef(id=activity_raw["id"])
+
+            # field_derivations
+            fd_raw = lineage_raw.get("field_derivations")
+            if fd_raw:
+                field_derivations_parsed = self._parse_field_derivations(fd_raw)
+
         return DatasetMetadata(
             name=dataset_data["name"],
             slug=dataset_data["slug"],
@@ -301,6 +472,10 @@ class DatasetsManager:
             rdf_prefixes=rdf_prefixes,
             custom_properties=custom_properties,
             publish=publish,
+            was_derived_from=was_derived_from,
+            was_generated_by=was_generated_by,
+            generated_at_time=generated_at_time,
+            field_derivations=field_derivations_parsed,
         )
 
     def find_dataset_by_location(self, location: str, dataset_type: Optional[str] = None) -> Optional[DatasetMetadata]:
@@ -587,6 +762,7 @@ class DatasetsManager:
         strict: bool = False,
         context: Optional[dict] = None,
         transformation_params: Optional[dict] = None,
+        activity: Optional[Activity] = None,
     ) -> None:
         """
         Update lineage metadata for an output dataset.
@@ -602,6 +778,9 @@ class DatasetsManager:
             lineage: The lineage metadata to persist.
             content_hash: SHA256 hash of the DataFrame content.
             strict: If True, validate without modifying. If False, update the file.
+            context: Optional execution context dict (backwards compat).
+            transformation_params: Optional transformation parameters dict.
+            activity: Optional PROV-O Activity for this output.
 
         Raises:
             DatasetNotFoundError: If the dataset doesn't exist.
@@ -651,6 +830,26 @@ class DatasetsManager:
             lineage_data["context"] = context
         if transformation_params:
             lineage_data["transformation_params"] = transformation_params
+
+        # PROV-O Activity (new)
+        if activity is not None:
+            from dataclasses import replace as _replace
+
+            # Relativize script_path without mutating the caller's object
+            activity_to_write = activity
+            if activity.script_path:
+                try:
+                    rel = Path(activity.script_path).resolve().relative_to(self.project_path)
+                    if not str(rel).startswith(".."):
+                        activity_to_write = _replace(activity, script_path=rel.as_posix())
+                except ValueError:
+                    pass
+            lineage_data["activity"] = self._activity_to_dict(activity_to_write)
+
+        # Field derivations (new)
+        field_derivations = lineage.field_derivations
+        if field_derivations:
+            lineage_data["field_derivations"] = self._field_derivations_to_list(field_derivations)
 
         # Create a copy of the data with updated lineage
         updated_data = self._data.copy()

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -1,14 +1,160 @@
 """
 Lineage metadata structures for tracking data provenance.
+
+Aligned with W3C PROV-O (https://www.w3.org/TR/prov-o/):
+- Entity: datasets (DatasetMetadata)
+- Activity: script/notebook executions (Activity)
+- Agent: users, software, organizations (Agent)
 """
 
 import hashlib
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# PROV-O core types
+# ---------------------------------------------------------------------------
+
+
+class AgentType(Enum):
+    """PROV-O agent subtypes."""
+
+    PERSON = "prov:Person"
+    SOFTWARE = "prov:SoftwareAgent"
+    ORGANIZATION = "prov:Organization"
+
+
+@dataclass
+class Agent:
+    """A PROV-O Agent: something that bears responsibility for an activity
+    or for the existence of an entity.
+
+    Maps to prov:Agent and subtypes prov:Person, prov:SoftwareAgent,
+    prov:Organization.
+    """
+
+    id: str
+    """Unique identifier (username, org name, software name)."""
+
+    type: AgentType = AgentType.PERSON
+    """The kind of agent."""
+
+    label: Optional[str] = None
+    """Human-readable label."""
+
+    version: Optional[str] = None
+    """Version string (for SoftwareAgent)."""
+
+
+@dataclass(frozen=True)
+class EntityRef:
+    """Lightweight reference to a PROV Entity (dataset).
+
+    Used in relationships to avoid circular object references.
+    """
+
+    slug: str
+    """Dataset slug identifier."""
+
+    namespace: Optional[str] = None
+    """Optional namespace URI for external entities."""
+
+
+@dataclass(frozen=True)
+class ActivityRef:
+    """Lightweight reference to a PROV Activity."""
+
+    id: str
+    """Activity identifier."""
+
+
+@dataclass
+class FieldDerivation:
+    """Records that an output field was derived from a source entity,
+    optionally from a specific source field.
+
+    Maps to prov:qualifiedDerivation at the field level.
+    """
+
+    output_field: str
+    """Name of the output field/column."""
+
+    source_entity: str
+    """Slug of the source dataset."""
+
+    source_field: Optional[str] = None
+    """Name of the source field, if known. None means derived from
+    the dataset as a whole (e.g., computed from multiple fields)."""
+
+
+@dataclass
+class UsageRecord:
+    """Records how an Activity used an Entity.
+
+    Maps to prov:qualifiedUsage.
+    """
+
+    entity: EntityRef
+    """Which entity was used."""
+
+    columns: Optional[List[str]] = None
+    """Which columns were selected (None means all)."""
+
+    filters: Optional[Dict[str, Any]] = None
+    """Filters applied during read."""
+
+
+@dataclass
+class Activity:
+    """A PROV-O Activity: a script or notebook execution that transforms
+    input entities into output entities.
+
+    One Activity corresponds to one script/notebook execution.
+    """
+
+    id: str
+    """Unique identifier (e.g. 'exec-{timestamp}-{hash}')."""
+
+    used: List[UsageRecord] = field(default_factory=list)
+    """prov:used — input entities consumed by this activity."""
+
+    generated: List[EntityRef] = field(default_factory=list)
+    """Inverse of prov:wasGeneratedBy — output entities produced."""
+
+    was_associated_with: List[Agent] = field(default_factory=list)
+    """prov:wasAssociatedWith — agents involved in this activity."""
+
+    started_at: Optional[datetime] = None
+    """prov:startedAtTime."""
+
+    ended_at: Optional[datetime] = None
+    """prov:endedAtTime."""
+
+    script_path: Optional[str] = None
+    """Path to the Python script that was executed."""
+
+    notebook_path: Optional[str] = None
+    """Path to the Jupyter notebook that was executed."""
+
+    git_commit: Optional[str] = None
+    """Git commit hash at time of execution."""
+
+    git_dirty: Optional[bool] = None
+    """Whether the git working tree had uncommitted changes."""
+
+    transformation_params: Optional[Dict[str, Any]] = None
+    """User-supplied parameters describing the transformation."""
+
+
+# ---------------------------------------------------------------------------
+# Dataset / source metadata
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -27,7 +173,10 @@ class SourceLocation:
 
 @dataclass
 class Source:
-    """Source attribution information for a dataset."""
+    """Source attribution information for a dataset.
+
+    Maps to prov:wasAttributedTo on the dataset entity.
+    """
 
     name: str
     """Name of the data source."""
@@ -35,8 +184,10 @@ class Source:
     location: SourceLocation
     """Location information for the source."""
 
-    attributed_to: str
-    """Organization or individual to attribute the data to."""
+    attributed_to: Union[str, Agent]
+    """Organization or individual to attribute the data to.
+    Accepts a plain string for backwards compatibility (interpreted
+    as an Organization agent)."""
 
     acquired_at: str
     """Date when the data was acquired (YYYY-MM-DD format)."""
@@ -46,10 +197,20 @@ class Source:
 
     license: str
     """SPDX license identifier."""
-    # TODO: Consider using a library for SPDX license validation.
 
     updated: Optional[str] = None
     """Optional description of update frequency."""
+
+    @property
+    def agent(self) -> Agent:
+        """Return the attributed_to value as an Agent object."""
+        if isinstance(self.attributed_to, Agent):
+            return self.attributed_to
+        return Agent(
+            id=self.attributed_to,
+            type=AgentType.ORGANIZATION,
+            label=self.attributed_to,
+        )
 
 
 @dataclass
@@ -187,6 +348,19 @@ class DatasetMetadata:
     publish: Optional[PublishConfig] = None
     """Per-dataset publish configuration (overrides top-level)."""
 
+    # PROV-O relation fields (optional, populated when available)
+    was_derived_from: Optional[List[EntityRef]] = None
+    """prov:wasDerivedFrom — source entities this dataset was derived from."""
+
+    was_generated_by: Optional[ActivityRef] = None
+    """prov:wasGeneratedBy — the activity that generated this entity."""
+
+    generated_at_time: Optional[datetime] = None
+    """prov:generatedAtTime — when this entity was created/updated."""
+
+    field_derivations: Optional[List[FieldDerivation]] = None
+    """prov:qualifiedDerivation — field-level derivation detail."""
+
 
 def compute_dataframe_hash(df: "pd.DataFrame") -> str:
     """
@@ -227,6 +401,15 @@ class LineageMetadata:
     project_path: Optional[str] = None
     """Path to the project directory containing datasets.yaml."""
 
+    activity: Optional[Activity] = None
+    """The PROV-O Activity that generated this data. When present,
+    this is the canonical provenance record; ``sources`` is kept
+    for backwards compatibility."""
+
+    field_derivations: Optional[List[FieldDerivation]] = None
+    """Field-level derivation detail (prov:qualifiedDerivation).
+    Propagated through DataFrame operations."""
+
     def add_source(self, dataset: DatasetMetadata) -> None:
         """
         Add a source dataset to the lineage.
@@ -245,7 +428,7 @@ class LineageMetadata:
             other: The other lineage metadata to merge.
 
         Returns:
-            A new LineageMetadata with combined sources.
+            A new LineageMetadata with combined sources and field derivations.
         """
         merged = LineageMetadata(
             sources=self.sources.copy(),
@@ -256,6 +439,21 @@ class LineageMetadata:
         for source in other.sources:
             if source not in merged.sources:
                 merged.sources.append(source)
+
+        # Merge field derivations (union, deduplicated by output_field + source)
+        all_derivations: List[FieldDerivation] = []
+        seen: set[tuple[str, str, Optional[str]]] = set()
+
+        for fd_list in (self.field_derivations, other.field_derivations):
+            if fd_list:
+                for fd in fd_list:
+                    key = (fd.output_field, fd.source_entity, fd.source_field)
+                    if key not in seen:
+                        seen.add(key)
+                        all_derivations.append(fd)
+
+        if all_derivations:
+            merged.field_derivations = all_derivations
 
         return merged
 

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -420,6 +420,19 @@ class LineageMetadata:
         if dataset not in self.sources:
             self.sources.append(dataset)
 
+    def populate_field_derivations(self, columns: List[str], slug: str) -> None:
+        """Auto-populate field derivations for columns read from a source dataset.
+
+        Creates a FieldDerivation(output_field=col, source_entity=slug,
+        source_field=col) for each column, so that field-level provenance
+        is tracked automatically from read through to write.
+        """
+        derivations = [FieldDerivation(output_field=col, source_entity=slug, source_field=col) for col in columns]
+        if self.field_derivations is None:
+            self.field_derivations = derivations
+        else:
+            self.field_derivations.extend(derivations)
+
     def merge(self, other: "LineageMetadata") -> "LineageMetadata":
         """
         Merge lineage from another DataFrame.

--- a/src/sunstone/queries.py
+++ b/src/sunstone/queries.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from .datasets import DatasetsManager
+
+if TYPE_CHECKING:
+    from .lineage import Activity
 
 
 @dataclass
@@ -28,6 +31,9 @@ class LineageNode:
 
     context: Optional[dict[str, Any]] = None
     """Optional execution context dict."""
+
+    activity: Optional[Activity] = None
+    """Optional PROV-O Activity that generated this node's dataset."""
 
     sources: list[LineageNode] = field(default_factory=list)
     """Upstream source nodes."""
@@ -92,8 +98,14 @@ def _build_node(
         lineage = output_data.get("lineage", {})
         source_refs = lineage.get("sources", [])
 
+        # Parse activity if present
+        parsed_activity = None
+        activity_raw = lineage.get("activity")
+        if activity_raw:
+            parsed_activity = mgr._parse_activity(activity_raw)
+
         if not source_refs:
-            return LineageNode(slug=slug)
+            return LineageNode(slug=slug, activity=parsed_activity)
 
         # Build child nodes with per-branch visited set copy
         sources = []
@@ -104,7 +116,7 @@ def _build_node(
                 child = _build_node(src_slug, mgr, branch_visited, depth + 1, max_depth)
                 sources.append(child)
 
-        return LineageNode(slug=slug, sources=sources)
+        return LineageNode(slug=slug, sources=sources, activity=parsed_activity)
 
     # Check if it's an input (leaf node, no further lineage)
     input_dataset = mgr.find_dataset_by_slug(slug, dataset_type="input")
@@ -157,10 +169,13 @@ def lineage_to_dict(node: LineageNode) -> dict[str, Any]:
     Returns:
         Nested dictionary with slug, version, context, sources, circular keys.
     """
-    return {
+    result: dict[str, Any] = {
         "slug": node.slug,
         "version": node.version,
         "context": node.context,
         "sources": [lineage_to_dict(s) for s in node.sources],
         "circular": node.circular,
     }
+    if node.activity is not None:
+        result["activity"] = DatasetsManager._activity_to_dict(node.activity)
+    return result

--- a/src/sunstone/session.py
+++ b/src/sunstone/session.py
@@ -6,9 +6,13 @@ are read during a workflow, and flushes that information with execution
 context when an output is written.
 """
 
+import hashlib
 import threading
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Optional
+
+from .lineage import Activity, EntityRef, UsageRecord
 
 
 @dataclass
@@ -27,6 +31,14 @@ class DatasetRead:
     filters: Optional[dict] = None
     """Optional filters applied during read."""
 
+    def to_usage_record(self) -> UsageRecord:
+        """Convert to a PROV-O UsageRecord."""
+        return UsageRecord(
+            entity=EntityRef(slug=self.slug),
+            columns=self.columns,
+            filters=self.filters,
+        )
+
 
 class LineageSession:
     """
@@ -41,6 +53,7 @@ class LineageSession:
         self._reads: list[DatasetRead] = []
         self._seen_keys: set[str] = set()
         self._context: Optional[Any] = None  # Lazy-initialized ExecutionContext
+        self._started_at: Optional[datetime] = None
 
     def record_read(self, dataset_read: DatasetRead) -> None:
         """
@@ -49,10 +62,21 @@ class LineageSession:
         Args:
             dataset_read: The dataset read to record.
         """
+        if self._started_at is None:
+            self._started_at = datetime.now(timezone.utc)
+
         key = f"{dataset_read.slug}:{dataset_read.version}"
         if key not in self._seen_keys:
             self._seen_keys.add(key)
             self._reads.append(dataset_read)
+
+    def _ensure_context(self) -> Any:
+        """Lazy-initialize execution context."""
+        if self._context is None:
+            from .context import detect_execution_context
+
+            self._context = detect_execution_context()
+        return self._context
 
     def flush_to_output(self, transformation_params: Optional[dict] = None) -> dict:
         """
@@ -69,11 +93,7 @@ class LineageSession:
         Returns:
             Dictionary with lineage metadata.
         """
-        # Lazy import to avoid circular imports
-        from .context import detect_execution_context
-
-        if self._context is None:
-            self._context = detect_execution_context()
+        ctx = self._ensure_context()
 
         sources = [
             {
@@ -87,17 +107,73 @@ class LineageSession:
 
         result: dict[str, Any] = {
             "sources": sources,
-            "context": self._context.to_dict(),
+            "context": ctx.to_dict(),
         }
 
         if transformation_params is not None:
             result["transformation_params"] = transformation_params
+
+        # Build Activity from the same reads (before clearing)
+        result["_activity"] = self._build_activity(ctx, transformation_params)
 
         # Clear reads after flush
         self._reads.clear()
         self._seen_keys.clear()
 
         return result
+
+    def _build_activity(
+        self,
+        ctx: Any,
+        transformation_params: Optional[dict] = None,
+    ) -> Activity:
+        """Build a PROV-O Activity from current reads and context."""
+        now = datetime.now(timezone.utc)
+
+        used = [r.to_usage_record() for r in self._reads]
+        agents = ctx.to_agents()
+
+        id_input = f"{ctx.execution_timestamp}:{ctx.script_path or ctx.notebook_path or 'unknown'}"
+        activity_hash = hashlib.sha256(id_input.encode()).hexdigest()[:8]
+        activity_id = f"exec-{activity_hash}"
+
+        return Activity(
+            id=activity_id,
+            used=used,
+            was_associated_with=agents,
+            started_at=self._started_at or now,
+            ended_at=now,
+            script_path=ctx.script_path,
+            notebook_path=ctx.notebook_path,
+            git_commit=ctx.git_commit,
+            git_dirty=ctx.git_dirty,
+            transformation_params=transformation_params,
+        )
+
+    def flush_activity(
+        self,
+        transformation_params: Optional[dict] = None,
+    ) -> Activity:
+        """
+        Flush accumulated reads and return a PROV-O Activity.
+
+        Constructs an Activity with proper used records, agents,
+        timestamps, and execution context fields.
+
+        Args:
+            transformation_params: Optional dict of transformation parameters.
+
+        Returns:
+            Activity representing this script/notebook execution.
+        """
+        ctx = self._ensure_context()
+        activity = self._build_activity(ctx, transformation_params)
+
+        # Clear reads after flush
+        self._reads.clear()
+        self._seen_keys.clear()
+
+        return activity
 
 
 # Thread-local storage for singleton session

--- a/tests/test_lineage_flow.py
+++ b/tests/test_lineage_flow.py
@@ -176,6 +176,17 @@ class TestFlushAndPersist:
         assert "context" in lineage
         assert lineage["context"]["user"] == "test-user"
 
+        # PROV-O: activity section should also be present
+        assert "activity" in lineage
+        activity = lineage["activity"]
+        assert activity["id"].startswith("exec-")
+        assert any(a["id"] == "test-user" for a in activity["agents"])
+        assert any(a["type"] == "prov:SoftwareAgent" for a in activity["agents"])
+        # Activity should record usage of both input datasets
+        used_slugs = {u["entity"] for u in activity["used"]}
+        assert "alpha-data" in used_slugs
+        assert "beta-data" in used_slugs
+
     @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
     def test_transformation_params_persisted(self, mock_ctx: Any, flow_project: Path) -> None:
         """to_csv(transformation_params=...) persists params in datasets.yaml."""
@@ -198,6 +209,10 @@ class TestFlushAndPersist:
 
         assert "transformation_params" in lineage
         assert lineage["transformation_params"]["threshold"] == 100
+
+        # PROV-O: activity should also carry transformation_params
+        assert "activity" in lineage
+        assert lineage["activity"]["transformation_params"]["threshold"] == 100
 
     @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
     def test_session_cleared_after_flush(self, mock_ctx: Any, flow_project: Path) -> None:
@@ -246,6 +261,10 @@ class TestFlushAndPersist:
         output = next(d for d in data["outputs"] if d["slug"] == "relative-test")
         context = output["lineage"]["context"]
         assert context["script_path"] == "scripts/process.py"
+
+        # PROV-O: activity script_path should also be relativized
+        activity = output["lineage"]["activity"]
+        assert activity["script_path"] == "scripts/process.py"
 
     def test_script_path_kept_absolute_when_outside_project(self, flow_project: Path) -> None:
         """script_path should stay absolute when outside the project."""

--- a/tests/test_lineage_flow.py
+++ b/tests/test_lineage_flow.py
@@ -298,3 +298,41 @@ class TestFlushAndPersist:
         output = next(d for d in data["outputs"] if d["slug"] == "absolute-test")
         context = output["lineage"]["context"]
         assert context["script_path"] == "/some/other/place/process.py"
+
+    @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
+    def test_field_derivations_auto_populated_and_persisted(self, mock_ctx: Any, flow_project: Path) -> None:
+        """Read two datasets, merge, write -> field_derivations appear in datasets.yaml."""
+        df1 = sunstone.DataFrame.read_dataset("alpha-data", project_path=flow_project)
+        df2 = sunstone.DataFrame.read_dataset("beta-data", project_path=flow_project)
+
+        merged = df1.merge(df2, on="id")
+        merged.to_csv(
+            "outputs/merged.csv",
+            slug="merged-output",
+            name="Merged Output",
+            index=False,
+        )
+
+        yaml = YAML()
+        with open(flow_project / "datasets.yaml") as f:
+            data = yaml.load(f)
+
+        output = next(d for d in data["outputs"] if d["slug"] == "merged-output")
+        lineage = output["lineage"]
+
+        assert "field_derivations" in lineage
+        fd = lineage["field_derivations"]
+        fd_by_field = {d["output_field"]: d for d in fd}
+
+        # Columns from alpha-data
+        assert fd_by_field["name"]["source_entity"] == "alpha-data"
+        assert fd_by_field["name"]["source_field"] == "name"
+        assert fd_by_field["value"]["source_entity"] == "alpha-data"
+        assert fd_by_field["value"]["source_field"] == "value"
+
+        # Column from beta-data
+        assert fd_by_field["score"]["source_entity"] == "beta-data"
+        assert fd_by_field["score"]["source_field"] == "score"
+
+        # 'id' exists in both — should have derivation from at least one source
+        assert "id" in fd_by_field

--- a/tests/test_lineage_persistence.py
+++ b/tests/test_lineage_persistence.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import sunstone
+from sunstone.lineage import FieldDerivation, LineageMetadata, Metadata
 
 
 class TestLineagePersistence:
@@ -57,3 +58,124 @@ class TestLineagePersistence:
         assert "NewCol" in df.data.columns
         # Lineage sources should be preserved after setitem
         assert len(df.metadata.lineage.sources) == initial_sources
+
+
+class TestFieldDerivationPersistence:
+    """Tests to ensure field_derivations are preserved through pandas operations."""
+
+    def _make_df_with_derivations(self) -> sunstone.DataFrame:
+        """Create a DataFrame with field_derivations set."""
+        meta = Metadata(
+            lineage=LineageMetadata(
+                field_derivations=[
+                    FieldDerivation(output_field="Member State", source_entity="raw-data"),
+                    FieldDerivation(output_field="ISO Code", source_entity="raw-data", source_field="code"),
+                    FieldDerivation(output_field="Year", source_entity="dates-data"),
+                ]
+            )
+        )
+        import pandas as pd
+
+        df = sunstone.DataFrame(
+            data=pd.DataFrame(
+                {
+                    "Member State": ["A", "B"],
+                    "ISO Code": ["AA", "BB"],
+                    "Year": [2020, 2021],
+                }
+            ),
+            metadata=meta,
+        )
+        return df
+
+    def test_head_preserves_field_derivations(self) -> None:
+        df = self._make_df_with_derivations()
+        result = df.head(1)
+        assert result.metadata.lineage.field_derivations is not None
+        assert len(result.metadata.lineage.field_derivations) == 3
+
+    def test_sort_values_preserves_field_derivations(self) -> None:
+        df = self._make_df_with_derivations()
+        result = df.sort_values("Year")
+        assert result.metadata.lineage.field_derivations is not None
+        assert len(result.metadata.lineage.field_derivations) == 3
+
+    def test_getitem_drops_removed_field_derivations(self) -> None:
+        """Column selection should drop derivations for removed columns."""
+        df = self._make_df_with_derivations()
+        result = df[["Member State", "Year"]]
+        assert result.metadata.lineage.field_derivations is not None
+        assert len(result.metadata.lineage.field_derivations) == 2
+        fields = {d.output_field for d in result.metadata.lineage.field_derivations}
+        assert fields == {"Member State", "Year"}
+
+    def test_merge_combines_field_derivations(self) -> None:
+        """Merge should union field_derivations from both sides."""
+        import pandas as pd
+
+        left = sunstone.DataFrame(
+            data=pd.DataFrame({"key": [1], "val_l": [10]}),
+            metadata=Metadata(
+                lineage=LineageMetadata(
+                    field_derivations=[FieldDerivation(output_field="val_l", source_entity="ds-left")]
+                )
+            ),
+        )
+        right = sunstone.DataFrame(
+            data=pd.DataFrame({"key": [1], "val_r": [20]}),
+            metadata=Metadata(
+                lineage=LineageMetadata(
+                    field_derivations=[FieldDerivation(output_field="val_r", source_entity="ds-right")]
+                )
+            ),
+        )
+        result = left.merge(right, on="key")
+        assert result.metadata.lineage.field_derivations is not None
+        assert len(result.metadata.lineage.field_derivations) == 2
+        fields = {d.output_field for d in result.metadata.lineage.field_derivations}
+        assert fields == {"val_l", "val_r"}
+
+    def test_join_combines_field_derivations(self) -> None:
+        """Join should union field_derivations from both sides."""
+        import pandas as pd
+
+        left = sunstone.DataFrame(
+            data=pd.DataFrame({"val_l": [10]}, index=[0]),
+            metadata=Metadata(
+                lineage=LineageMetadata(
+                    field_derivations=[FieldDerivation(output_field="val_l", source_entity="ds-left")]
+                )
+            ),
+        )
+        right = sunstone.DataFrame(
+            data=pd.DataFrame({"val_r": [20]}, index=[0]),
+            metadata=Metadata(
+                lineage=LineageMetadata(
+                    field_derivations=[FieldDerivation(output_field="val_r", source_entity="ds-right")]
+                )
+            ),
+        )
+        result = left.join(right)
+        assert result.metadata.lineage.field_derivations is not None
+        assert len(result.metadata.lineage.field_derivations) == 2
+
+    def test_concat_combines_field_derivations(self) -> None:
+        """Concat should union field_derivations from all DataFrames."""
+        import pandas as pd
+
+        df1 = sunstone.DataFrame(
+            data=pd.DataFrame({"a": [1]}),
+            metadata=Metadata(
+                lineage=LineageMetadata(field_derivations=[FieldDerivation(output_field="a", source_entity="ds1")])
+            ),
+        )
+        df2 = sunstone.DataFrame(
+            data=pd.DataFrame({"a": [2]}),
+            metadata=Metadata(
+                lineage=LineageMetadata(field_derivations=[FieldDerivation(output_field="a", source_entity="ds2")])
+            ),
+        )
+        result = df1.concat([df2])
+        assert result.metadata.lineage.field_derivations is not None
+        # Both derivations: (a, ds1) and (a, ds2) are distinct because source_entity differs
+        assert len(result.metadata.lineage.field_derivations) == 2

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,7 +4,7 @@ import warnings
 from pathlib import Path
 
 import sunstone
-from sunstone.lineage import FieldSchema, LineageMetadata, Metadata
+from sunstone.lineage import FieldDerivation, FieldSchema, LineageMetadata, Metadata
 
 
 class TestMetadataConstruction:
@@ -395,6 +395,79 @@ class TestConflictingMetadata:
 
         # Data: all rows present
         assert len(result) == 5
+
+
+class TestFieldDerivationMergeConflicts:
+    """Tests that field_derivations are properly combined during merge/join/concat."""
+
+    def test_merge_combines_field_derivations(self):
+        """Merge should union field_derivations from both sides."""
+        left = sunstone.DataFrame({"key": [1], "val_l": [10]})
+        left.metadata.lineage.field_derivations = [
+            FieldDerivation(output_field="val_l", source_entity="ds-left"),
+        ]
+
+        right = sunstone.DataFrame({"key": [1], "val_r": [20]})
+        right.metadata.lineage.field_derivations = [
+            FieldDerivation(output_field="val_r", source_entity="ds-right"),
+        ]
+
+        result = left.merge(right, on="key")
+        fds = result.metadata.lineage.field_derivations
+        assert fds is not None
+        assert len(fds) == 2
+        assert {d.output_field for d in fds} == {"val_l", "val_r"}
+
+    def test_join_combines_field_derivations(self):
+        """Join should union field_derivations from both sides."""
+        left = sunstone.DataFrame({"val_l": [10]})
+        left.metadata.lineage.field_derivations = [
+            FieldDerivation(output_field="val_l", source_entity="ds-left"),
+        ]
+
+        right = sunstone.DataFrame({"val_r": [20]})
+        right.metadata.lineage.field_derivations = [
+            FieldDerivation(output_field="val_r", source_entity="ds-right"),
+        ]
+
+        result = left.join(right)
+        fds = result.metadata.lineage.field_derivations
+        assert fds is not None
+        assert len(fds) == 2
+
+    def test_concat_combines_field_derivations(self):
+        """Concat should union field_derivations from all DataFrames."""
+        df1 = sunstone.DataFrame({"a": [1]})
+        df1.metadata.lineage.field_derivations = [
+            FieldDerivation(output_field="a", source_entity="ds1"),
+        ]
+
+        df2 = sunstone.DataFrame({"a": [2]})
+        df2.metadata.lineage.field_derivations = [
+            FieldDerivation(output_field="a", source_entity="ds2"),
+        ]
+
+        result = df1.concat([df2])
+        fds = result.metadata.lineage.field_derivations
+        assert fds is not None
+        # (a, ds1) and (a, ds2) are distinct derivations
+        assert len(fds) == 2
+
+    def test_merge_deduplicates_same_derivation(self):
+        """If both sides have the same derivation, it should appear only once."""
+        shared_fd = FieldDerivation(output_field="shared", source_entity="same-source")
+
+        left = sunstone.DataFrame({"key": [1], "shared": [10]})
+        left.metadata.lineage.field_derivations = [shared_fd]
+
+        right = sunstone.DataFrame({"key": [1], "other": [20]})
+        right.metadata.lineage.field_derivations = [shared_fd]
+
+        result = left.merge(right, on="key")
+        fds = result.metadata.lineage.field_derivations
+        assert fds is not None
+        shared_fds = [d for d in fds if d.output_field == "shared"]
+        assert len(shared_fds) == 1
 
 
 class TestBuildFieldSchema:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,667 @@
+"""
+Tests for PROV-O aligned provenance types.
+
+Tests the new Agent, Activity, FieldDerivation, UsageRecord, EntityRef types
+and their integration with session flush, datasets.yaml serialization, and
+DataFrame operations.
+"""
+
+from collections.abc import Generator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from ruamel.yaml import YAML
+
+import sunstone
+from sunstone.lineage import (
+    Activity,
+    Agent,
+    AgentType,
+    EntityRef,
+    FieldDerivation,
+    LineageMetadata,
+    Metadata,
+    UsageRecord,
+)
+from sunstone.session import DatasetRead, LineageSession, close_session
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for PROV-O types
+# ---------------------------------------------------------------------------
+
+
+class TestAgent:
+    def test_default_type_is_person(self) -> None:
+        agent = Agent(id="alice")
+        assert agent.type == AgentType.PERSON
+
+    def test_software_agent(self) -> None:
+        agent = Agent(id="sunstone-py", type=AgentType.SOFTWARE, version="1.0.0")
+        assert agent.type == AgentType.SOFTWARE
+        assert agent.version == "1.0.0"
+
+    def test_organization_agent(self) -> None:
+        agent = Agent(id="UN", type=AgentType.ORGANIZATION, label="United Nations")
+        assert agent.type == AgentType.ORGANIZATION
+        assert agent.label == "United Nations"
+
+    def test_agent_type_values(self) -> None:
+        assert AgentType.PERSON.value == "prov:Person"
+        assert AgentType.SOFTWARE.value == "prov:SoftwareAgent"
+        assert AgentType.ORGANIZATION.value == "prov:Organization"
+
+
+class TestEntityRef:
+    def test_basic_ref(self) -> None:
+        ref = EntityRef(slug="my-dataset")
+        assert ref.slug == "my-dataset"
+        assert ref.namespace is None
+
+    def test_ref_with_namespace(self) -> None:
+        ref = EntityRef(slug="data", namespace="https://example.org/")
+        assert ref.namespace == "https://example.org/"
+
+    def test_frozen(self) -> None:
+        ref = EntityRef(slug="test")
+        with pytest.raises(AttributeError):
+            ref.slug = "changed"  # type: ignore[misc]
+
+
+class TestFieldDerivation:
+    def test_basic(self) -> None:
+        fd = FieldDerivation(output_field="Country", source_entity="raw-data", source_field="Member State")
+        assert fd.output_field == "Country"
+        assert fd.source_entity == "raw-data"
+        assert fd.source_field == "Member State"
+
+    def test_no_source_field(self) -> None:
+        fd = FieldDerivation(output_field="score", source_entity="input-data")
+        assert fd.source_field is None
+
+
+class TestUsageRecord:
+    def test_basic(self) -> None:
+        ur = UsageRecord(entity=EntityRef(slug="input-1"))
+        assert ur.entity.slug == "input-1"
+        assert ur.columns is None
+        assert ur.filters is None
+
+    def test_with_columns_and_filters(self) -> None:
+        ur = UsageRecord(
+            entity=EntityRef(slug="input-1"),
+            columns=["a", "b"],
+            filters={"year": 2024},
+        )
+        assert ur.columns == ["a", "b"]
+        assert ur.filters == {"year": 2024}
+
+
+class TestActivity:
+    def test_basic(self) -> None:
+        a = Activity(id="exec-abc123")
+        assert a.id == "exec-abc123"
+        assert a.used == []
+        assert a.generated == []
+        assert a.was_associated_with == []
+
+    def test_full(self) -> None:
+        a = Activity(
+            id="exec-abc123",
+            used=[UsageRecord(entity=EntityRef(slug="input-1"))],
+            generated=[EntityRef(slug="output-1")],
+            was_associated_with=[
+                Agent(id="alice", type=AgentType.PERSON),
+                Agent(id="sunstone-py", type=AgentType.SOFTWARE, version="1.0"),
+            ],
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc),
+            script_path="scripts/process.py",
+            git_commit="abc123",
+            git_dirty=False,
+            transformation_params={"threshold": 100},
+        )
+        assert len(a.used) == 1
+        assert len(a.was_associated_with) == 2
+        assert a.transformation_params == {"threshold": 100}
+
+
+# ---------------------------------------------------------------------------
+# DatasetRead.to_usage_record
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetReadConversion:
+    def test_to_usage_record(self) -> None:
+        dr = DatasetRead(slug="my-data", columns=["a", "b"], filters={"x": 1})
+        ur = dr.to_usage_record()
+        assert ur.entity.slug == "my-data"
+        assert ur.columns == ["a", "b"]
+        assert ur.filters == {"x": 1}
+
+    def test_to_usage_record_minimal(self) -> None:
+        dr = DatasetRead(slug="simple")
+        ur = dr.to_usage_record()
+        assert ur.entity.slug == "simple"
+        assert ur.columns is None
+        assert ur.filters is None
+
+
+# ---------------------------------------------------------------------------
+# Session flush_activity
+# ---------------------------------------------------------------------------
+
+
+def _mock_detect_context() -> Any:
+    from sunstone.context import ExecutionContext
+
+    return ExecutionContext(
+        user="test-user",
+        script_path="scripts/process.py",
+        execution_timestamp="2026-01-15T10:00:00+00:00",
+    )
+
+
+class TestSessionFlushActivity:
+    @pytest.fixture(autouse=True)
+    def _fresh_session(self) -> Generator[None]:
+        close_session()
+        yield
+        close_session()
+
+    @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
+    def test_flush_activity_basic(self, mock_ctx: Any) -> None:
+        session = LineageSession()
+        session.record_read(DatasetRead(slug="input-1"))
+        session.record_read(DatasetRead(slug="input-2"))
+
+        activity = session.flush_activity()
+
+        assert activity.id.startswith("exec-")
+        assert len(activity.used) == 2
+        assert activity.used[0].entity.slug == "input-1"
+        assert activity.used[1].entity.slug == "input-2"
+        assert activity.script_path == "scripts/process.py"
+        assert activity.started_at is not None
+        assert activity.ended_at is not None
+
+        # Agents: person + software
+        assert len(activity.was_associated_with) == 2
+        person = activity.was_associated_with[0]
+        software = activity.was_associated_with[1]
+        assert person.id == "test-user"
+        assert person.type == AgentType.PERSON
+        assert software.id == "sunstone-py"
+        assert software.type == AgentType.SOFTWARE
+
+    @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
+    def test_flush_activity_clears_reads(self, mock_ctx: Any) -> None:
+        session = LineageSession()
+        session.record_read(DatasetRead(slug="input-1"))
+        session.flush_activity()
+
+        # Second flush should have no reads
+        activity2 = session.flush_activity()
+        assert len(activity2.used) == 0
+
+    @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
+    def test_flush_to_output_includes_activity(self, mock_ctx: Any) -> None:
+        session = LineageSession()
+        session.record_read(DatasetRead(slug="input-1"))
+
+        result = session.flush_to_output(transformation_params={"k": "v"})
+
+        assert "_activity" in result
+        activity = result["_activity"]
+        assert isinstance(activity, Activity)
+        assert activity.used[0].entity.slug == "input-1"
+        assert activity.transformation_params == {"k": "v"}
+
+    @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
+    def test_flush_activity_deterministic_id(self, mock_ctx: Any) -> None:
+        """Same context produces the same activity ID."""
+        s1 = LineageSession()
+        s1.record_read(DatasetRead(slug="x"))
+        a1 = s1.flush_activity()
+
+        s2 = LineageSession()
+        s2.record_read(DatasetRead(slug="y"))
+        a2 = s2.flush_activity()
+
+        assert a1.id == a2.id  # Same context → same ID
+
+
+# ---------------------------------------------------------------------------
+# ExecutionContext.to_agents
+# ---------------------------------------------------------------------------
+
+
+class TestContextToAgents:
+    def test_to_agents_with_user(self) -> None:
+        from sunstone.context import ExecutionContext
+
+        ctx = ExecutionContext(user="stig")
+        agents = ctx.to_agents()
+
+        assert len(agents) == 2
+        assert agents[0].id == "stig"
+        assert agents[0].type == AgentType.PERSON
+        assert agents[1].id == "sunstone-py"
+        assert agents[1].type == AgentType.SOFTWARE
+
+    def test_to_agents_without_user(self) -> None:
+        from sunstone.context import ExecutionContext
+
+        ctx = ExecutionContext()
+        agents = ctx.to_agents()
+
+        # Only software agent when no user
+        assert len(agents) == 1
+        assert agents[0].id == "sunstone-py"
+
+
+# ---------------------------------------------------------------------------
+# LineageMetadata.merge with field_derivations
+# ---------------------------------------------------------------------------
+
+
+class TestLineageMergeFieldDerivations:
+    def test_merge_both_have_derivations(self) -> None:
+        lm1 = LineageMetadata(
+            field_derivations=[
+                FieldDerivation(output_field="a", source_entity="ds1"),
+            ]
+        )
+        lm2 = LineageMetadata(
+            field_derivations=[
+                FieldDerivation(output_field="b", source_entity="ds2"),
+            ]
+        )
+        merged = lm1.merge(lm2)
+        assert merged.field_derivations is not None
+        assert len(merged.field_derivations) == 2
+        fields = {d.output_field for d in merged.field_derivations}
+        assert fields == {"a", "b"}
+
+    def test_merge_one_has_derivations(self) -> None:
+        lm1 = LineageMetadata(
+            field_derivations=[
+                FieldDerivation(output_field="a", source_entity="ds1"),
+            ]
+        )
+        lm2 = LineageMetadata()
+        merged = lm1.merge(lm2)
+        assert merged.field_derivations is not None
+        assert len(merged.field_derivations) == 1
+
+    def test_merge_deduplicates(self) -> None:
+        fd = FieldDerivation(output_field="a", source_entity="ds1")
+        lm1 = LineageMetadata(field_derivations=[fd])
+        lm2 = LineageMetadata(field_derivations=[fd])
+        merged = lm1.merge(lm2)
+        assert merged.field_derivations is not None
+        assert len(merged.field_derivations) == 1
+
+    def test_merge_neither_has_derivations(self) -> None:
+        lm1 = LineageMetadata()
+        lm2 = LineageMetadata()
+        merged = lm1.merge(lm2)
+        assert merged.field_derivations is None
+
+
+# ---------------------------------------------------------------------------
+# Source.agent property
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAgent:
+    def test_string_attributed_to_returns_org_agent(self) -> None:
+        from sunstone.lineage import Source, SourceLocation
+
+        s = Source(
+            name="Test",
+            location=SourceLocation(),
+            attributed_to="United Nations",
+            acquired_at="2026-01-01",
+            acquisition_method="manual",
+            license="CC-BY-4.0",
+        )
+        agent = s.agent
+        assert agent.id == "United Nations"
+        assert agent.type == AgentType.ORGANIZATION
+
+    def test_agent_attributed_to_returns_same(self) -> None:
+        from sunstone.lineage import Source, SourceLocation
+
+        a = Agent(id="UN", type=AgentType.ORGANIZATION)
+        s = Source(
+            name="Test",
+            location=SourceLocation(),
+            attributed_to=a,
+            acquired_at="2026-01-01",
+            acquisition_method="manual",
+            license="CC-BY-4.0",
+        )
+        assert s.agent is a
+
+
+# ---------------------------------------------------------------------------
+# datasets.yaml round-trip: Activity + FieldDerivations
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetsYamlRoundTrip:
+    @pytest.fixture
+    def project_with_output(self, tmp_path: Path) -> Path:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "inputs").mkdir()
+        (project / "outputs").mkdir()
+        (project / "inputs" / "data.csv").write_text("id,name\n1,Alice\n")
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+        data = {
+            "inputs": [
+                {
+                    "name": "Input Data",
+                    "slug": "input-data",
+                    "location": "inputs/data.csv",
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "name", "type": "string"},
+                    ],
+                    "source": {
+                        "name": "Test Source",
+                        "location": {"data": None},
+                        "attributedTo": "Test Org",
+                        "acquiredAt": "2026-01-01",
+                        "acquisitionMethod": "manual",
+                        "license": "CC-BY-4.0",
+                    },
+                },
+            ],
+            "outputs": [
+                {
+                    "name": "Output Data",
+                    "slug": "output-data",
+                    "location": "outputs/out.csv",
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "name", "type": "string"},
+                    ],
+                },
+            ],
+        }
+        with open(project / "datasets.yaml", "w") as f:
+            yaml.dump(data, f)
+
+        return project
+
+    @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
+    def test_activity_persisted_to_yaml(self, mock_ctx: Any, project_with_output: Path) -> None:
+        """Writing an output should persist an activity section in datasets.yaml."""
+        close_session()
+
+        df = sunstone.DataFrame.read_dataset("input-data", project_path=project_with_output)
+        df.to_csv("outputs/out.csv", index=False)
+
+        yaml = YAML()
+        with open(project_with_output / "datasets.yaml") as f:
+            data = yaml.load(f)
+
+        output = next(d for d in data["outputs"] if d["slug"] == "output-data")
+        lineage = output["lineage"]
+
+        assert "activity" in lineage
+        activity = lineage["activity"]
+        assert activity["id"].startswith("exec-")
+        assert "agents" in activity
+        assert any(a["id"] == "test-user" for a in activity["agents"])
+        assert any(a["type"] == "prov:SoftwareAgent" for a in activity["agents"])
+        assert "used" in activity
+        assert any(u["entity"] == "input-data" for u in activity["used"])
+
+    @patch("sunstone.context.detect_execution_context", side_effect=_mock_detect_context)
+    def test_field_derivations_persisted_to_yaml(self, mock_ctx: Any, project_with_output: Path) -> None:
+        """Setting field source metadata should persist field_derivations."""
+        close_session()
+
+        df = sunstone.DataFrame.read_dataset("input-data", project_path=project_with_output)
+        df.set_field_metadata("name", source="input-data")
+        df.to_csv("outputs/out.csv", index=False)
+
+        yaml = YAML()
+        with open(project_with_output / "datasets.yaml") as f:
+            data = yaml.load(f)
+
+        output = next(d for d in data["outputs"] if d["slug"] == "output-data")
+        lineage = output["lineage"]
+
+        assert "field_derivations" in lineage
+        fd = lineage["field_derivations"]
+        assert len(fd) == 1
+        assert fd[0]["output_field"] == "name"
+        assert fd[0]["source_entity"] == "input-data"
+
+    def test_activity_parsed_from_yaml(self, tmp_path: Path) -> None:
+        """Activity section in datasets.yaml should be parseable."""
+        project = tmp_path / "parse_proj"
+        project.mkdir()
+        (project / "outputs").mkdir()
+
+        yaml = YAML()
+        data = {
+            "inputs": [],
+            "outputs": [
+                {
+                    "name": "Output",
+                    "slug": "output-data",
+                    "location": "outputs/out.csv",
+                    "fields": [{"name": "id", "type": "integer"}],
+                    "lineage": {
+                        "content_hash": "abc123",
+                        "created_at": "2026-01-15T10:00:00",
+                        "sources": [{"slug": "input-data"}],
+                        "activity": {
+                            "id": "exec-abc123",
+                            "started_at": "2026-01-15T10:00:00",
+                            "ended_at": "2026-01-15T10:05:00",
+                            "script_path": "scripts/process.py",
+                            "git_commit": "abc123",
+                            "agents": [
+                                {"id": "alice", "type": "prov:Person"},
+                                {"id": "sunstone-py", "type": "prov:SoftwareAgent", "version": "1.0"},
+                            ],
+                            "used": [
+                                {"entity": "input-data", "columns": ["id"]},
+                            ],
+                        },
+                        "field_derivations": [
+                            {
+                                "output_field": "id",
+                                "source_entity": "input-data",
+                                "source_field": "id",
+                            },
+                        ],
+                    },
+                },
+            ],
+        }
+        with open(project / "datasets.yaml", "w") as f:
+            yaml.dump(data, f)
+
+        from sunstone.datasets import DatasetsManager
+
+        mgr = DatasetsManager(project)
+        ds = mgr.find_dataset_by_slug("output-data", dataset_type="output")
+        assert ds is not None
+
+        # PROV-O fields should be populated
+        assert ds.was_derived_from is not None
+        assert len(ds.was_derived_from) == 1
+        assert ds.was_derived_from[0].slug == "input-data"
+
+        assert ds.was_generated_by is not None
+        assert ds.was_generated_by.id == "exec-abc123"
+
+        assert ds.generated_at_time is not None
+
+        assert ds.field_derivations is not None
+        assert len(ds.field_derivations) == 1
+        assert ds.field_derivations[0].source_field == "id"
+
+    def test_old_format_without_activity_still_parses(self, tmp_path: Path) -> None:
+        """datasets.yaml without activity section should still parse fine."""
+        project = tmp_path / "old_proj"
+        project.mkdir()
+        (project / "outputs").mkdir()
+
+        yaml = YAML()
+        data = {
+            "inputs": [],
+            "outputs": [
+                {
+                    "name": "Output",
+                    "slug": "output-data",
+                    "location": "outputs/out.csv",
+                    "fields": [{"name": "id", "type": "integer"}],
+                    "lineage": {
+                        "content_hash": "abc123",
+                        "created_at": "2026-01-15T10:00:00",
+                        "sources": [{"slug": "input-data"}],
+                        "context": {"user": "alice"},
+                    },
+                },
+            ],
+        }
+        with open(project / "datasets.yaml", "w") as f:
+            yaml.dump(data, f)
+
+        from sunstone.datasets import DatasetsManager
+
+        mgr = DatasetsManager(project)
+        ds = mgr.find_dataset_by_slug("output-data", dataset_type="output")
+        assert ds is not None
+        assert ds.was_derived_from is not None
+        assert ds.was_generated_by is None  # No activity in old format
+        assert ds.field_derivations is None
+
+
+# ---------------------------------------------------------------------------
+# DataFrame field_derivations propagation
+# ---------------------------------------------------------------------------
+
+
+class TestFieldDerivationPropagation:
+    def test_wrap_result_filters_derivations(self) -> None:
+        """_wrap_result should filter out field_derivations for dropped columns."""
+        import pandas as pd
+
+        meta = Metadata(
+            lineage=LineageMetadata(
+                field_derivations=[
+                    FieldDerivation(output_field="a", source_entity="ds1"),
+                    FieldDerivation(output_field="b", source_entity="ds1"),
+                    FieldDerivation(output_field="c", source_entity="ds2"),
+                ]
+            )
+        )
+        df = sunstone.DataFrame(data=pd.DataFrame({"a": [1], "b": [2], "c": [3]}), metadata=meta)
+
+        # Select only columns a and c
+        result = df[["a", "c"]]
+        assert result.metadata.lineage.field_derivations is not None
+        assert len(result.metadata.lineage.field_derivations) == 2
+        fields = {d.output_field for d in result.metadata.lineage.field_derivations}
+        assert fields == {"a", "c"}
+
+    def test_set_field_metadata_creates_derivation(self) -> None:
+        """set_field_metadata with source should create a FieldDerivation."""
+        import pandas as pd
+
+        df = sunstone.DataFrame(data=pd.DataFrame({"x": [1]}))
+        df.set_field_metadata("x", source="input-ds")
+
+        assert df.metadata.lineage.field_derivations is not None
+        assert len(df.metadata.lineage.field_derivations) == 1
+        assert df.metadata.lineage.field_derivations[0].output_field == "x"
+        assert df.metadata.lineage.field_derivations[0].source_entity == "input-ds"
+
+    def test_set_field_metadata_replaces_derivation(self) -> None:
+        """Setting source again replaces the derivation, not duplicates."""
+        import pandas as pd
+
+        df = sunstone.DataFrame(data=pd.DataFrame({"x": [1]}))
+        df.set_field_metadata("x", source="ds1")
+        df.set_field_metadata("x", source="ds2")
+
+        assert df.metadata.lineage.field_derivations is not None
+        assert len(df.metadata.lineage.field_derivations) == 1
+        assert df.metadata.lineage.field_derivations[0].source_entity == "ds2"
+
+
+# ---------------------------------------------------------------------------
+# LineageNode with Activity
+# ---------------------------------------------------------------------------
+
+
+class TestLineageNodeActivity:
+    def test_lineage_node_with_activity(self, tmp_path: Path) -> None:
+        """get_upstream should populate activity on LineageNode."""
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        yaml = YAML()
+        data = {
+            "inputs": [
+                {
+                    "name": "Input",
+                    "slug": "input-data",
+                    "location": "inputs/data.csv",
+                    "fields": [{"name": "id", "type": "integer"}],
+                    "source": {
+                        "name": "Test",
+                        "location": {"data": None},
+                        "attributedTo": "Test",
+                        "acquiredAt": "2026-01-01",
+                        "acquisitionMethod": "manual",
+                        "license": "CC-BY-4.0",
+                    },
+                },
+            ],
+            "outputs": [
+                {
+                    "name": "Output",
+                    "slug": "output-data",
+                    "location": "outputs/out.csv",
+                    "fields": [{"name": "id", "type": "integer"}],
+                    "lineage": {
+                        "content_hash": "abc",
+                        "sources": [{"slug": "input-data"}],
+                        "activity": {
+                            "id": "exec-test",
+                            "agents": [{"id": "alice", "type": "prov:Person"}],
+                            "used": [{"entity": "input-data"}],
+                        },
+                    },
+                },
+            ],
+        }
+        with open(project / "datasets.yaml", "w") as f:
+            yaml.dump(data, f)
+
+        from sunstone.queries import get_upstream, lineage_to_dict
+
+        node = get_upstream("output-data", project_path=project)
+        assert node.activity is not None
+        assert node.activity.id == "exec-test"
+        assert node.activity.was_associated_with[0].id == "alice"
+
+        # lineage_to_dict should include activity
+        d = lineage_to_dict(node)
+        assert "activity" in d
+        assert d["activity"]["id"] == "exec-test"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -443,9 +443,14 @@ class TestDatasetsYamlRoundTrip:
 
         assert "field_derivations" in lineage
         fd = lineage["field_derivations"]
-        assert len(fd) == 1
-        assert fd[0]["output_field"] == "name"
-        assert fd[0]["source_entity"] == "input-data"
+        fd_by_field = {d["output_field"]: d for d in fd}
+
+        # Auto-populated derivation for 'id'
+        assert fd_by_field["id"]["source_entity"] == "input-data"
+        assert fd_by_field["id"]["source_field"] == "id"
+
+        # Explicitly set derivation for 'name' (replaces auto-populated one)
+        assert fd_by_field["name"]["source_entity"] == "input-data"
 
     def test_activity_parsed_from_yaml(self, tmp_path: Path) -> None:
         """Activity section in datasets.yaml should be parseable."""


### PR DESCRIPTION
## Summary
- Align the lineage data model with W3C PROV-O: Activity, Agent, UsageRecord, EntityRef, FieldDerivation classes
- Add PROV-O Activity serialization to datasets.yaml (agents, used entities, timestamps, script path, git state)
- Auto-populate field_derivations on read so field-level provenance flows through merge/join/concat to datasets.yaml without manual setup

## Test plan
- [x] End-to-end flow test: read two datasets, merge, write — verify activity, sources, field_derivations all appear in datasets.yaml
- [x] Field derivation persistence through DataFrame operations (head, sort, getitem, merge, join, concat)
- [x] Transformation params and context persisted correctly
- [x] Script path relativization in both context and activity sections
- [x] Full test suite passes (879 tests)