### PR TITLE
License tracking with SPDX validation and write-time compatibility checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Added: full attribution chain traversal with `get_full_attribution()` and `generate_attribution_statement()`
 - Added: `sunstone lineage attribution` CLI command with text, markdown, and HTML output formats
+- Added: `sunstone.licenses` module with embedded SPDX registry (CC, ODC, CC0/PDDL, common LicenseRef-),
+  `LicenseProperties`, `check_compatibility()`, `get_most_restrictive_license()`, and
+  `LicenseCompatibilityError` (closes #13).
+- Added: per-output `license:` field in `datasets.yaml` (falls back to `package.license`).
+- Added: write-time license compatibility enforcement on `DataFrame.to_csv` / `to_parquet`
+  (default `check_license=True`); raises `LicenseCompatibilityError` with conflict descriptions
+  and suggested compatible target licenses. Pass `license=` to override or persist a target license.
+- Added: `sunstone license check [SLUG]` and `sunstone license list` CLI commands (with `--json`).
+- Changed: `sunstone dataset validate` now flags non-SPDX identifiers in dataset, source, and
+  package license fields (LicenseRef-* identifiers are accepted).
 
 ## [1.10.0] - 2026-05-06
 

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -358,14 +358,16 @@ dataset_app = typer.Typer(help="Manage datasets in datasets.yaml.")
 package_app = typer.Typer(help="Manage data packages.")
 lineage_app = typer.Typer(help="Query dataset lineage.")
 env_app = typer.Typer(help="Manage data platform environments.")
+license_app = typer.Typer(help="Inspect and check dataset licenses.")
 
 app.add_typer(dataset_app, name="dataset")
 app.add_typer(package_app, name="package")
 app.add_typer(lineage_app, name="lineage")
 app.add_typer(env_app, name="env")
+app.add_typer(license_app, name="license")
 
 # Mount plugin CLI groups
-_BUILTIN_GROUPS = {"dataset", "package", "lineage", "env"}
+_BUILTIN_GROUPS = {"dataset", "package", "lineage", "env", "license"}
 
 
 def _mount_plugin_cli_groups() -> None:
@@ -710,6 +712,26 @@ def dataset_validate(
                             f"(must be one of: {', '.join(sorted(VALID_FIELD_TYPES))})"
                         )
 
+        # SPDX validation on output license
+        from .licenses import is_valid_spdx
+
+        if ds_type == "outputs":
+            license_value = ds.get("license")
+            if license_value is not None and not is_valid_spdx(str(license_value)):
+                errors.append(
+                    f"{prefix}: 'license' is not a recognized SPDX identifier or LicenseRef-* form: {license_value!r}"
+                )
+
+        # SPDX validation on input source license
+        if ds_type == "inputs":
+            source = ds.get("source")
+            if isinstance(source, dict):
+                source_license = source.get("license")
+                if source_license is not None and not is_valid_spdx(str(source_license)):
+                    errors.append(
+                        f"{prefix}.source: 'license' is not a recognized SPDX identifier or LicenseRef-* form: {source_license!r}"
+                    )
+
     # Validate inputs
     inputs = data.get("inputs", [])
     if not isinstance(inputs, list):
@@ -731,6 +753,28 @@ def dataset_validate(
                 errors.append(f"outputs[{i}]: must be an object")
             else:
                 validate_dataset_entry(ds, "outputs", i)
+
+    # SPDX validation on package licenses (only when not filtering by slug)
+    if not datasets_to_validate:
+        from .licenses import is_valid_spdx as _is_valid_spdx
+
+        package_block = data.get("package")
+        if isinstance(package_block, dict):
+            pkg_license = package_block.get("license")
+            if pkg_license is not None and not _is_valid_spdx(str(pkg_license)):
+                errors.append(
+                    f"package: 'license' is not a recognized SPDX identifier or LicenseRef-* form: {pkg_license!r}"
+                )
+        packages_block = data.get("packages")
+        if isinstance(packages_block, list):
+            for i, pkg in enumerate(packages_block):
+                if not isinstance(pkg, dict):
+                    continue
+                pkg_license = pkg.get("license")
+                if pkg_license is not None and not _is_valid_spdx(str(pkg_license)):
+                    errors.append(
+                        f"packages[{i}]: 'license' is not a recognized SPDX identifier or LicenseRef-* form: {pkg_license!r}"
+                    )
 
     # Check if requested datasets were found
     if datasets_to_validate:
@@ -1825,6 +1869,153 @@ def lineage_attribution(
         sys.exit(1)
 
     typer.echo(statement)
+
+
+# =============================================================================
+# License commands
+# =============================================================================
+
+
+def _resolve_license_project_path(datasets_file: str) -> tuple[Path, str]:
+    """Resolve a datasets.yaml argument to (project_path, file_name)."""
+    yaml_path = Path(datasets_file).resolve()
+    if yaml_path.is_dir():
+        project_path = yaml_path
+        file_name = "datasets.yaml"
+    else:
+        project_path = yaml_path.parent
+        file_name = yaml_path.name
+    return project_path, file_name
+
+
+@license_app.command("list")
+def license_list(
+    datasets_file: str = typer.Option("datasets.yaml", "-f", "--file", help="Path to datasets.yaml"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON instead of text."),
+) -> None:
+    """List every license used in the project, with the datasets that declare it."""
+    import json as _json
+
+    from .datasets import DatasetsManager
+
+    project_path, file_name = _resolve_license_project_path(datasets_file)
+    if not (project_path / file_name).exists():
+        typer.echo(f"Error: {datasets_file} not found", err=True)
+        sys.exit(1)
+
+    manager = DatasetsManager(project_path, datasets_file=file_name)
+    usage: dict[str, list[str]] = {}
+
+    for ds in manager.get_all_inputs():
+        if ds.source is not None and ds.source.license:
+            usage.setdefault(ds.source.license, []).append(f"input:{ds.slug}")
+    for ds in manager.get_all_outputs():
+        eff = manager.effective_license_for(ds.slug)
+        if eff:
+            usage.setdefault(eff, []).append(f"output:{ds.slug}")
+
+    if json_output:
+        payload = {license_id: sorted(refs) for license_id, refs in sorted(usage.items())}
+        typer.echo(_json.dumps(payload, indent=2))
+        return
+
+    if not usage:
+        typer.echo("No licenses declared in this project.")
+        return
+
+    for license_id in sorted(usage):
+        typer.echo(license_id)
+        for ref in sorted(usage[license_id]):
+            typer.echo(f"  - {ref}")
+
+
+@license_app.command("check")
+def license_check(
+    slug: Optional[str] = typer.Argument(None, help="Output dataset slug to check (omit to check all outputs)."),
+    datasets_file: str = typer.Option("datasets.yaml", "-f", "--file", help="Path to datasets.yaml"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON instead of text."),
+) -> None:
+    """Check license compatibility for one output (or every output) against its sources."""
+    import json as _json
+
+    from .datasets import DatasetsManager
+    from .licenses import check_compatibility
+
+    project_path, file_name = _resolve_license_project_path(datasets_file)
+    if not (project_path / file_name).exists():
+        typer.echo(f"Error: {datasets_file} not found", err=True)
+        sys.exit(1)
+
+    manager = DatasetsManager(project_path, datasets_file=file_name)
+
+    if slug is not None:
+        single = manager.find_dataset_by_slug(slug, "output")
+        if single is None:
+            typer.echo(f"Error: output dataset '{slug}' not found", err=True)
+            sys.exit(1)
+        target_outputs = [single]
+    else:
+        target_outputs = list(manager.get_all_outputs())
+
+    reports: list[dict[str, Any]] = []
+    any_conflict = False
+
+    for output in target_outputs:
+        target_license = manager.effective_license_for(output.slug)
+        # Collect direct source licenses from the output's wasDerivedFrom refs.
+        source_licenses: list[str] = []
+        sources_seen: list[str] = []
+        for ref in output.was_derived_from or []:
+            ds = manager.find_dataset_by_slug(ref.slug)
+            if ds is None:
+                continue
+            sources_seen.append(ref.slug)
+            if ds.dataset_type == "input" and ds.source is not None and ds.source.license:
+                source_licenses.append(ds.source.license)
+            elif ds.dataset_type == "output":
+                eff = manager.effective_license_for(ref.slug)
+                if eff:
+                    source_licenses.append(eff)
+
+        report: dict[str, Any] = {
+            "slug": output.slug,
+            "target_license": target_license,
+            "sources": sources_seen,
+            "source_licenses": source_licenses,
+        }
+
+        if not source_licenses or target_license is None:
+            report["status"] = "skipped"
+            report["reason"] = "no source licenses to check" if not source_licenses else "no target license declared"
+            reports.append(report)
+            continue
+
+        result = check_compatibility(source_licenses, target_license)
+        report["compatible"] = result.compatible
+        report["conflicts"] = result.conflicts
+        report["suggestions"] = result.suggestions
+        report["unknown_sources"] = result.unknown_sources
+        report["unknown_target"] = result.unknown_target
+        report["status"] = "compatible" if result.compatible else "conflict"
+        if not result.compatible:
+            any_conflict = True
+        reports.append(report)
+
+    if json_output:
+        typer.echo(_json.dumps({"reports": reports}, indent=2))
+    else:
+        for r in reports:
+            label = r["target_license"] or "(none)"
+            typer.echo(f"{r['slug']}: target={label} status={r['status']}")
+            if r["status"] == "conflict":
+                for c in r.get("conflicts", []):
+                    typer.echo(f"  conflict: {c}")
+                if r.get("suggestions"):
+                    typer.echo(f"  suggestions: {', '.join(r['suggestions'])}")
+            elif r["status"] == "skipped":
+                typer.echo(f"  skipped: {r['reason']}")
+
+    sys.exit(1 if any_conflict else 0)
 
 
 if __name__ == "__main__":

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -229,6 +229,61 @@ class DataFrame:
             datasets_file=self._datasets_file,
         )
 
+    def _enforce_license_compatibility(
+        self,
+        manager: DatasetsManager,
+        dataset_slug: str,
+        target_license: Optional[str],
+    ) -> None:
+        """Check the proposed write against source licenses.
+
+        Raises :class:`LicenseCompatibilityError` if the target license is
+        incompatible with any source license collected from the current session.
+        Warns if there are source licenses to check but no target license
+        could be determined.
+        """
+        from .licenses import LicenseCompatibilityError, check_compatibility
+        from .session import get_session
+
+        source_slugs = get_session().current_source_slugs()
+        source_licenses: list[str] = []
+        for slug in source_slugs:
+            ds = manager.find_dataset_by_slug(slug)
+            if ds is None:
+                continue
+            if ds.dataset_type == "input" and ds.source is not None and ds.source.license:
+                source_licenses.append(ds.source.license)
+            elif ds.dataset_type == "output":
+                eff = manager.effective_license_for(slug)
+                if eff:
+                    source_licenses.append(eff)
+
+        if not source_licenses:
+            return
+
+        if target_license is None:
+            warnings.warn(
+                f"Output '{dataset_slug}' has source datasets with declared licenses "
+                f"({source_licenses}) but no target license is declared "
+                f"(set 'license:' on the dataset, on a package, or pass license= to the writer). "
+                f"Skipping license compatibility check.",
+                UserWarning,
+                stacklevel=3,
+            )
+            return
+
+        result = check_compatibility(source_licenses, target_license)
+        if result.compatible:
+            return
+
+        message_lines = [f"License compatibility check failed for output '{dataset_slug}' (target: {target_license})."]
+        message_lines.extend(f"  - {c}" for c in result.conflicts)
+        if result.suggestions:
+            message_lines.append("Suggested compatible target licenses: " + ", ".join(result.suggestions))
+        if result.unknown_sources:
+            message_lines.append("Unknown source licenses (not validated): " + ", ".join(result.unknown_sources))
+        raise LicenseCompatibilityError("\n".join(message_lines))
+
     @classmethod
     def read_dataset(
         cls,
@@ -612,6 +667,8 @@ class DataFrame:
         publish: bool = False,
         transformation_params: Optional[dict] = None,
         track: bool = True,
+        license: Optional[str] = None,
+        check_license: bool = True,
         **kwargs: Any,
     ) -> None:
         """
@@ -627,11 +684,21 @@ class DataFrame:
             publish: Reserved for future use (publishing to data catalog).
             track: If False, write the CSV directly without lineage tracking
                 or dataset registration. Useful for tests and exploratory work.
+            license: SPDX license identifier for the output. Persisted to
+                datasets.yaml and used for compatibility checking against
+                source licenses. Falls back to the dataset's existing license
+                or ``package.license`` when omitted.
+            check_license: If True (default), raise
+                :class:`~sunstone.licenses.LicenseCompatibilityError` when
+                the target license is incompatible with any source license
+                in the current session lineage.
             **kwargs: Additional arguments passed to pandas.to_csv.
 
         Raises:
             StrictModeError: In strict mode, if dataset not registered.
             ValueError: In relaxed mode, if slug/name not provided for new dataset.
+            LicenseCompatibilityError: If ``check_license`` is True and the
+                target license conflicts with a source license.
         """
         # Filter out any Sunstone-specific kwargs that might have slipped through
         pandas_kwargs = {k: v for k, v in kwargs.items() if k not in self._SUNSTONE_KWARGS}
@@ -689,7 +756,15 @@ class DataFrame:
                     description=self.metadata.description,
                     rdf_prefixes=self.metadata.rdf_prefixes,
                     custom_properties=self.metadata.custom_properties,
+                    license=license,
                 )
+        elif license is not None and dataset.license != license:
+            # Persist explicit override on a pre-registered dataset
+            dataset = manager.update_output_dataset(slug=dataset.slug, license=license)
+
+        if check_license:
+            target_license = license or manager.effective_license_for(dataset.slug)
+            self._enforce_license_compatibility(manager, dataset.slug, target_license)
 
         # Write the data
         absolute_path = manager.get_absolute_path(dataset.location)
@@ -739,6 +814,8 @@ class DataFrame:
         publish: bool = False,
         transformation_params: Optional[dict] = None,
         track: bool = True,
+        license: Optional[str] = None,
+        check_license: bool = True,
         **kwargs: Any,
     ) -> None:
         """
@@ -754,11 +831,21 @@ class DataFrame:
             publish: Reserved for future use (publishing to data catalog).
             track: If False, write the Parquet directly without lineage tracking
                 or dataset registration. Useful for tests and exploratory work.
+            license: SPDX license identifier for the output. Persisted to
+                datasets.yaml and used for compatibility checking against
+                source licenses. Falls back to the dataset's existing license
+                or ``package.license`` when omitted.
+            check_license: If True (default), raise
+                :class:`~sunstone.licenses.LicenseCompatibilityError` when
+                the target license is incompatible with any source license
+                in the current session lineage.
             **kwargs: Additional arguments passed to pandas.to_parquet.
 
         Raises:
             StrictModeError: In strict mode, if dataset not registered.
             ValueError: In relaxed mode, if slug/name not provided for new dataset.
+            LicenseCompatibilityError: If ``check_license`` is True and the
+                target license conflicts with a source license.
         """
         # Filter out any Sunstone-specific kwargs that might have slipped through
         pandas_kwargs = {k: v for k, v in kwargs.items() if k not in self._SUNSTONE_KWARGS}
@@ -816,7 +903,15 @@ class DataFrame:
                     description=self.metadata.description,
                     rdf_prefixes=self.metadata.rdf_prefixes,
                     custom_properties=self.metadata.custom_properties,
+                    license=license,
                 )
+        elif license is not None and dataset.license != license:
+            # Persist explicit override on a pre-registered dataset
+            dataset = manager.update_output_dataset(slug=dataset.slug, license=license)
+
+        if check_license:
+            target_license = license or manager.effective_license_for(dataset.slug)
+            self._enforce_license_compatibility(manager, dataset.slug, target_license)
 
         # Write the data
         absolute_path = manager.get_absolute_path(dataset.location)

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -653,6 +653,7 @@ class DatasetsManager:
             resource_type=dataset_data.get("type"),
             fields=fields,
             source=source,
+            license=dataset_data.get("license"),
             strict=dataset_data.get("strict", False),
             dataset_type=dataset_type,
             rdf_prefixes=rdf_prefixes,
@@ -893,6 +894,27 @@ class DatasetsManager:
             datasets=list(datasets),
         )
 
