### PR TITLE
Add NLOD, CC-BY-3.0-IGO, and CC-BY-NC-SA-3.0-IGO to license registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added: `sunstone license check [SLUG]` and `sunstone license list` CLI commands (with `--json`).
 - Changed: `sunstone dataset validate` now flags non-SPDX identifiers in dataset, source, and
   package license fields (LicenseRef-* identifiers are accepted).
+- Added: `NLOD-1.0`, `NLOD-2.0` (Norwegian Licence for Open Government Data), `CC-BY-3.0-IGO`,
+  and `CC-BY-NC-SA-3.0-IGO` to the embedded license registry — needed for Norwegian government
+  data publishers (Fiskeridirektoratet, Miljødirektoratet) and additional UN/IGO datasets.
 
 ## [1.10.0] - 2026-05-06
 

--- a/src/sunstone/licenses.py
+++ b/src/sunstone/licenses.py
@@ -101,6 +101,21 @@ _REGISTRY_ENTRIES: tuple[LicenseProperties, ...] = (
         name="UK Open Government Licence v3.0",
         attribution=True,
     ),
+    LicenseProperties(
+        spdx="CC-BY-3.0-IGO",
+        name="Creative Commons Attribution 3.0 IGO",
+        attribution=True,
+    ),
+    LicenseProperties(
+        spdx="NLOD-2.0",
+        name="Norwegian Licence for Open Government Data 2.0",
+        attribution=True,
+    ),
+    LicenseProperties(
+        spdx="NLOD-1.0",
+        name="Norwegian Licence for Open Government Data 1.0",
+        attribution=True,
+    ),
     # Attribution + ShareAlike
     LicenseProperties(
         spdx="CC-BY-SA-4.0",
@@ -152,6 +167,14 @@ _REGISTRY_ENTRIES: tuple[LicenseProperties, ...] = (
         share_alike=True,
         non_commercial=True,
         family="cc-by-nc-sa-3",
+    ),
+    LicenseProperties(
+        spdx="CC-BY-NC-SA-3.0-IGO",
+        name="Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO",
+        attribution=True,
+        share_alike=True,
+        non_commercial=True,
+        family="cc-by-nc-sa-3-igo",
     ),
 )
 

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -43,11 +43,30 @@ class TestRegistry:
             "PDDL-1.0",
             "ODC-By-1.0",
             "ODbL-1.0",
+            "CC-BY-3.0-IGO",
             "CC-BY-NC-3.0-IGO",
+            "CC-BY-NC-SA-3.0-IGO",
+            "NLOD-1.0",
+            "NLOD-2.0",
             "LicenseRef-US-PD",
             "LicenseRef-OGL-3.0",
         ):
             assert required in spdx
+
+    def test_nlod_2_attribution_only(self):
+        nlod = get_properties("NLOD-2.0")
+        assert nlod is not None
+        assert nlod.attribution
+        assert not nlod.share_alike
+        assert not nlod.non_commercial
+
+    def test_cc_by_nc_sa_3_igo_distinct_share_alike_family(self):
+        # Different SA family from CC-BY-NC-SA-3.0 and CC-BY-NC-SA-4.0.
+        igo = get_properties("CC-BY-NC-SA-3.0-IGO")
+        assert igo is not None
+        assert igo.family == "cc-by-nc-sa-3-igo"
+        result = check_compatibility(["CC-BY-NC-SA-3.0-IGO"], "CC-BY-NC-SA-4.0")
+        assert not result.compatible
 
     def test_get_properties_known(self):
         cc_by_sa = get_properties("CC-BY-SA-4.0")


### PR DESCRIPTION
Follow-up to #60. Adds four real license identifiers to the embedded SPDX registry, covering licenses already used by Sunstone projects but missing from the initial registry.

## What's added
- **NLOD-2.0** — Norwegian Licence for Open Government Data 2.0 (attribution-only). Used by Fiskeridirektoratet (\`aquaculture-data\`, \`fishmap-dashboard\`) and Miljødirektoratet (TEOTIL pollution data).
- **NLOD-1.0** — same family, predecessor (deprecated since 2017 transition, included for completeness).
- **CC-BY-3.0-IGO** — Attribution 3.0 IGO. Used in \`NepalEducationAnalysis\` (UNESCO/UIS data).
- **CC-BY-NC-SA-3.0-IGO** — Attribution-NonCommercial-ShareAlike 3.0 IGO. Used in \`EnergyTransitionProject\`. Distinct ShareAlike \`family\` from the non-IGO 3.0 and 4.0 variants since the IGO license text is legally separate.

## Why this surfaced
After #60 landed, scanning \`~/git/sunstone/projects/**/datasets.yaml\` flagged these as unsupported. Bare \`NLOD\` (no version) is not valid SPDX — projects using it should now write \`NLOD-2.0\` (verified against Miljødirektoratet's metadata: "Norsk lisens for offentlige data (NLOD) 2.0").

## Not added (kept out deliberately)
- \`proprietary\`, \`Public domain\`, \`public-domain\`, \`unknown\` — not SPDX identifiers. Projects using these should switch to \`LicenseRef-proprietary\`, \`CC0-1.0\`, \`LicenseRef-US-PD\`, or \`LicenseRef-unknown\` as appropriate. The registry shouldn't legitimize non-canonical strings.

## Test plan
- [x] 2 new tests: NLOD-2.0 properties + CC-BY-NC-SA-3.0-IGO family-isolation.
- [x] \`tests/test_licenses.py\`: 44 passing (42 prior + 2 new).
- [x] Full suite: 1074 passing.
- [x] \`ruff\` clean, \`mypy\` clean.
- [ ] CI green across the test matrix.