### PR TITLE
feat: NumPy .npz format handler for AssetKind.ARRAY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: NumPy `.npz` format handler for `AssetKind.ARRAY` (#64).
 - Added: Asset envelope — generic format handler protocol supporting non-tabular kinds (raster/array/tile).
 - Added: `sunstone.read()` / `sunstone.write()` top-level entry points returning/accepting `Asset`.
 - Added: `Asset.derive()` for explicit provenance with single- and multi-parent `prov:wasDerivedFrom`.

--- a/docs/tensors.md
+++ b/docs/tensors.md
@@ -8,8 +8,8 @@ is `dict[str, numpy.ndarray]` keyed by variable name.
 - **AssetKind:** `AssetKind.ARRAY`
 - **Payload:** `dict[str, numpy.ndarray]`
 - **Typed accessor:** `Asset.as_array() -> dict[str, numpy.ndarray]`
-- **Status:** Asset envelope ready; format handlers (NumPy `.npz`,
-  Zarr, NetCDF) are on the roadmap.
+- **Status:** Asset envelope ready. NumPy `.npz` is supported today;
+  Zarr and NetCDF handlers are on the roadmap.
 
 ## Why a dict, not a single ndarray
 
@@ -31,32 +31,37 @@ ARRAY is for many.
 - Per-variable metadata flows through `Metadata.component_metadata`
   with `component_kind="variable"` — same shape as for tabular
   columns, raster bands, and tile layers.
+- **NumPy `.npz`** — single-file zip of `.npy` arrays. Stream-based
+  `FormatHandler` that round-trips the sunstone `Metadata` blob (slug,
+  name, description, RDF prefixes, custom properties, and per-variable
+  `component_metadata`) inside the archive under a reserved key.
 
 ## What's coming
 
-Three planned handlers cover the common formats:
+Two further handlers cover the rest of the common formats:
 
-1. **NumPy `.npz`** — single-file zip of `.npy` arrays. Uses the
-   stream-based `FormatHandler` protocol.
-2. **Zarr** — chunked, compressed n-D arrays in a directory or cloud
+1. **Zarr** — chunked, compressed n-D arrays in a directory or cloud
    store. Uses `StoreFormatHandler` because the data is spread across
    many objects and is opened, not streamed.
-3. **NetCDF** / HDF5 — single-file but with random access semantics;
+2. **NetCDF** / HDF5 — single-file but with random access semantics;
    handler choice depends on whether the underlying library is
    stream-friendly.
 
-## Reading a tensor (planned API)
+## Reading a tensor
 
 ```python
 import sunstone as ss
 
-asset = ss.read("inputs/era5_2024.zarr")
+asset = ss.read("inputs/era5_2024.npz")
 assert asset.kind is ss.AssetKind.ARRAY
 
 vars = asset.as_array()
 temp = vars["temperature"]   # ndarray, shape (time, lat, lon)
 pressure = vars["pressure"]
 ```
+
+Zarr and NetCDF use the same dispatch — once those handlers land, swap
+the extension and the rest of the code is unchanged.
 
 ## Writing a derived tensor
 
@@ -72,7 +77,7 @@ child = source.derive(
     slug="era5-2024-monthly",
     name="ERA5 2024, monthly means",
 )
-ss.write(child, "outputs/era5_monthly.zarr")
+ss.write(child, "outputs/era5_monthly.npz")
 ```
 
 ## Component metadata per variable

--- a/src/sunstone/handlers_npz.py
+++ b/src/sunstone/handlers_npz.py
@@ -1,0 +1,248 @@
+"""NumPy ``.npz`` format handler for ``AssetKind.ARRAY`` assets.
+
+Reads and writes a single-file zip of ``.npy`` arrays (``numpy.savez`` /
+``numpy.load``) into and out of the unified :class:`~sunstone.asset.Asset`
+envelope. Round-trips a sunstone :class:`~sunstone.lineage.Metadata` blob by
+storing the JSON-LD payload inside the archive under a reserved key.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from dataclasses import asdict, fields as _dc_fields
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any, BinaryIO
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from .asset import Asset
+
+
+class NpzFormatHandler:
+    """Handles NumPy ``.npz`` archives for ``AssetKind.ARRAY`` assets.
+
+    Stream-based ``FormatHandler`` (protocol v2). The archive stores one
+    ``.npy`` per variable plus an optional reserved entry,
+    ``__sunstone_metadata__``, carrying a uint8 array of the JSON-LD-encoded
+    sunstone ``Metadata`` blob (including any ``component_metadata`` for
+    per-variable schemas).
+    """
+
+    __sunstone_handler_protocol__ = 2
+
+    _METADATA_KEY = "__sunstone_metadata__"
+    """Reserved npz archive key used to embed the sunstone Metadata blob."""
+
+    _COMPONENT_METADATA_DOC_KEY = "si:components"
+    """Reserved JSON-LD doc key carrying serialised ``component_metadata``.
+
+    ``Metadata.to_jsonld()`` does not (yet) emit ``component_metadata``; we
+    piggy-back it on the doc here and restore it in :meth:`read` so the
+    handler round-trips losslessly today and degrades cleanly once a future
+    ``Metadata`` revision learns to emit components natively.
+    """
+
+    # --- capability predicates ---------------------------------------------
+
+    def supports_native_metadata_extraction(self) -> bool:
+        """The archive can carry an embedded JSON-LD sidecar."""
+        return True
+
+    def supports_sunstone_metadata_embedding(self) -> bool:
+        """Full sunstone ``Metadata`` round-trips via the reserved key."""
+        return True
+
+    def supports_metadata(self) -> bool:
+        """Legacy alias for ``supports_sunstone_metadata_embedding()``."""
+        return self.supports_sunstone_metadata_embedding()
+
+    def supported_kinds(self) -> tuple:
+        from .asset import AssetKind
+
+        return (AssetKind.ARRAY,)
+
+    # --- dispatch helpers --------------------------------------------------
+
+    def _resolve_format(self, path: str, format: str | None) -> str | None:
+        if format is not None:
+            return "npz" if format == "npz" else None
+        parsed = urlparse(path)
+        file_path = parsed.path if parsed.scheme else path
+        suffix = PurePosixPath(file_path).suffix.lower()
+        return "npz" if suffix == ".npz" else None
+
+    def can_read(self, path: str, format: str | None) -> bool:
+        return self._resolve_format(path, format) == "npz"
+
+    def can_write(self, path: str, format: str | None) -> bool:
+        return self._resolve_format(path, format) == "npz"
+
+    # --- read --------------------------------------------------------------
+
+    def read(self, stream: BinaryIO, **kwargs: object) -> "Asset":
+        import numpy as np
+
+        from .asset import Asset, AssetKind
+        from .lineage import Metadata
+
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+
+        npz = np.load(stream, allow_pickle=False)
+        try:
+            arrays: dict[str, np.ndarray] = {}
+            meta_blob: bytes | None = None
+            for key in npz.files:
+                if key == self._METADATA_KEY:
+                    raw = npz[key]
+                    # JSON-LD bytes were stored as a uint8 array.
+                    meta_blob = bytes(raw.tobytes())
+                else:
+                    # Materialise so the array stays usable after the
+                    # underlying zip closes.
+                    arrays[key] = np.array(npz[key])
+        finally:
+            npz.close()
+
+        meta = Metadata()
+        if meta_blob is not None:
+            try:
+                doc = _json.loads(meta_blob.decode("utf-8"))
+            except Exception:
+                doc = None
+            if isinstance(doc, dict):
+                component_doc = doc.pop(self._COMPONENT_METADATA_DOC_KEY, None)
+                try:
+                    meta = Metadata.from_jsonld(doc)
+                except Exception:
+                    meta = Metadata()
+                if isinstance(component_doc, dict):
+                    meta.component_metadata = _deserialise_component_metadata(component_doc)
+
+        return Asset(payload=arrays, kind=AssetKind.ARRAY, metadata=meta)
+
+    # --- write -------------------------------------------------------------
+
+    def write(self, asset: object, stream: BinaryIO, **kwargs: object) -> None:
+        import numpy as np
+
+        from .asset import AssetKind
+        from .errors import IncompatibleAssetKindError
+
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+
+        kind = getattr(asset, "kind", None)
+        if kind is not AssetKind.ARRAY:
+            raise IncompatibleAssetKindError(
+                expected=AssetKind.ARRAY,
+                actual=kind if isinstance(kind, AssetKind) else AssetKind.TABULAR,
+            )
+
+        payload = asset.as_array()  # type: ignore[attr-defined]
+        if not isinstance(payload, dict):
+            raise TypeError(f"ARRAY asset payload must be dict[str, ndarray], got {type(payload).__name__}")
+        for key, arr in payload.items():
+            if key == self._METADATA_KEY:
+                raise ValueError(f"Variable name {key!r} is reserved for sunstone metadata embedding.")
+
+        to_write: dict[str, np.ndarray] = {name: np.asarray(arr) for name, arr in payload.items()}
+
+        metadata = getattr(asset, "metadata", None)
+        if metadata is not None and _metadata_has_content(metadata):
+            doc = metadata.to_jsonld()
+            component_doc = _serialise_component_metadata(metadata.component_metadata)
+            if component_doc:
+                doc[self._COMPONENT_METADATA_DOC_KEY] = component_doc
+            blob = _json.dumps(doc).encode("utf-8")
+            to_write[self._METADATA_KEY] = np.frombuffer(blob, dtype=np.uint8)
+
+        np.savez_compressed(stream, **to_write)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _metadata_has_content(metadata: Any) -> bool:
+    """Return True if ``metadata`` carries anything worth serialising.
+
+    The empty ``Metadata()`` produced by a bare read is skipped so we don't
+    pollute the archive with an empty JSON-LD blob.
+    """
+    if metadata is None:
+        return False
+    if metadata.slug or metadata.name or metadata.description:
+        return True
+    if metadata.rdf_prefixes:
+        return True
+    if metadata.custom_properties:
+        return True
+    if metadata.field_metadata:
+        return True
+    if metadata.component_metadata:
+        return True
+    if metadata.identity:
+        return True
+    lineage = getattr(metadata, "lineage", None)
+    if lineage is not None:
+        if lineage.sources:
+            return True
+        if lineage.activity is not None:
+            return True
+        if lineage.field_derivations:
+            return True
+        if lineage.created_at is not None:
+            return True
+        if lineage.data_hash is not None:
+            return True
+    return False
+
+
+def _serialise_component_metadata(components: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Serialise ``Metadata.component_metadata`` into a JSON-safe dict."""
+    if not components:
+        return {}
+    from .component import ComponentSchema
+
+    out: dict[str, dict[str, Any]] = {}
+    for name, comp in components.items():
+        if not isinstance(comp, ComponentSchema):
+            continue
+        entry: dict[str, Any] = {}
+        for f in _dc_fields(comp):
+            value = getattr(comp, f.name)
+            if value is None:
+                continue
+            if f.name == "derived_from" and value is not None:
+                entry[f.name] = [asdict(d) for d in value]
+            else:
+                entry[f.name] = value
+        out[name] = entry
+    return out
+
+
+def _deserialise_component_metadata(doc: dict[str, Any]) -> dict[str, Any]:
+    """Inverse of :func:`_serialise_component_metadata`."""
+    from .component import ComponentSchema
+    from .lineage import FieldDerivation
+
+    out: dict[str, ComponentSchema] = {}
+    for name, entry in doc.items():
+        if not isinstance(entry, dict):
+            continue
+        derived_raw = entry.get("derived_from")
+        derived_from = None
+        if isinstance(derived_raw, list):
+            derived_from = [FieldDerivation(**d) for d in derived_raw if isinstance(d, dict)]
+        out[name] = ComponentSchema(
+            name=entry.get("name", name),
+            component_kind=entry.get("component_kind", "variable"),
+            dtype=entry.get("dtype"),
+            units=entry.get("units"),
+            description=entry.get("description"),
+            custom_properties=entry.get("custom_properties"),
+            derived_from=derived_from,
+        )
+    return out

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -231,6 +231,12 @@ class PluginRegistry:
         # these in the TabularDataFrameAdapter, which conforms to the wider
         # Protocol exactly.
         self._format_handlers.append(ParquetFormatHandler())  # type: ignore[arg-type]
+        try:
+            from .handlers_npz import NpzFormatHandler
+
+            self._format_handlers.append(NpzFormatHandler())  # type: ignore[arg-type]
+        except ImportError:
+            pass  # numpy not installed (shouldn't normally happen — pandas pulls it in)
         self._format_handlers.append(BuiltinFormatHandler())  # type: ignore[arg-type]
         self._url_handlers.append(HttpURLHandler())
         # LocalFileHandler is always present (registered in __init__)

--- a/tests/test_handlers_npz.py
+++ b/tests/test_handlers_npz.py
@@ -1,0 +1,197 @@
+"""Tests for ``NpzFormatHandler`` (NumPy ``.npz`` round-trip)."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import sunstone
+from sunstone.asset import Asset, AssetKind
+from sunstone.component import ComponentSchema
+from sunstone.errors import IncompatibleAssetKindError
+from sunstone.handlers_npz import NpzFormatHandler
+from sunstone.lineage import Metadata
+
+
+@pytest.fixture
+def handler() -> NpzFormatHandler:
+    return NpzFormatHandler()
+
+
+class TestNpzCapabilities:
+    def test_protocol_v2(self, handler):
+        assert getattr(handler, "__sunstone_handler_protocol__", 0) == 2
+
+    def test_supports_native_extraction(self, handler):
+        assert handler.supports_native_metadata_extraction() is True
+
+    def test_supports_embedding(self, handler):
+        assert handler.supports_sunstone_metadata_embedding() is True
+
+    def test_supports_metadata_alias(self, handler):
+        assert handler.supports_metadata() is True
+
+    def test_supported_kinds(self, handler):
+        assert handler.supported_kinds() == (AssetKind.ARRAY,)
+
+    def test_can_read_npz(self, handler):
+        assert handler.can_read("data.npz", None)
+
+    def test_can_read_explicit_format(self, handler):
+        assert handler.can_read("data.whatever", "npz")
+
+    def test_can_write_npz(self, handler):
+        assert handler.can_write("out.npz", None)
+
+    def test_can_write_explicit_format(self, handler):
+        assert handler.can_write("out.dat", "npz")
+
+    def test_cannot_read_parquet(self, handler):
+        assert not handler.can_read("data.parquet", None)
+
+    def test_cannot_write_csv(self, handler):
+        assert not handler.can_write("data.csv", None)
+
+
+class TestNpzRoundTrip:
+    def test_round_trip_arrays_only(self, handler, tmp_path):
+        arrays = {
+            "temperature": np.arange(24, dtype=np.float32).reshape(2, 3, 4),
+            "labels": np.array(["a", "b", "c"]),
+        }
+        asset = Asset(payload=arrays, kind=AssetKind.ARRAY, metadata=Metadata())
+
+        path = tmp_path / "vars.npz"
+        with open(path, "wb") as f:
+            handler.write(asset, f)
+
+        with open(path, "rb") as f:
+            restored = handler.read(f)
+
+        assert isinstance(restored, Asset)
+        assert restored.kind is AssetKind.ARRAY
+        restored_arrays = restored.as_array()
+        assert set(restored_arrays) == {"temperature", "labels"}
+        npt.assert_array_equal(restored_arrays["temperature"], arrays["temperature"])
+        assert restored_arrays["temperature"].dtype == np.float32
+        npt.assert_array_equal(restored_arrays["labels"], arrays["labels"])
+
+    def test_round_trip_with_metadata(self, handler, tmp_path):
+        meta = Metadata()
+        meta.slug = "era5-snapshot"
+        meta.name = "ERA5 Snapshot"
+        meta.description = "Two variables from ERA5 reanalysis"
+        meta.component_metadata["temperature"] = ComponentSchema(
+            name="temperature",
+            component_kind="variable",
+            dtype="float32",
+            units="kelvin",
+            description="2-metre air temperature",
+        )
+
+        arrays = {
+            "temperature": np.array([[273.15, 280.0], [290.5, 300.0]], dtype=np.float32),
+            "pressure": np.array([[101.3, 100.8]], dtype=np.float64),
+        }
+        asset = Asset(payload=arrays, kind=AssetKind.ARRAY, metadata=meta)
+
+        path = tmp_path / "era5.npz"
+        with open(path, "wb") as f:
+            handler.write(asset, f)
+
+        with open(path, "rb") as f:
+            restored = handler.read(f)
+
+        assert restored.metadata.slug == "era5-snapshot"
+        assert restored.metadata.name == "ERA5 Snapshot"
+        assert restored.metadata.description == "Two variables from ERA5 reanalysis"
+
+        comp = restored.metadata.component_metadata["temperature"]
+        assert isinstance(comp, ComponentSchema)
+        assert comp.name == "temperature"
+        assert comp.component_kind == "variable"
+        assert comp.dtype == "float32"
+        assert comp.units == "kelvin"
+        assert comp.description == "2-metre air temperature"
+
+        # Payload arrays survive intact.
+        restored_arrays = restored.as_array()
+        npt.assert_array_equal(restored_arrays["temperature"], arrays["temperature"])
+        npt.assert_array_equal(restored_arrays["pressure"], arrays["pressure"])
+        assert restored_arrays["temperature"].dtype == np.float32
+        assert restored_arrays["pressure"].dtype == np.float64
+
+    def test_read_legacy_npz_without_metadata(self, handler, tmp_path):
+        """A plain ``np.savez`` archive reads as an ARRAY asset with empty metadata."""
+        path = tmp_path / "plain.npz"
+        x = np.arange(6, dtype=np.int32).reshape(2, 3)
+        y = np.linspace(0.0, 1.0, 5)
+        np.savez(path, x=x, y=y)
+
+        with open(path, "rb") as f:
+            asset = handler.read(f)
+
+        assert isinstance(asset, Asset)
+        assert asset.kind is AssetKind.ARRAY
+        arrays = asset.as_array()
+        npt.assert_array_equal(arrays["x"], x)
+        npt.assert_array_equal(arrays["y"], y)
+
+        # Empty Metadata — no slug/name, no components, no lineage sources.
+        meta = asset.metadata
+        assert meta.slug is None
+        assert meta.name is None
+        assert meta.description is None
+        assert meta.component_metadata == {}
+        assert meta.lineage.sources == []
+
+
+class TestNpzKindEnforcement:
+    def test_write_rejects_non_array_kind(self, handler, tmp_path):
+        import pandas as pd
+
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        asset = Asset(payload=df, kind=AssetKind.TABULAR, metadata=Metadata())
+
+        path = tmp_path / "wrong.npz"
+        with pytest.raises(IncompatibleAssetKindError) as excinfo:
+            with open(path, "wb") as f:
+                handler.write(asset, f)
+        assert excinfo.value.expected is AssetKind.ARRAY
+        assert excinfo.value.actual is AssetKind.TABULAR
+
+    def test_write_rejects_reserved_variable_name(self, handler, tmp_path):
+        arrays = {NpzFormatHandler._METADATA_KEY: np.zeros(3)}
+        asset = Asset(payload=arrays, kind=AssetKind.ARRAY, metadata=Metadata())
+
+        path = tmp_path / "reserved.npz"
+        with pytest.raises(ValueError, match="reserved"):
+            with open(path, "wb") as f:
+                handler.write(asset, f)
+
+
+class TestTopLevelDispatch:
+    def test_top_level_read_dispatches_to_npz(self, handler, tmp_path):
+        arrays = {
+            "a": np.arange(10, dtype=np.int64),
+            "b": np.linspace(-1.0, 1.0, 7, dtype=np.float32),
+        }
+        meta = Metadata()
+        meta.slug = "dispatch-test"
+        meta.name = "Dispatch Test"
+        asset = Asset(payload=arrays, kind=AssetKind.ARRAY, metadata=meta)
+
+        path = tmp_path / "dispatch.npz"
+        with open(path, "wb") as f:
+            handler.write(asset, f)
+
+        restored = sunstone.read(str(path))
+        assert isinstance(restored, Asset)
+        assert restored.kind is AssetKind.ARRAY
+        assert restored.metadata.slug == "dispatch-test"
+        assert restored.metadata.name == "Dispatch Test"
+
+        restored_arrays = restored.as_array()
+        npt.assert_array_equal(restored_arrays["a"], arrays["a"])
+        npt.assert_array_equal(restored_arrays["b"], arrays["b"])


### PR DESCRIPTION
## Summary

- Adds `NpzFormatHandler` (stream-based `FormatHandler` v2) that reads/writes `.npz` files into/from `Asset(kind=AssetKind.ARRAY)`.
- Embeds sunstone `Metadata` as JSON-LD under a reserved `__sunstone_metadata__` key inside the npz archive; round-trips losslessly.
- Refuses non-ARRAY assets at write time via `IncompatibleAssetKindError`.
- Wired into `PluginRegistry._discover()` with the standard `try/except ImportError` guard.
- No new dependencies — numpy comes transitively via pandas/pyarrow.

## Notes

- `Metadata.to_jsonld()` doesn't yet emit `component_metadata`. Worked around by piggy-backing a `si:components` block on the JSON-LD blob inside the npz; will degrade cleanly when `Metadata` learns this natively.
- Reserved key collision: a user variable literally named `__sunstone_metadata__` is rejected at write time with `ValueError` rather than silently overwriting embedded metadata.

## Test plan

- [x] `uv run pytest tests/test_handlers_npz.py -v` — 17 passed
- [x] `uv run pytest` — 1189 passed (full suite)
- [x] ruff + ruff-format + mypy pre-commit hooks clean