+    def effective_license_for(self, slug: str) -> Optional[str]:
+        """Return the effective license identifier for an output dataset.
+
+        Resolution order: explicit ``license`` on the dataset, then the
+        license of any package whose ``datasets`` list contains the slug
+        (or the singular ``package:`` if no explicit ``packages:`` are defined).
+        Returns ``None`` when no license is declared anywhere.
+        """
+        ds = self.find_dataset_by_slug(slug, "output")
+        if ds is not None and ds.license:
+            return ds.license
+        try:
+            packages = self.get_packages()
+        except ValueError:
+            return None
+        for pkg in packages:
+            covers = pkg.datasets is None or slug in pkg.datasets
+            if covers and pkg.metadata.license:
+                return pkg.metadata.license
+        return None
+
     def get_top_level_custom_properties(self) -> Dict[str, Any]:
         """
         Get top-level custom properties from datasets.yaml.
@@ -926,6 +948,7 @@ class DatasetsManager:
         description: Optional[str] = None,
         rdf_prefixes: Optional[Dict[str, str]] = None,
         custom_properties: Optional[Dict[str, Any]] = None,
+        license: Optional[str] = None,
     ) -> DatasetMetadata:
         """
         Add a new output dataset to datasets.yaml.
@@ -938,6 +961,7 @@ class DatasetsManager:
             description: Optional dataset description.
             rdf_prefixes: Optional RDF namespace prefix map.
             custom_properties: Optional custom/RDF properties to include.
