### PR TITLE
Add full attribution chain traversal and statement generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: full attribution chain traversal with `get_full_attribution()` and `generate_attribution_statement()`
+- Added: `sunstone lineage attribution` CLI command with text, markdown, and HTML output formats
+
 ## [1.10.0] - 2026-05-06
 
 - Added: `sunstone.set_project_path()`, `get_project_path()`, `clear_project_path()`, and

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -1805,5 +1805,27 @@ def lint_cmd(
     sys.exit(1 if has_blocking else 0)
 
 
+@lineage_app.command("attribution")
+def lineage_attribution(
+    slug: str = typer.Argument(..., help="Dataset slug to show attributions for"),
+    datasets_file: str = typer.Option("datasets.yaml", "-f", "--file", help="Path to datasets.yaml"),
+    format: str = typer.Option("text", "--format", help="Output format: text, markdown, or html"),
+) -> None:
+    """Show source attributions for a dataset by traversing its lineage tree."""
+    from .queries import generate_attribution_statement
+
+    project_path = Path(datasets_file).resolve().parent
+    try:
+        statement = generate_attribution_statement(slug, project_path=project_path, format=format)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    typer.echo(statement)
+
+
 if __name__ == "__main__":
     app()

--- a/src/sunstone/queries.py
+++ b/src/sunstone/queries.py
@@ -2,11 +2,13 @@
 Lineage query API for traversing dataset lineage trees.
 
 Provides functions to build, display, and export lineage trees
-from datasets.yaml metadata.
+from datasets.yaml metadata, collect source attributions, and
+generate human-readable attribution statements.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -15,6 +17,8 @@ from .datasets import DatasetsManager
 
 if TYPE_CHECKING:
     from .lineage import Activity
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -179,3 +183,195 @@ def lineage_to_dict(node: LineageNode) -> dict[str, Any]:
     if node.activity is not None:
         result["activity"] = DatasetsManager._activity_to_dict(node.activity)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Attribution chain traversal
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Attribution:
+    """Source attribution collected from a leaf node in the lineage tree."""
+
+    organization: str
+    """Organization or individual the data is attributed to."""
+
+    dataset_name: str
+    """Human-readable name of the source dataset."""
+
+    license: str
+    """SPDX license identifier."""
+
+    acquired_at: Optional[str] = None
+    """Date when the data was acquired (YYYY-MM-DD)."""
+
+    source_url: Optional[str] = None
+    """URL to the source data."""
+
+
+def _collect_leaf_slugs(node: LineageNode) -> list[str]:
+    """Walk the lineage tree and return slugs of all leaf nodes (no sources)."""
+    if node.circular:
+        return []
+    if not node.sources:
+        return [node.slug]
+    slugs: list[str] = []
+    for child in node.sources:
+        slugs.extend(_collect_leaf_slugs(child))
+    return slugs
+
+
+def get_full_attribution(
+    slug: str,
+    project_path: Optional[str | Path] = None,
+) -> list[Attribution]:
+    """
+    Traverse the full lineage tree for a dataset and collect source attributions.
+
+    Walks the lineage tree to find leaf nodes (inputs with no further sources),
+    looks up their ``source`` block in datasets.yaml, and builds deduplicated
+    Attribution objects sorted by organization then dataset name.
+
+    Args:
+        slug: The output dataset slug to query.
+        project_path: Path to the project directory. Defaults to cwd.
+
+    Returns:
+        Sorted, deduplicated list of Attribution objects.
+    """
+    if project_path is None:
+        project_path = Path.cwd()
+
+    tree = get_upstream(slug, project_path=project_path)
+    leaf_slugs = _collect_leaf_slugs(tree)
+
+    # Deduplicate while preserving order
+    seen_slugs: set[str] = set()
+    unique_slugs: list[str] = []
+    for s in leaf_slugs:
+        if s not in seen_slugs:
+            seen_slugs.add(s)
+            unique_slugs.append(s)
+
+    mgr = DatasetsManager(project_path)
+    seen_keys: set[tuple[str, str]] = set()
+    attributions: list[Attribution] = []
+
+    for leaf_slug in unique_slugs:
+        ds = mgr.find_dataset_by_slug(leaf_slug)
+        if ds is None:
+            logger.warning("Dataset '%s' not found, skipping attribution", leaf_slug)
+            continue
+
+        if ds.source is None:
+            logger.warning("Dataset '%s' has no source attribution", leaf_slug)
+            continue
+
+        org = ds.source.agent.label or ds.source.agent.id
+        name = ds.source.name
+        key = (org, name)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+
+        source_url: Optional[str] = None
+        if ds.source.location:
+            source_url = ds.source.location.data or ds.source.location.about
+
+        attributions.append(
+            Attribution(
+                organization=org,
+                dataset_name=name,
+                license=ds.source.license,
+                acquired_at=ds.source.acquired_at,
+                source_url=source_url,
+            )
+        )
+
+    attributions.sort(key=lambda a: (a.organization.lower(), a.dataset_name.lower()))
+    return attributions
+
+
+def generate_attribution_statement(
+    slug: str,
+    project_path: Optional[str | Path] = None,
+    format: str = "text",
+) -> str:
+    """
+    Generate a human-readable attribution statement for a dataset.
+
+    Traverses the lineage tree, collects attributions from leaf nodes,
+    and formats them in the requested style.
+
+    Args:
+        slug: The output dataset slug to query.
+        project_path: Path to the project directory. Defaults to cwd.
+        format: Output format — ``"text"``, ``"markdown"``, or ``"html"``.
+
+    Returns:
+        Formatted attribution statement string.
+
+    Raises:
+        ValueError: If *format* is not one of the supported values.
+    """
+    if format not in ("text", "markdown", "html"):
+        raise ValueError(f"Unsupported format: {format!r} (expected 'text', 'markdown', or 'html')")
+
+    attributions = get_full_attribution(slug, project_path=project_path)
+
+    if not attributions:
+        return "No source attributions found."
+
+    if format == "text":
+        return _format_text(attributions)
+    elif format == "markdown":
+        return _format_markdown(attributions)
+    else:
+        return _format_html(attributions)
+
+
+def _format_text(attributions: list[Attribution]) -> str:
+    lines = ["This dataset is derived from:"]
+    for attr in attributions:
+        lines.append(f'  - "{attr.dataset_name}" by {attr.organization}')
+        detail = f"    License: {attr.license}"
+        if attr.acquired_at:
+            detail += f", acquired {attr.acquired_at}"
+        lines.append(detail)
+        if attr.source_url:
+            lines.append(f"    {attr.source_url}")
+    return "\n".join(lines)
+
+
+def _format_markdown(attributions: list[Attribution]) -> str:
+    lines = ["This dataset is derived from:"]
+    lines.append("")
+    for attr in attributions:
+        if attr.source_url:
+            lines.append(f'- **"{attr.dataset_name}"** by **{attr.organization}**')
+        else:
+            lines.append(f'- **"{attr.dataset_name}"** by **{attr.organization}**')
+        detail = f"  License: `{attr.license}`"
+        if attr.acquired_at:
+            detail += f", acquired {attr.acquired_at}"
+        lines.append(detail)
+        if attr.source_url:
+            lines.append(f"  URL: [{attr.source_url}]({attr.source_url})")
+    return "\n".join(lines)
+
+
+def _format_html(attributions: list[Attribution]) -> str:
+    lines = ["<p>This dataset is derived from:</p>", "<ul>"]
+    for attr in attributions:
+        lines.append("  <li>")
+        lines.append(f'    <strong>"{attr.dataset_name}"</strong> by <strong>{attr.organization}</strong><br>')
+        detail = f"    License: {attr.license}"
+        if attr.acquired_at:
+            detail += f", acquired {attr.acquired_at}"
+        lines.append(f"    {detail}<br>")
+        if attr.source_url:
+            lines.append(f'    <a href="{attr.source_url}">{attr.source_url}</a>')
+        lines.append("  </li>")
+    lines.append("</ul>")
+    return "\n".join(lines)

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,315 @@
+"""
+Tests for attribution chain traversal and statement generation (queries.py).
+"""
+
+import textwrap
+from pathlib import Path
+
+from sunstone.queries import generate_attribution_statement, get_full_attribution
+
+
+def _write_datasets_yaml(tmp_path: Path, content: str) -> Path:
+    """Helper to write a datasets.yaml file in a temp directory."""
+    yaml_path = tmp_path / "datasets.yaml"
+    yaml_path.write_text(textwrap.dedent(content))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# datasets.yaml fixtures
+# ---------------------------------------------------------------------------
+
+SIMPLE_CHAIN = """\
+inputs:
+  - name: Raw Data
+    slug: raw-data
+    location: inputs/raw.csv
+    source:
+      name: World Bank Open Data
+      attributedTo: World Bank
+      license: CC-BY-4.0
+      acquiredAt: "2026-02-15"
+      acquisitionMethod: manual-download
+      location:
+        data: https://data.worldbank.org/example.csv
+        about: https://data.worldbank.org/
+outputs:
+  - name: Processed Data
+    slug: processed-data
+    location: outputs/processed.csv
+    lineage:
+      sources:
+        - slug: raw-data
+"""
+
+TWO_INPUTS = """\
+inputs:
+  - name: Population Data
+    slug: population-data
+    location: inputs/population.csv
+    source:
+      name: UN Population Database
+      attributedTo: United Nations
+      license: CC-BY-4.0
+      acquiredAt: "2026-01-10"
+      acquisitionMethod: api
+      location:
+        data: https://population.un.org/data.csv
+  - name: GDP Data
+    slug: gdp-data
+    location: inputs/gdp.csv
+    source:
+      name: IMF World Economic Outlook
+      attributedTo: International Monetary Fund
+      license: CC-BY-NC-SA-4.0
+      acquiredAt: "2026-03-01"
+      acquisitionMethod: manual-download
+      location:
+        data: https://imf.org/weo/data.csv
+        about: https://imf.org/weo
+outputs:
+  - name: Combined Output
+    slug: combined-output
+    location: outputs/combined.csv
+    lineage:
+      sources:
+        - slug: population-data
+        - slug: gdp-data
+"""
+
+MULTI_LEVEL = """\
+inputs:
+  - name: Source A
+    slug: source-a
+    location: inputs/a.csv
+    source:
+      name: Dataset Alpha
+      attributedTo: Org Alpha
+      license: MIT
+      acquiredAt: "2025-12-01"
+      acquisitionMethod: manual-download
+      location:
+        data: https://alpha.org/data.csv
+  - name: Source B
+    slug: source-b
+    location: inputs/b.csv
+    source:
+      name: Dataset Beta
+      attributedTo: Org Beta
+      license: Apache-2.0
+      acquiredAt: "2025-11-15"
+      acquisitionMethod: api
+      location:
+        about: https://beta.org/about
+outputs:
+  - name: Intermediate
+    slug: intermediate
+    location: outputs/intermediate.csv
+    lineage:
+      sources:
+        - slug: source-a
+  - name: Final
+    slug: final-output
+    location: outputs/final.csv
+    lineage:
+      sources:
+        - slug: intermediate
+        - slug: source-b
+"""
+
+NO_SOURCE_ATTRIBUTION = """\
+inputs:
+  - name: Local Data
+    slug: local-data
+    location: inputs/local.csv
+outputs:
+  - name: Output
+    slug: output
+    location: outputs/output.csv
+    lineage:
+      sources:
+        - slug: local-data
+"""
+
+DUPLICATE_SOURCES = """\
+inputs:
+  - name: Shared Source
+    slug: shared-source
+    location: inputs/shared.csv
+    source:
+      name: Common Dataset
+      attributedTo: Shared Org
+      license: CC-BY-4.0
+      acquiredAt: "2026-01-01"
+      acquisitionMethod: manual-download
+      location:
+        data: https://shared.org/data.csv
+outputs:
+  - name: Branch A
+    slug: branch-a
+    location: outputs/a.csv
+    lineage:
+      sources:
+        - slug: shared-source
+  - name: Branch B
+    slug: branch-b
+    location: outputs/b.csv
+    lineage:
+      sources:
+        - slug: shared-source
+  - name: Merged
+    slug: merged
+    location: outputs/merged.csv
+    lineage:
+      sources:
+        - slug: branch-a
+        - slug: branch-b
+"""
+
+
+# ---------------------------------------------------------------------------
+# get_full_attribution tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetFullAttribution:
+    """Tests for get_full_attribution()."""
+
+    def test_simple_chain(self, tmp_path):
+        """Single input -> single output should produce one attribution."""
+        _write_datasets_yaml(tmp_path, SIMPLE_CHAIN)
+        result = get_full_attribution("processed-data", project_path=tmp_path)
+
+        assert len(result) == 1
+        attr = result[0]
+        assert attr.organization == "World Bank"
+        assert attr.dataset_name == "World Bank Open Data"
+        assert attr.license == "CC-BY-4.0"
+        assert attr.acquired_at == "2026-02-15"
+        assert attr.source_url == "https://data.worldbank.org/example.csv"
+
+    def test_two_inputs(self, tmp_path):
+        """Output with two inputs should produce two attributions."""
+        _write_datasets_yaml(tmp_path, TWO_INPUTS)
+        result = get_full_attribution("combined-output", project_path=tmp_path)
+
+        assert len(result) == 2
+        orgs = {a.organization for a in result}
+        assert orgs == {"International Monetary Fund", "United Nations"}
+
+    def test_multi_level_traversal(self, tmp_path):
+        """Should traverse through intermediate outputs to find leaf inputs."""
+        _write_datasets_yaml(tmp_path, MULTI_LEVEL)
+        result = get_full_attribution("final-output", project_path=tmp_path)
+
+        assert len(result) == 2
+        names = {a.dataset_name for a in result}
+        assert names == {"Dataset Alpha", "Dataset Beta"}
+
+    def test_deduplication(self, tmp_path):
+        """Same source via multiple paths should appear only once."""
+        _write_datasets_yaml(tmp_path, DUPLICATE_SOURCES)
+        result = get_full_attribution("merged", project_path=tmp_path)
+
+        assert len(result) == 1
+        assert result[0].organization == "Shared Org"
+
+    def test_missing_source_attribution(self, tmp_path):
+        """Input without source block should be skipped gracefully."""
+        _write_datasets_yaml(tmp_path, NO_SOURCE_ATTRIBUTION)
+        result = get_full_attribution("output", project_path=tmp_path)
+
+        assert len(result) == 0
+
+    def test_no_lineage(self, tmp_path):
+        """Output with no lineage returns empty list."""
+        _write_datasets_yaml(
+            tmp_path,
+            """\
+            inputs: []
+            outputs:
+              - name: Standalone
+                slug: standalone
+                location: outputs/standalone.csv
+            """,
+        )
+        result = get_full_attribution("standalone", project_path=tmp_path)
+        assert len(result) == 0
+
+    def test_source_url_falls_back_to_about(self, tmp_path):
+        """When location.data is missing, source_url should use location.about."""
+        _write_datasets_yaml(tmp_path, MULTI_LEVEL)
+        result = get_full_attribution("final-output", project_path=tmp_path)
+
+        beta_attr = [a for a in result if a.organization == "Org Beta"][0]
+        assert beta_attr.source_url == "https://beta.org/about"
+
+    def test_sorted_by_organization(self, tmp_path):
+        """Attributions should be sorted by organization name (case-insensitive)."""
+        _write_datasets_yaml(tmp_path, TWO_INPUTS)
+        result = get_full_attribution("combined-output", project_path=tmp_path)
+
+        assert result[0].organization == "International Monetary Fund"
+        assert result[1].organization == "United Nations"
+
+
+# ---------------------------------------------------------------------------
+# generate_attribution_statement tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAttributionStatement:
+    """Tests for generate_attribution_statement()."""
+
+    def test_text_format(self, tmp_path):
+        """Text format should have readable plain-text output."""
+        _write_datasets_yaml(tmp_path, SIMPLE_CHAIN)
+        result = generate_attribution_statement("processed-data", project_path=tmp_path, format="text")
+
+        assert "This dataset is derived from:" in result
+        assert '"World Bank Open Data" by World Bank' in result
+        assert "License: CC-BY-4.0" in result
+        assert "acquired 2026-02-15" in result
+        assert "https://data.worldbank.org/example.csv" in result
+
+    def test_markdown_format(self, tmp_path):
+        """Markdown format should use bold and links."""
+        _write_datasets_yaml(tmp_path, SIMPLE_CHAIN)
+        result = generate_attribution_statement("processed-data", project_path=tmp_path, format="markdown")
+
+        assert "**" in result  # Bold markers
+        assert "`CC-BY-4.0`" in result  # Code-formatted license
+        assert "[https://data.worldbank.org/example.csv]" in result  # Markdown link
+
+    def test_html_format(self, tmp_path):
+        """HTML format should use proper tags."""
+        _write_datasets_yaml(tmp_path, SIMPLE_CHAIN)
+        result = generate_attribution_statement("processed-data", project_path=tmp_path, format="html")
+
+        assert "<ul>" in result
+        assert "<li>" in result
+        assert "<strong>" in result
+        assert '<a href="https://data.worldbank.org/example.csv">' in result
+
+    def test_no_attributions(self, tmp_path):
+        """Should return informative message when no attributions found."""
+        _write_datasets_yaml(tmp_path, NO_SOURCE_ATTRIBUTION)
+        result = generate_attribution_statement("output", project_path=tmp_path)
+
+        assert result == "No source attributions found."
+
+    def test_invalid_format_raises(self, tmp_path):
+        """Invalid format should raise ValueError."""
+        _write_datasets_yaml(tmp_path, SIMPLE_CHAIN)
+        import pytest
+
+        with pytest.raises(ValueError, match="Unsupported format"):
+            generate_attribution_statement("processed-data", project_path=tmp_path, format="pdf")
+
+    def test_multiple_attributions_text(self, tmp_path):
+        """Text format with multiple sources should list all."""
+        _write_datasets_yaml(tmp_path, TWO_INPUTS)
+        result = generate_attribution_statement("combined-output", project_path=tmp_path, format="text")
+
+        assert '"UN Population Database" by United Nations' in result
+        assert '"IMF World Economic Outlook" by International Monetary Fund' in result


### PR DESCRIPTION
## Summary
- Add `Attribution` dataclass, `get_full_attribution()`, and `generate_attribution_statement()` to `queries.py`
- Traverses lineage tree to leaf nodes, collects source attributions, deduplicates by org+name
- Supports text, markdown, and HTML output formats
- Add `sunstone lineage attribution SLUG [--format text|markdown|html]` CLI command

Fixes #14

## Test plan
- [x] Single-input and multi-input attribution chains
- [x] Multi-level traversal through intermediate outputs to leaf inputs
- [x] Deduplication when same source appears via multiple paths
- [x] Graceful handling of missing source attribution (warns, doesn't fail)
- [x] All three output formats (text, markdown, HTML)
- [x] Invalid format raises ValueError
- [x] Empty attribution message