+            license: Optional SPDX license identifier (overrides package.license).
 
         Returns:
             The newly created DatasetMetadata.
@@ -955,6 +979,8 @@ class DatasetsManager:
         }
         if description is not None:
             dataset_data["description"] = description
+        if license is not None:
+            dataset_data["license"] = license
         if rdf_prefixes is not None:
             dataset_data["rdfPrefixes"] = rdf_prefixes
         if custom_properties is not None:
@@ -972,6 +998,7 @@ class DatasetsManager:
         description: Optional[str] = None,
         rdf_prefixes: Optional[Dict[str, str]] = None,
         custom_properties: Optional[Dict[str, Any]] = None,
+        license: Optional[str] = None,
     ) -> DatasetMetadata:
         """
         Update an existing output dataset.
@@ -983,6 +1010,7 @@ class DatasetsManager:
             description: Optional dataset description.
             rdf_prefixes: Optional RDF namespace prefix map.
             custom_properties: Optional custom/RDF properties to include.
+            license: Optional SPDX license identifier (overrides package.license).
 
         Returns:
             The updated DatasetMetadata.
@@ -990,7 +1018,7 @@ class DatasetsManager:
         Raises:
             DatasetNotFoundError: If the dataset doesn't exist.
         """
-        for i, dataset_data in enumerate(self._data["outputs"]):
+        for dataset_data in self._data["outputs"]:
             if dataset_data["slug"] == slug:
                 if fields is not None:
                     dataset_data["fields"] = [_field_schema_to_dict(field) for field in fields]
@@ -998,6 +1026,8 @@ class DatasetsManager:
                     dataset_data["location"] = location
                 if description is not None:
                     dataset_data["description"] = description
+                if license is not None:
+                    dataset_data["license"] = license
                 if rdf_prefixes is not None:
                     dataset_data["rdfPrefixes"] = rdf_prefixes
                 if custom_properties is not None:

--- a/src/sunstone/licenses.py
+++ b/src/sunstone/licenses.py
@@ -1,0 +1,344 @@
+"""
+License tracking with SPDX validation and compatibility enforcement.
+
+Provides an embedded list of common research-data licenses, a property
+model (attribution / ShareAlike / NonCommercial / public-domain), a
+rules-based compatibility engine, and a ``LicenseCompatibilityError``
+that surfaces actionable conflict descriptions at write time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from .exceptions import SunstoneError
+
+
+class LicenseCompatibilityError(SunstoneError):
+    """Raised when a target license is incompatible with one or more source licenses."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class LicenseProperties:
+    """Properties of a license that drive compatibility rules.
+
+    These properties are sufficient to encode the compatibility behavior of
+    every license in the embedded registry. A license missing from the
+    registry has unknown properties and is treated conservatively.
+    """
+
+    spdx: str
+    """SPDX identifier (e.g., 'CC-BY-4.0')."""
+
+    name: str
+    """Human-readable license name."""
+
+    public_domain: bool = False
+    """True for CC0, PDDL, and similar — compatible with everything."""
+
+    attribution: bool = False
+    """True if downstream users must credit the source (CC-BY family, ODC-By, ODbL)."""
+
+    share_alike: bool = False
+    """True if derivatives must use the same license (CC-BY-SA, ODbL, CC-BY-NC-SA)."""
+
+    non_commercial: bool = False
+    """True if commercial use is forbidden (CC-BY-NC, CC-BY-NC-SA, CC-BY-NC-3.0-IGO)."""
+
+    family: Optional[str] = None
+    """Identifier for the ShareAlike family. Only same-family SA licenses are mutually compatible."""
+
+    aliases: tuple[str, ...] = ()
+    """Alternate identifiers (case-insensitive) that map to this license."""
+
+
+# ---------------------------------------------------------------------------
+# Embedded license registry
+#
+# This is intentionally focused on the licenses the issue mentions —
+# CC, ODC, CC0/PDDL, plus a couple of LicenseRef- entries. New licenses
+# should be added by appending to this list.
+# ---------------------------------------------------------------------------
+
+_REGISTRY_ENTRIES: tuple[LicenseProperties, ...] = (
+    # Public-domain dedications
+    LicenseProperties(
+        spdx="CC0-1.0",
+        name="Creative Commons Zero v1.0 Universal",
+        public_domain=True,
+    ),
+    LicenseProperties(
+        spdx="PDDL-1.0",
+        name="Open Data Commons Public Domain Dedication and Licence 1.0",
+        public_domain=True,
+    ),
+    LicenseProperties(
+        spdx="LicenseRef-US-PD",
+        name="United States Public Domain (work of US Federal Government)",
+        public_domain=True,
+    ),
+    # Attribution-only
+    LicenseProperties(
+        spdx="CC-BY-4.0",
+        name="Creative Commons Attribution 4.0 International",
+        attribution=True,
+    ),
+    LicenseProperties(
+        spdx="CC-BY-3.0",
+        name="Creative Commons Attribution 3.0 Unported",
+        attribution=True,
+    ),
+    LicenseProperties(
+        spdx="ODC-By-1.0",
+        name="Open Data Commons Attribution License 1.0",
+        attribution=True,
+    ),
+    LicenseProperties(
+        spdx="LicenseRef-OGL-3.0",
+        name="UK Open Government Licence v3.0",
+        attribution=True,
+    ),
+    # Attribution + ShareAlike
+    LicenseProperties(
+        spdx="CC-BY-SA-4.0",
+        name="Creative Commons Attribution-ShareAlike 4.0 International",
+        attribution=True,
+        share_alike=True,
+        family="cc-by-sa-4",
+    ),
+    LicenseProperties(
+        spdx="CC-BY-SA-3.0",
+        name="Creative Commons Attribution-ShareAlike 3.0 Unported",
+        attribution=True,
+        share_alike=True,
+        family="cc-by-sa-3",
+    ),
+    LicenseProperties(
+        spdx="ODbL-1.0",
+        name="Open Data Commons Open Database License 1.0",
+        attribution=True,
+        share_alike=True,
+        family="odbl-1",
+    ),
+    # Attribution + NonCommercial
+    LicenseProperties(
+        spdx="CC-BY-NC-4.0",
+        name="Creative Commons Attribution-NonCommercial 4.0 International",
+        attribution=True,
+        non_commercial=True,
+    ),
+    LicenseProperties(
+        spdx="CC-BY-NC-3.0-IGO",
+        name="Creative Commons Attribution-NonCommercial 3.0 IGO",
+        attribution=True,
+        non_commercial=True,
+    ),
+    # Attribution + NonCommercial + ShareAlike
+    LicenseProperties(
+        spdx="CC-BY-NC-SA-4.0",
+        name="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International",
+        attribution=True,
+        share_alike=True,
+        non_commercial=True,
+        family="cc-by-nc-sa-4",
+    ),
+    LicenseProperties(
+        spdx="CC-BY-NC-SA-3.0",
+        name="Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported",
+        attribution=True,
+        share_alike=True,
+        non_commercial=True,
+        family="cc-by-nc-sa-3",
+    ),
+)
+
+
+_BY_LOWER: dict[str, LicenseProperties] = {}
+for _entry in _REGISTRY_ENTRIES:
+    _BY_LOWER[_entry.spdx.lower()] = _entry
+    for _alias in _entry.aliases:
+        _BY_LOWER[_alias.lower()] = _entry
+
+
+def known_licenses() -> list[LicenseProperties]:
+    """Return all licenses in the embedded registry, sorted by SPDX identifier."""
+    return sorted(_REGISTRY_ENTRIES, key=lambda e: e.spdx.lower())
+
+
+def is_valid_spdx(identifier: str) -> bool:
+    """True if *identifier* is a known SPDX id, a known LicenseRef-, or any LicenseRef-* form.
+
+    LicenseRef-* identifiers are accepted as user-defined per the SPDX spec —
+    they cannot be used in property-based compatibility rules unless they
+    appear in the embedded registry.
+    """
+    if not identifier:
+        return False
+    if identifier.lower() in _BY_LOWER:
+        return True
+    return identifier.startswith("LicenseRef-") and len(identifier) > len("LicenseRef-")
+
+
+def get_properties(identifier: str) -> Optional[LicenseProperties]:
+    """Return :class:`LicenseProperties` for *identifier*, or ``None`` if unknown.
+
+    Returns ``None`` for valid LicenseRef-* identifiers that are not in the
+    embedded registry — callers must decide how to treat unknown licenses.
+    """
+    return _BY_LOWER.get(identifier.lower()) if identifier else None
+
+
+# ---------------------------------------------------------------------------
+# Compatibility checking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LicenseCompatibilityResult:
+    """Outcome of a compatibility check between source licenses and a target license."""
+
+    target: str
+    """The proposed target license identifier."""
+
+    sources: list[str] = field(default_factory=list)
+    """Source license identifiers that were considered (deduplicated)."""
+
+    compatible: bool = True
+    """True if the target license satisfies every source's downstream requirements."""
+
+    conflicts: list[str] = field(default_factory=list)
+    """Human-readable conflict descriptions; empty when ``compatible`` is True."""
+
+    suggestions: list[str] = field(default_factory=list)
+    """Suggested target licenses that would resolve the conflicts (best-effort)."""
+
+    unknown_sources: list[str] = field(default_factory=list)
+    """Source identifiers not present in the registry (e.g., user-defined LicenseRef-*)."""
+
+    unknown_target: bool = False
+    """True if the target identifier is not in the registry."""
+
+
+def _dedupe_preserving_order(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        key = item.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(item)
+    return out
+
+
+def _check_pair(source: LicenseProperties, target: LicenseProperties) -> Optional[str]:
+    """Return a conflict description if *target* fails to satisfy *source*; else ``None``."""
+    if source.public_domain:
+        return None
+    if source.share_alike:
+        if not target.share_alike or source.family != target.family:
+            return (
+                f"{source.spdx} is ShareAlike: derivatives must be released under "
+                f"{source.spdx} (or a same-family ShareAlike license), not {target.spdx}"
+            )
+    if source.non_commercial and not target.non_commercial:
+        return f"{source.spdx} is NonCommercial: derivatives must also be NonCommercial, not {target.spdx}"
+    if source.attribution and not (target.attribution or target.share_alike):
+        return (
+            f"{source.spdx} requires attribution: derivatives must use a license "
+            f"that preserves attribution, not {target.spdx}"
+        )
+    return None
+
+
+def _suggest_targets(sources: list[LicenseProperties]) -> list[str]:
+    """Suggest target licenses that could satisfy every known source."""
+    candidates: list[str] = []
+    for entry in known_licenses():
+        if all(_check_pair(src, entry) is None for src in sources):
+            candidates.append(entry.spdx)
+    return candidates
+
+
+def check_compatibility(
+    source_licenses: Iterable[str],
+    target_license: str,
+) -> LicenseCompatibilityResult:
+    """Check whether *target_license* is compatible with every license in *source_licenses*.
+
+    Unknown licenses (valid LicenseRef-* identifiers not in the registry, or
+    unrecognized identifiers) are reported on the result but do not raise. The
+    caller is responsible for deciding whether to treat unknowns as a failure.
+    """
+    deduped_sources = _dedupe_preserving_order(source_licenses)
+    result = LicenseCompatibilityResult(target=target_license, sources=deduped_sources)
+
+    target_props = get_properties(target_license)
+    if target_props is None:
+        result.unknown_target = True
+
+    known_source_props: list[LicenseProperties] = []
+    for source_id in deduped_sources:
+        props = get_properties(source_id)
+        if props is None:
+            result.unknown_sources.append(source_id)
+            continue
+        known_source_props.append(props)
+
+    if target_props is None:
+        # Without target properties we cannot apply the rules engine. Surface as a
+        # conflict so callers don't silently pass unknown targets.
+        if known_source_props:
+            result.compatible = False
+            result.conflicts.append(
+                f"Target license {target_license!r} is not in the embedded registry; "
+                f"compatibility cannot be verified against known sources "
+                f"{[p.spdx for p in known_source_props]!r}."
+            )
+        return result
+
+    for src_props in known_source_props:
+        conflict = _check_pair(src_props, target_props)
+        if conflict:
+            result.compatible = False
+            result.conflicts.append(conflict)
+
+    if not result.compatible:
+        result.suggestions = _suggest_targets(known_source_props)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Most-restrictive license picker
+# ---------------------------------------------------------------------------
+
+
+def _restrictiveness(props: LicenseProperties) -> tuple[int, int, int, int, str]:
+    """Sort key — higher tuple = more restrictive."""
+    return (
+        1 if props.share_alike else 0,
+        1 if props.non_commercial else 0,
+        1 if props.attribution else 0,
+        0 if props.public_domain else 1,
+        props.spdx.lower(),
+    )
+
+
+def get_most_restrictive_license(licenses: Iterable[str]) -> Optional[str]:
+    """Return the SPDX identifier of the most restrictive license in *licenses*.
+
+    Returns ``None`` if *licenses* is empty or contains no known licenses.
+    Useful for auto-suggesting an output license for a derived dataset.
+    """
+    known: list[LicenseProperties] = []
+    for ident in licenses:
+        props = get_properties(ident)
+        if props is not None:
+            known.append(props)
+    if not known:
+        return None
+    return max(known, key=_restrictiveness).spdx

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -354,6 +354,9 @@ class DatasetMetadata:
     source: Optional[Source] = None
     """Source attribution (for input datasets)."""
 
+    license: Optional[str] = None
+    """SPDX license identifier for output datasets. Falls back to package.license when unset."""
+
     strict: bool = False
     """Whether strict mode is enabled (lineage cannot be modified)."""
 

--- a/src/sunstone/session.py
+++ b/src/sunstone/session.py
@@ -150,6 +150,21 @@ class LineageSession:
             transformation_params=transformation_params,
         )
 
+    def current_source_slugs(self) -> list[str]:
+        """Return slugs of datasets read so far in this session, in order, deduplicated.
+
+        Useful for inspecting upcoming lineage (e.g., for write-time license checks)
+        without consuming the accumulated reads.
+        """
+        seen: set[str] = set()
+        out: list[str] = []
+        for r in self._reads:
+            if r.slug in seen:
+                continue
+            seen.add(r.slug)
+            out.append(r.slug)
+        return out
+
     def flush_activity(
         self,
         transformation_params: Optional[dict] = None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1420,7 +1420,7 @@ class TestBuildDatapackageWithPackageMetadata:
         assert "Processed data" in dp["description"]
         assert dp["version"] == "1.0.0"
         assert dp["keywords"] == ["united-nations", "member-states", "international-organizations"]
-        assert dp["license"] == "CC-BY-4.0"
+        assert dp["license"] == "CC-BY-NC-3.0-IGO"
         assert dp["contributors"] == [{"title": "Sunstone Institute", "roles": ["creator", "publisher"]}]
 
     def test_build_without_package_metadata(self, runner: CliRunner, tmp_path: Path) -> None:
@@ -1470,7 +1470,7 @@ class TestBuildDatapackageWithPackageMetadata:
             dp = json.loads(handler.uploaded_text[dp_path])
             assert dp["title"] == "UN Member States Dataset"
             assert dp["version"] == "1.0.0"
-            assert dp["license"] == "CC-BY-4.0"
+            assert dp["license"] == "CC-BY-NC-3.0-IGO"
             assert len(dp["contributors"]) == 1
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -202,7 +202,7 @@ class TestPackageMetadata:
         assert package is not None
         assert package.title == "UN Member States Dataset"
         assert package.version == "1.0.0"
-        assert package.license == "CC-BY-4.0"
+        assert package.license == "CC-BY-NC-3.0-IGO"
 
     def test_package_description(self, project_path: Path) -> None:
         """Test that package description is parsed correctly."""

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -1,0 +1,523 @@
+"""
+Tests for the license module: SPDX validation, compatibility rules, write-time
+enforcement, and the ``sunstone license`` CLI subcommands.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from sunstone import DataFrame, set_project_path
+from sunstone.cli import app
+from sunstone.licenses import (
+    LicenseCompatibilityError,
+    check_compatibility,
+    get_most_restrictive_license,
+    get_properties,
+    is_valid_spdx,
+    known_licenses,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry / SPDX validation
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    """Tests for the embedded license registry."""
+
+    def test_known_licenses_includes_required_research_data_set(self):
+        spdx = {entry.spdx for entry in known_licenses()}
+        for required in (
+            "CC0-1.0",
+            "CC-BY-4.0",
+            "CC-BY-SA-4.0",
+            "CC-BY-NC-4.0",
+            "CC-BY-NC-SA-4.0",
+            "PDDL-1.0",
+            "ODC-By-1.0",
+            "ODbL-1.0",
+            "CC-BY-NC-3.0-IGO",
+            "LicenseRef-US-PD",
+            "LicenseRef-OGL-3.0",
+        ):
+            assert required in spdx
+
+    def test_get_properties_known(self):
+        cc_by_sa = get_properties("CC-BY-SA-4.0")
+        assert cc_by_sa is not None
+        assert cc_by_sa.attribution
+        assert cc_by_sa.share_alike
+        assert not cc_by_sa.non_commercial
+        assert cc_by_sa.family == "cc-by-sa-4"
+
+    def test_get_properties_unknown_returns_none(self):
+        assert get_properties("LicenseRef-Custom-Foo") is None
+        assert get_properties("definitely-not-a-license") is None
+
+    def test_get_properties_case_insensitive(self):
+        assert get_properties("cc-by-4.0") is get_properties("CC-BY-4.0")
+
+
+class TestIsValidSpdx:
+    """Tests for is_valid_spdx()."""
+
+    def test_known_identifier(self):
+        assert is_valid_spdx("CC-BY-4.0")
+        assert is_valid_spdx("CC0-1.0")
+
+    def test_known_identifier_case_insensitive(self):
+        assert is_valid_spdx("cc-by-4.0")
+
+    def test_user_defined_licenseref_accepted(self):
+        assert is_valid_spdx("LicenseRef-Custom-Org-1.0")
+
+    def test_bare_licenseref_rejected(self):
+        assert not is_valid_spdx("LicenseRef-")
+
+    def test_unknown_rejected(self):
+        assert not is_valid_spdx("GPL-99.0")
+
+    def test_empty_rejected(self):
+        assert not is_valid_spdx("")
+
+
+# ---------------------------------------------------------------------------
+# Compatibility rules
+# ---------------------------------------------------------------------------
+
+
+class TestCompatibility:
+    """Tests for check_compatibility()."""
+
+    def test_public_domain_source_compatible_with_anything(self):
+        result = check_compatibility(["CC0-1.0"], "CC-BY-NC-SA-4.0")
+        assert result.compatible
+
+    def test_attribution_only_to_attribution_only(self):
+        result = check_compatibility(["CC-BY-4.0"], "CC-BY-4.0")
+        assert result.compatible
+
+    def test_share_alike_to_same_family_ok(self):
+        result = check_compatibility(["CC-BY-SA-4.0"], "CC-BY-SA-4.0")
+        assert result.compatible
+
+    def test_share_alike_to_different_family_fails(self):
+        result = check_compatibility(["CC-BY-SA-4.0"], "CC-BY-4.0")
+        assert not result.compatible
+        assert any("ShareAlike" in c for c in result.conflicts)
+        assert "CC-BY-SA-4.0" in result.suggestions
+
+    def test_share_alike_to_different_share_alike_family_fails(self):
+        # CC-BY-SA-4.0 and ODbL-1.0 are different SA families.
+        result = check_compatibility(["CC-BY-SA-4.0"], "ODbL-1.0")
+        assert not result.compatible
+
+    def test_non_commercial_must_propagate(self):
+        result = check_compatibility(["CC-BY-NC-4.0"], "CC-BY-4.0")
+        assert not result.compatible
+        assert any("NonCommercial" in c for c in result.conflicts)
+
+    def test_non_commercial_satisfied_by_nc_target(self):
+        result = check_compatibility(["CC-BY-NC-4.0"], "CC-BY-NC-4.0")
+        assert result.compatible
+
+    def test_share_alike_and_non_commercial_combined_have_no_compatible_target(self):
+        # CC-BY-SA-4.0 + CC-BY-NC-4.0 → SA forces same family (CC-BY-SA-4.0),
+        # NC forces NC. Neither CC-BY-SA-4.0 (no NC) nor CC-BY-NC-SA-4.0
+        # (different family) satisfies both.
+        result = check_compatibility(["CC-BY-SA-4.0", "CC-BY-NC-4.0"], "CC-BY-NC-SA-4.0")
+        assert not result.compatible
+
+    def test_unknown_target_marked_and_blocked(self):
+        result = check_compatibility(["CC-BY-4.0"], "LicenseRef-Custom-Org")
+        assert result.unknown_target
+        assert not result.compatible
+
+    def test_unknown_source_recorded(self):
+        result = check_compatibility(["LicenseRef-Custom-Org"], "CC-BY-4.0")
+        assert "LicenseRef-Custom-Org" in result.unknown_sources
+        # No known sources to check, so target alone makes it compatible.
+        assert result.compatible
+
+    def test_dedupe_sources(self):
+        result = check_compatibility(["CC-BY-4.0", "CC-BY-4.0"], "CC-BY-4.0")
+        assert result.sources == ["CC-BY-4.0"]
+
+    def test_suggestions_contain_only_compatible_targets(self):
+        result = check_compatibility(["CC-BY-NC-4.0"], "CC-BY-4.0")
+        assert not result.compatible
+        assert all(get_properties(s).non_commercial for s in result.suggestions)
+
+
+class TestMostRestrictive:
+    """Tests for get_most_restrictive_license()."""
+
+    def test_picks_share_alike_over_attribution(self):
+        result = get_most_restrictive_license(["CC-BY-4.0", "CC-BY-SA-4.0"])
+        assert result == "CC-BY-SA-4.0"
+
+    def test_picks_nc_sa_over_sa(self):
+        result = get_most_restrictive_license(["CC-BY-SA-4.0", "CC-BY-NC-SA-4.0"])
+        assert result == "CC-BY-NC-SA-4.0"
+
+    def test_returns_none_for_empty(self):
+        assert get_most_restrictive_license([]) is None
+
+    def test_returns_none_for_unknown_only(self):
+        assert get_most_restrictive_license(["LicenseRef-Custom-Foo"]) is None
+
+    def test_skips_unknown_keeps_known(self):
+        result = get_most_restrictive_license(["LicenseRef-Custom-Foo", "CC-BY-4.0"])
+        assert result == "CC-BY-4.0"
+
+
+# ---------------------------------------------------------------------------
+# Write-time enforcement on DataFrame
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_with_inputs(tmp_path: Path):
+    """Project layout with one input file, ready for output writes."""
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "outputs").mkdir()
+    (tmp_path / "inputs" / "raw.csv").write_text("a,b\n1,2\n3,4\n")
+    return tmp_path
+
+
+def _write_yaml(path: Path, body: str) -> None:
+    (path / "datasets.yaml").write_text(textwrap.dedent(body).strip() + "\n")
+
+
+class TestWriteTimeEnforcement:
+    """Tests that DataFrame.to_csv enforces license compatibility against sources."""
+
+    def test_compatible_write_succeeds(self, project_with_inputs: Path):
+        _write_yaml(
+            project_with_inputs,
+            """
+            package:
+              license: CC-BY-4.0
+            inputs:
+              - name: Raw
+                slug: raw
+                location: inputs/raw.csv
+                source:
+                  name: Raw
+                  attributedTo: Org
+                  license: CC-BY-4.0
+                  acquiredAt: "2026-01-01"
+                  acquisitionMethod: manual-download
+                  location:
+                    data: https://example.org/raw.csv
+            """,
+        )
+        set_project_path(project_with_inputs)
+        from sunstone import pandas as spd
+
+        df = spd.read_csv("inputs/raw.csv")
+        df.to_csv("outputs/out.csv", slug="out", name="Out", index=False)
+        assert (project_with_inputs / "outputs" / "out.csv").exists()
+
+    def test_share_alike_source_blocks_attribution_target(self, project_with_inputs: Path):
+        _write_yaml(
+            project_with_inputs,
+            """
+            package:
+              license: CC-BY-4.0
+            inputs:
+              - name: Raw
+                slug: raw
+                location: inputs/raw.csv
+                source:
+                  name: Raw
+                  attributedTo: Org
+                  license: CC-BY-SA-4.0
+                  acquiredAt: "2026-01-01"
+                  acquisitionMethod: manual-download
+                  location:
+                    data: https://example.org/raw.csv
+            """,
+        )
+        set_project_path(project_with_inputs)
+        from sunstone import pandas as spd
+
+        df = spd.read_csv("inputs/raw.csv")
+        with pytest.raises(LicenseCompatibilityError) as excinfo:
+            df.to_csv("outputs/out.csv", slug="out", name="Out", index=False)
+        assert "ShareAlike" in str(excinfo.value)
+        assert "CC-BY-SA-4.0" in str(excinfo.value)
+
+    def test_check_license_false_skips_check(self, project_with_inputs: Path):
+        _write_yaml(
+            project_with_inputs,
+            """
+            package:
+              license: CC-BY-4.0
+            inputs:
+              - name: Raw
+                slug: raw
+                location: inputs/raw.csv
+                source:
+                  name: Raw
+                  attributedTo: Org
+                  license: CC-BY-SA-4.0
+                  acquiredAt: "2026-01-01"
+                  acquisitionMethod: manual-download
+                  location:
+                    data: https://example.org/raw.csv
+            """,
+        )
+        set_project_path(project_with_inputs)
+        from sunstone import pandas as spd
+
+        df = spd.read_csv("inputs/raw.csv")
+        df.to_csv(
+            "outputs/out.csv",
+            slug="out",
+            name="Out",
+            index=False,
+            check_license=False,
+        )
+        assert (project_with_inputs / "outputs" / "out.csv").exists()
+
+    def test_explicit_license_arg_persists_to_yaml(self, project_with_inputs: Path):
+        _write_yaml(
+            project_with_inputs,
+            """
+            package:
+              license: CC-BY-NC-4.0
+            inputs:
+              - name: Raw
+                slug: raw
+                location: inputs/raw.csv
+                source:
+                  name: Raw
+                  attributedTo: Org
+                  license: CC-BY-NC-4.0
+                  acquiredAt: "2026-01-01"
+                  acquisitionMethod: manual-download
+                  location:
+                    data: https://example.org/raw.csv
+            """,
+        )
+        set_project_path(project_with_inputs)
+        from sunstone import pandas as spd
+
+        df = spd.read_csv("inputs/raw.csv")
+        df.to_csv(
+            "outputs/out.csv",
+            slug="out",
+            name="Out",
+            index=False,
+            license="CC-BY-NC-SA-4.0",
+        )
+        assert "license: CC-BY-NC-SA-4.0" in (project_with_inputs / "datasets.yaml").read_text()
+
+    def test_no_target_license_warns_when_sources_have_licenses(self, project_with_inputs: Path):
+        _write_yaml(
+            project_with_inputs,
+            """
+            inputs:
+              - name: Raw
+                slug: raw
+                location: inputs/raw.csv
+                source:
+                  name: Raw
+                  attributedTo: Org
+                  license: CC-BY-4.0
+                  acquiredAt: "2026-01-01"
+                  acquisitionMethod: manual-download
+                  location:
+                    data: https://example.org/raw.csv
+            """,
+        )
+        set_project_path(project_with_inputs)
+        from sunstone import pandas as spd
+
+        df = spd.read_csv("inputs/raw.csv")
+        with pytest.warns(UserWarning, match="no target license is declared"):
+            df.to_csv("outputs/out.csv", slug="out", name="Out", index=False)
+
+    def test_no_sources_no_warning_no_check(self, project_with_inputs: Path, recwarn):
+        _write_yaml(project_with_inputs, "outputs: []\n")
+        set_project_path(project_with_inputs)
+        df = DataFrame(pd.DataFrame({"a": [1, 2]}))
+        df.metadata.lineage.project_path = str(project_with_inputs)
+        df.to_csv("outputs/orphan.csv", slug="orphan", name="Orphan", index=False)
+        license_warns = [w for w in recwarn if isinstance(w.message, UserWarning) and "license" in str(w.message)]
+        assert not license_warns
+
+
+# ---------------------------------------------------------------------------
+# CLI: sunstone license list / check
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_project(tmp_path: Path):
+    _write_yaml(
+        tmp_path,
+        """
+        package:
+          license: CC-BY-NC-4.0
+        inputs:
+          - name: Raw A
+            slug: raw-a
+            location: inputs/a.csv
+            source:
+              name: Raw A
+              attributedTo: Org A
+              license: CC-BY-SA-4.0
+              acquiredAt: "2026-01-01"
+              acquisitionMethod: manual-download
+              location:
+                data: https://example.org/a.csv
+        outputs:
+          - name: Output
+            slug: out
+            location: outputs/out.csv
+            lineage:
+              sources:
+                - slug: raw-a
+        """,
+    )
+    return tmp_path
+
+
+class TestLicenseListCommand:
+    def test_list_groups_by_license(self, cli_project: Path):
+        runner = CliRunner()
+        result = runner.invoke(app, ["license", "list", "-f", str(cli_project / "datasets.yaml")])
+        assert result.exit_code == 0
+        assert "CC-BY-SA-4.0" in result.stdout  # input source license
+        assert "CC-BY-NC-4.0" in result.stdout  # effective output license (from package)
+        assert "input:raw-a" in result.stdout
+        assert "output:out" in result.stdout
+
+    def test_list_json(self, cli_project: Path):
+        import json as _json
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["license", "list", "-f", str(cli_project / "datasets.yaml"), "--json"])
+        assert result.exit_code == 0
+        payload = _json.loads(result.stdout)
+        assert "CC-BY-SA-4.0" in payload
+        assert "CC-BY-NC-4.0" in payload
+
+
+class TestLicenseCheckCommand:
+    def test_check_reports_conflict(self, cli_project: Path):
+        runner = CliRunner()
+        result = runner.invoke(app, ["license", "check", "-f", str(cli_project / "datasets.yaml")])
+        # Output 'out' inherits CC-BY-NC-4.0 (from package) but source is CC-BY-SA-4.0:
+        # SA requires same family, NC isn't SA's family.
+        assert result.exit_code == 1
+        assert "conflict" in result.stdout
+        assert "out" in result.stdout
+
+    def test_check_specific_slug(self, cli_project: Path):
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["license", "check", "out", "-f", str(cli_project / "datasets.yaml")],
+        )
+        assert result.exit_code == 1
+        assert "out" in result.stdout
+
+    def test_check_unknown_slug(self, cli_project: Path):
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["license", "check", "nonexistent", "-f", str(cli_project / "datasets.yaml")],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+    def test_check_compatible_project_passes(self, tmp_path: Path):
+        _write_yaml(
+            tmp_path,
+            """
+            package:
+              license: CC-BY-SA-4.0
+            inputs:
+              - name: Raw
+                slug: raw
+                location: inputs/r.csv
+                source:
+                  name: Raw
+                  attributedTo: Org
+                  license: CC-BY-SA-4.0
+                  acquiredAt: "2026-01-01"
+                  acquisitionMethod: manual-download
+                  location:
+                    data: https://example.org/r.csv
+            outputs:
+              - name: Out
+                slug: out
+                location: outputs/out.csv
+                lineage:
+                  sources:
+                    - slug: raw
+            """,
+        )
+        runner = CliRunner()
+        result = runner.invoke(app, ["license", "check", "-f", str(tmp_path / "datasets.yaml")])
+        assert result.exit_code == 0
+        assert "compatible" in result.stdout
+
+
+class TestDatasetValidateSpdx:
+    def test_invalid_spdx_in_output_license(self, tmp_path: Path):
+        _write_yaml(
+            tmp_path,
+            """
+            outputs:
+              - name: Out
+                slug: out
+                location: outputs/out.csv
+                license: NotASpdxId
+            """,
+        )
+        runner = CliRunner()
+        result = runner.invoke(app, ["dataset", "validate", "-f", str(tmp_path / "datasets.yaml")])
+        assert result.exit_code == 1
+        assert "SPDX" in result.stderr
+
+    def test_invalid_spdx_in_package_license(self, tmp_path: Path):
+        _write_yaml(
+            tmp_path,
+            """
+            package:
+              license: NotASpdxId
+            outputs: []
+            """,
+        )
+        runner = CliRunner()
+        result = runner.invoke(app, ["dataset", "validate", "-f", str(tmp_path / "datasets.yaml")])
+        assert result.exit_code == 1
+        assert "SPDX" in result.stderr
+
+    def test_licenseref_accepted(self, tmp_path: Path):
+        _write_yaml(
+            tmp_path,
+            """
+            package:
+              license: LicenseRef-Custom-Org-1.0
+            outputs:
+              - name: Out
+                slug: out
+                location: outputs/out.csv
+                license: LicenseRef-OGL-3.0
+            """,
+        )
+        runner = CliRunner()
+        result = runner.invoke(app, ["dataset", "validate", "-f", str(tmp_path / "datasets.yaml")])
+        assert result.exit_code == 0

--- a/tests/testdata/UNMembersProject/datasets.yaml
+++ b/tests/testdata/UNMembersProject/datasets.yaml
@@ -8,7 +8,7 @@ package:
     - united-nations
     - member-states
     - international-organizations
-  license: CC-BY-4.0
+  license: CC-BY-NC-3.0-IGO
   contributors:
     - title: Sunstone Institute
       roles:


### PR DESCRIPTION
Closes #13.

## Summary
- New `sunstone.licenses` module: embedded SPDX registry (CC family, CC0/PDDL/ODC, common `LicenseRef-`), `LicenseProperties`, `check_compatibility`, `get_most_restrictive_license`, `LicenseCompatibilityError`.
- New `outputs[].license` schema field on `DatasetMetadata` with parse + roundtrip serialization. `DatasetsManager.effective_license_for(slug)` resolves the dataset → package fallback.
- Write-time enforcement on `DataFrame.to_csv` / `to_parquet`: collects source licenses from session lineage, checks compatibility against target license, raises `LicenseCompatibilityError` with conflict descriptions and suggested compatible target licenses. `check_license=True` default; `license=` argument persists overrides to `datasets.yaml`.
- New CLI subcommands: `sunstone license check [SLUG]` and `sunstone license list` (both support `--json`).
- `sunstone dataset validate` now flags non-SPDX identifiers in dataset, source, and package license fields. `LicenseRef-*` identifiers accepted as user-defined per SPDX spec.
- Fixed: `tests/testdata/UNMembersProject/datasets.yaml` — `package.license` was `CC-BY-4.0` but UN data is `CC-BY-NC-3.0-IGO`. The new write-time check correctly flagged this; corrected to `CC-BY-NC-3.0-IGO` (which is exactly the kind of bug this feature is built to catch).

## Compatibility rules (rules-based, not a static matrix)
- Public-domain source (CC0, PDDL, US-PD): compatible with any target.
- ShareAlike source: target must be ShareAlike in the same family (different SA families like `CC-BY-SA-4.0` vs `ODbL-1.0` vs `CC-BY-NC-SA-4.0` are mutually incompatible).
- NonCommercial source: target must also be NonCommercial.
- Attribution source: target must require attribution (or ShareAlike, which preserves it).
- Unknown sources are listed in the result; unknown targets are reported as conflicts so they are never silently accepted.

## Test plan
- [x] 42 new tests in `tests/test_licenses.py` covering registry, SPDX validation, compatibility rules, write-time enforcement (compatible / blocked / opt-out / persist override / no-target-license warning), and CLI (`license list`, `license check`, dataset validate SPDX).
- [x] Full suite: 1072 passing locally (1030 prior + 42 new).
- [x] `ruff check` clean.
- [x] mypy clean (pre-commit pass).
- [ ] CI green across the test matrix.