### PR TITLE
feat: Zarr store format handler for AssetKind.ARRAY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: Zarr store-format handler for `AssetKind.ARRAY` via the `[zarr]` extra (#65).
 - Added: NumPy `.npz` format handler for `AssetKind.ARRAY` (#64).
 - Added: Asset envelope — generic format handler protocol supporting non-tabular kinds (raster/array/tile).
 - Added: `sunstone.read()` / `sunstone.write()` top-level entry points returning/accepting `Asset`.

--- a/docs/tensors.md
+++ b/docs/tensors.md
@@ -8,8 +8,8 @@ is `dict[str, numpy.ndarray]` keyed by variable name.
 - **AssetKind:** `AssetKind.ARRAY`
 - **Payload:** `dict[str, numpy.ndarray]`
 - **Typed accessor:** `Asset.as_array() -> dict[str, numpy.ndarray]`
-- **Status:** Asset envelope ready. NumPy `.npz` is supported today;
-  Zarr and NetCDF handlers are on the roadmap.
+- **Status:** Asset envelope ready. NumPy `.npz` and Zarr (local
+  directory store) are supported today; NetCDF/HDF5 is on the roadmap.
 
 ## Why a dict, not a single ndarray
 
@@ -35,33 +35,35 @@ ARRAY is for many.
   `FormatHandler` that round-trips the sunstone `Metadata` blob (slug,
   name, description, RDF prefixes, custom properties, and per-variable
   `component_metadata`) inside the archive under a reserved key.
+- **Zarr** directory stores (local filesystem) round-trip via
+  `ZarrStoreHandler`. Install with `pip install sunstone-py[zarr]`.
+  The handler embeds the sunstone `Metadata` blob as JSON-LD in the
+  root group's `.attrs` under key `"sunstone"`, and projects each
+  variable's `units` / `long_name` / `description` onto the array's
+  `.attrs` for ecosystem interop (xarray, Panoply, ncview, ...).
+  Works with both zarr v2 (`>=2.18`) and zarr v3.
 
 ## What's coming
 
-Two further handlers cover the rest of the common formats:
-
-1. **Zarr** — chunked, compressed n-D arrays in a directory or cloud
-   store. Uses `StoreFormatHandler` because the data is spread across
-   many objects and is opened, not streamed.
-2. **NetCDF** / HDF5 — single-file but with random access semantics;
-   handler choice depends on whether the underlying library is
-   stream-friendly.
+- **NetCDF** / HDF5 — single-file with random-access semantics;
+  handler choice depends on whether the underlying library is
+  stream-friendly.
+- **Remote Zarr stores** (`gs://`, `s3://`) — the v1 Zarr handler is
+  local-directory only. Object-store routing through the URLHandler
+  registry is planned.
 
 ## Reading a tensor
 
 ```python
 import sunstone as ss
 
-asset = ss.read("inputs/era5_2024.npz")
+asset = ss.read("inputs/era5_2024.zarr")
 assert asset.kind is ss.AssetKind.ARRAY
 
 vars = asset.as_array()
 temp = vars["temperature"]   # ndarray, shape (time, lat, lon)
 pressure = vars["pressure"]
 ```
-
-Zarr and NetCDF use the same dispatch — once those handlers land, swap
-the extension and the rest of the code is unchanged.
 
 ## Writing a derived tensor
 
@@ -77,7 +79,7 @@ child = source.derive(
     slug="era5-2024-monthly",
     name="ERA5 2024, monthly means",
 )
-ss.write(child, "outputs/era5_monthly.npz")
+ss.write(child, "outputs/era5_monthly.zarr")
 ```
 
 ## Component metadata per variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ s3 = [
 qudt = [
     "ontopint>=0.1",
 ]
+zarr = [
+    "zarr>=2.18",
+]
 
 [project.license]
 text = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ exclude = [
 overrides = [
     { module = "tests.*", disallow_untyped_defs = false },
     { module = "ontopint", ignore_missing_imports = true },
+    { module = "zarr", ignore_missing_imports = true },
 ]
 
 [tool.pytest.ini_options]

--- a/src/sunstone/handlers_zarr.py
+++ b/src/sunstone/handlers_zarr.py
@@ -1,0 +1,195 @@
+"""Zarr directory-store format handler.
+
+Implements the :class:`~sunstone.resource.StoreFormatHandler` protocol for
+``AssetKind.ARRAY`` payloads (``dict[str, numpy.ndarray]``).
+
+Round-trip strategy:
+- The full sunstone :class:`~sunstone.lineage.Metadata` blob is serialised as
+  JSON-LD into the root group's ``.attrs`` under key ``"sunstone"``.
+- Per-variable :class:`~sunstone.component.ComponentSchema` entries are also
+  projected onto each array's ``.attrs`` as CF-convention attributes
+  (``units``, ``long_name``, ``description``) — purely for ecosystem
+  interoperability with xarray, Panoply, ncview, etc.
+
+v1 supports local directory stores only. Remote stores (``gs://``, ``s3://``)
+are tracked as follow-up work — see ``docs/tensors.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .resource import ResourceLocation
+
+
+_ZARR_V2_GROUP_MARKERS = (".zgroup", ".zarray")
+_ZARR_V3_GROUP_MARKER = "zarr.json"
+
+
+def _path_looks_like_zarr(path: str) -> bool:
+    """Cheap path-suffix sniff. Does not require disk access."""
+    parsed = urlparse(path)
+    file_path = parsed.path if parsed.scheme else path
+    return file_path.lower().rstrip("/").endswith(".zarr")
+
+
+def _dir_has_zarr_marker(path: Path) -> bool:
+    """True if ``path`` is a directory with a zarr v2 or v3 marker file."""
+    if not path.is_dir():
+        return False
+    for marker in _ZARR_V2_GROUP_MARKERS:
+        if (path / marker).exists():
+            return True
+    if (path / _ZARR_V3_GROUP_MARKER).exists():
+        return True
+    return False
+
+
+class ZarrStoreHandler:
+    """Read/write :class:`~sunstone.asset.Asset` of kind ``ARRAY`` against a
+    Zarr directory store on the local filesystem.
+
+    Compatible with both zarr v2 (``>=2.18``) and v3. v3 uses ``zarr.json``
+    markers and ``create_array``; v2 uses ``.zgroup``/``.zarray`` and
+    ``create_dataset``. This handler uses the version-agnostic ``g[name] =
+    arr`` assignment shorthand for writes.
+    """
+
+    __sunstone_handler_protocol__ = 2
+    _METADATA_KEY = "sunstone"
+
+    def supports_native_metadata_extraction(self) -> bool:
+        """Per-variable CF attrs are native metadata that this handler reads."""
+        return True
+
+    def supports_sunstone_metadata_embedding(self) -> bool:
+        """Full sunstone metadata round-trips via the root group's ``sunstone`` attr."""
+        return True
+
+    def supports_metadata(self) -> bool:
+        """Legacy alias for ``supports_sunstone_metadata_embedding()``."""
+        return self.supports_sunstone_metadata_embedding()
+
+    def supported_kinds(self) -> tuple:
+        from .asset import AssetKind
+
+        return (AssetKind.ARRAY,)
+
+    # --- store classification ---------------------------------------------
+
+    def can_read_store(self, location: "ResourceLocation", format: str | None) -> bool:
+        if format == "zarr":
+            return True
+        if _path_looks_like_zarr(location.path):
+            return True
+        return _dir_has_zarr_marker(location.as_path())
+
+    def can_write_store(self, location: "ResourceLocation", format: str | None) -> bool:
+        if format == "zarr":
+            return True
+        if _path_looks_like_zarr(location.path):
+            return True
+        # Allow existing zarr directories to be overwritten.
+        return _dir_has_zarr_marker(location.as_path())
+
+    # --- I/O --------------------------------------------------------------
+
+    def read(self, location: "ResourceLocation", **kwargs: Any) -> Any:
+        """Read a Zarr directory into an :class:`Asset` of kind ARRAY."""
+        import zarr
+
+        from .asset import Asset, AssetKind
+        from .component import ComponentSchema
+        from .lineage import Metadata
+
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+
+        group = zarr.open_group(str(location.as_path()), mode="r")
+
+        # 1. Read root attrs and hydrate sunstone metadata if present.
+        root_attrs = dict(group.attrs)
+        raw = root_attrs.get(self._METADATA_KEY)
+        if raw is not None:
+            try:
+                doc = json.loads(raw) if isinstance(raw, str) else raw
+                meta = Metadata.from_jsonld(doc)
+            except Exception:
+                meta = Metadata()
+        else:
+            meta = Metadata()
+
+        # 2. Walk the immediate child arrays.
+        payload: dict[str, np.ndarray] = {}
+        for name, arr in group.arrays():
+            payload[name] = np.asarray(arr[:])
+
+            # 3. CF-style per-variable attrs — only populate ComponentSchema
+            #    when nothing was already restored from the JSON-LD blob for
+            #    this name (avoid clobbering richer info).
+            if name in meta.component_metadata:
+                continue
+            var_attrs = dict(arr.attrs)
+            units = var_attrs.get("units")
+            long_name = var_attrs.get("long_name")
+            description = var_attrs.get("description") or long_name
+            if units is None and description is None and long_name is None:
+                continue
+            meta.component_metadata[name] = ComponentSchema(
+                name=name,
+                component_kind="variable",
+                dtype=str(arr.dtype),
+                units=units,
+                description=description,
+            )
+
+        return Asset(payload=payload, kind=AssetKind.ARRAY, metadata=meta)
+
+    def write(self, asset: Any, location: "ResourceLocation", **kwargs: Any) -> None:
+        """Write an ARRAY-kind :class:`Asset` to a Zarr directory store."""
+        import zarr
+
+        from .asset import AssetKind
+        from .errors import IncompatibleAssetKindError
+
+        if not hasattr(asset, "kind") or asset.kind is not AssetKind.ARRAY:
+            actual = getattr(asset, "kind", None)
+            raise IncompatibleAssetKindError(
+                expected=AssetKind.ARRAY,
+                actual=actual if actual is not None else AssetKind.ARRAY,
+            )
+
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+
+        arrays: dict[str, np.ndarray] = asset.as_array()
+        component_meta = asset.metadata.component_metadata or {}
+
+        target = Path(location.path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        group = zarr.open_group(str(target), mode="w")
+
+        for name, arr in arrays.items():
+            np_arr = np.asarray(arr)
+            # version-agnostic write: assignment shorthand works in v2 and v3.
+            group[name] = np_arr
+            cs = component_meta.get(name)
+            if cs is None:
+                continue
+            # CF-convention attrs for ecosystem interop.
+            written = group[name]
+            if cs.units is not None:
+                written.attrs["units"] = cs.units
+            if cs.description is not None:
+                written.attrs["long_name"] = cs.description
+                written.attrs["description"] = cs.description
+
+        # Embed the sunstone metadata blob as a JSON string at the root.
+        doc = asset.metadata.to_jsonld()
+        group.attrs[self._METADATA_KEY] = json.dumps(doc)

--- a/src/sunstone/handlers_zarr.py
+++ b/src/sunstone/handlers_zarr.py
@@ -119,7 +119,10 @@ class ZarrStoreHandler:
         if raw is not None:
             try:
                 doc = json.loads(raw) if isinstance(raw, str) else raw
-                meta = Metadata.from_jsonld(doc)
+                if isinstance(doc, dict):
+                    meta = Metadata.from_jsonld(doc)
+                else:
+                    meta = Metadata()
             except Exception:
                 meta = Metadata()
         else:
@@ -136,10 +139,12 @@ class ZarrStoreHandler:
             if name in meta.component_metadata:
                 continue
             var_attrs = dict(arr.attrs)
-            units = var_attrs.get("units")
-            long_name = var_attrs.get("long_name")
-            description = var_attrs.get("description") or long_name
-            if units is None and description is None and long_name is None:
+            raw_units = var_attrs.get("units")
+            raw_long_name = var_attrs.get("long_name")
+            raw_description = var_attrs.get("description") or raw_long_name
+            units = raw_units if isinstance(raw_units, str) else None
+            description = raw_description if isinstance(raw_description, str) else None
+            if units is None and description is None:
                 continue
             meta.component_metadata[name] = ComponentSchema(
                 name=name,

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -223,6 +223,14 @@ class PluginRegistry:
         except ImportError:
             pass  # boto3 not installed
 
+        # Optional store-format handlers
+        try:
+            from .handlers_zarr import ZarrStoreHandler
+
+            self._store_format_handlers.append(ZarrStoreHandler())
+        except ImportError:
+            pass  # zarr not installed
+
         # Internal handlers last (fallback)
         from .handlers import BuiltinFormatHandler, HttpURLHandler, ParquetFormatHandler
 

--- a/tests/test_handlers_zarr.py
+++ b/tests/test_handlers_zarr.py
@@ -1,0 +1,215 @@
+"""Tests for the optional Zarr store-format handler."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+zarr = pytest.importorskip("zarr")  # skip cleanly when [zarr] extra is absent
+
+from sunstone.asset import Asset, AssetKind  # noqa: E402
+from sunstone.component import ComponentSchema  # noqa: E402
+from sunstone.errors import IncompatibleAssetKindError  # noqa: E402
+from sunstone.handlers_zarr import ZarrStoreHandler  # noqa: E402
+from sunstone.lineage import Metadata  # noqa: E402
+from sunstone.resource import ResourceLocation  # noqa: E402
+
+
+def _sample_payload() -> dict[str, np.ndarray]:
+    return {
+        "temperature": np.arange(24, dtype=np.float32).reshape(2, 3, 4),
+        "pressure": np.linspace(900.0, 1050.0, 12, dtype=np.float64).reshape(3, 4),
+        "mask": np.array([[1, 0, 1], [0, 1, 0]], dtype=np.uint8),
+    }
+
+
+def test_round_trip_arrays_only(tmp_path):
+    """Write and read back a dict of mixed-dtype ndarrays without metadata."""
+    handler = ZarrStoreHandler()
+    target = tmp_path / "plain.zarr"
+
+    asset = Asset(payload=_sample_payload(), kind=AssetKind.ARRAY, metadata=Metadata())
+    handler.write(asset, ResourceLocation(path=str(target)))
+
+    loaded = handler.read(ResourceLocation(path=str(target)))
+    assert loaded.kind is AssetKind.ARRAY
+    arrays = loaded.as_array()
+    assert set(arrays.keys()) == set(asset.payload.keys())
+    for name, expected in asset.payload.items():
+        np.testing.assert_array_equal(arrays[name], expected)
+        assert arrays[name].dtype == expected.dtype
+
+
+def test_round_trip_with_metadata(tmp_path):
+    """Slug/name/description and ComponentSchema entries all survive a round-trip."""
+    handler = ZarrStoreHandler()
+    target = tmp_path / "with_meta.zarr"
+
+    meta = Metadata(
+        slug="era5-test",
+        name="ERA5 Test Slice",
+        description="Toy slice for round-trip verification.",
+    )
+    meta.component_metadata["temperature"] = ComponentSchema(
+        name="temperature",
+        component_kind="variable",
+        dtype="float32",
+        units="kelvin",
+        description="2-metre air temperature",
+    )
+    meta.component_metadata["pressure"] = ComponentSchema(
+        name="pressure",
+        component_kind="variable",
+        dtype="float64",
+        units="hPa",
+        description="Surface pressure",
+    )
+
+    asset = Asset(payload=_sample_payload(), kind=AssetKind.ARRAY, metadata=meta)
+    handler.write(asset, ResourceLocation(path=str(target)))
+
+    loaded = handler.read(ResourceLocation(path=str(target)))
+    assert loaded.metadata.slug == "era5-test"
+    assert loaded.metadata.name == "ERA5 Test Slice"
+    assert loaded.metadata.description == "Toy slice for round-trip verification."
+
+    cm = loaded.metadata.component_metadata
+    assert "temperature" in cm
+    assert cm["temperature"].units == "kelvin"
+    assert cm["temperature"].description == "2-metre air temperature"
+    assert cm["pressure"].units == "hPa"
+    assert cm["pressure"].description == "Surface pressure"
+
+
+def test_cf_attrs_visible_on_disk(tmp_path):
+    """Per-variable ``units`` / ``long_name`` attrs are exposed for xarray etc."""
+    handler = ZarrStoreHandler()
+    target = tmp_path / "cf_attrs.zarr"
+
+    meta = Metadata(slug="cf-demo", name="CF Demo")
+    meta.component_metadata["temperature"] = ComponentSchema(
+        name="temperature",
+        component_kind="variable",
+        units="kelvin",
+        description="Air temperature at 2m",
+    )
+
+    asset = Asset(
+        payload={"temperature": np.arange(6, dtype=np.float32).reshape(2, 3)},
+        kind=AssetKind.ARRAY,
+        metadata=meta,
+    )
+    handler.write(asset, ResourceLocation(path=str(target)))
+
+    # Now reach into the store with the raw zarr API — not the handler.
+    group = zarr.open_group(str(target), mode="r")
+    arr_attrs = dict(group["temperature"].attrs)
+    assert arr_attrs.get("units") == "kelvin"
+    assert arr_attrs.get("long_name") == "Air temperature at 2m"
+
+
+def test_read_unknown_zarr_without_sunstone_attr(tmp_path):
+    """A vanilla Zarr store (no ``sunstone`` attr) still reads as an empty-meta Asset."""
+    target = tmp_path / "vanilla.zarr"
+    group = zarr.open_group(str(target), mode="w")
+    group["x"] = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    group["y"] = np.array([[1, 2], [3, 4]], dtype=np.int32)
+    # Deliberately no group.attrs["sunstone"].
+
+    handler = ZarrStoreHandler()
+    asset = handler.read(ResourceLocation(path=str(target)))
+
+    assert asset.kind is AssetKind.ARRAY
+    assert asset.metadata.slug is None
+    assert asset.metadata.name is None
+    assert asset.metadata.description is None
+    arrays = asset.as_array()
+    np.testing.assert_array_equal(arrays["x"], np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(arrays["y"], np.array([[1, 2], [3, 4]]))
+
+
+def test_write_rejects_non_array_kind(tmp_path):
+    """Writing a TABULAR asset to the Zarr handler must raise."""
+    import pandas as pd
+
+    handler = ZarrStoreHandler()
+    target = tmp_path / "wrong_kind.zarr"
+
+    asset = Asset(
+        payload=pd.DataFrame({"a": [1, 2, 3]}),
+        kind=AssetKind.TABULAR,
+        metadata=Metadata(),
+    )
+    with pytest.raises(IncompatibleAssetKindError):
+        handler.write(asset, ResourceLocation(path=str(target)))
+
+
+def test_top_level_read_dispatches_to_zarr(tmp_path):
+    """``sunstone.read()`` of a ``.zarr`` directory routes to the store handler."""
+    import sunstone
+
+    target = tmp_path / "dispatch.zarr"
+    handler = ZarrStoreHandler()
+
+    asset = Asset(
+        payload={"value": np.arange(8, dtype=np.float32).reshape(2, 4)},
+        kind=AssetKind.ARRAY,
+        metadata=Metadata(slug="dispatch-test", name="Dispatch Test"),
+    )
+    handler.write(asset, ResourceLocation(path=str(target)))
+
+    # Reset the cached registry so the optional handler registration runs cleanly.
+    from sunstone.plugins import PluginRegistry
+
+    PluginRegistry._instance = None
+    PluginRegistry._instances = {}
+
+    loaded = sunstone.read(str(target))
+    assert loaded.kind is AssetKind.ARRAY
+    np.testing.assert_array_equal(
+        loaded.as_array()["value"],
+        np.arange(8, dtype=np.float32).reshape(2, 4),
+    )
+    assert loaded.metadata.slug == "dispatch-test"
+
+
+def test_can_read_store_recognises_markers(tmp_path):
+    """Sanity-check the directory-marker detection."""
+    handler = ZarrStoreHandler()
+
+    # .zarr suffix alone is sufficient
+    assert handler.can_read_store(ResourceLocation(path="/tmp/anything.zarr"), None)
+    assert handler.can_read_store(ResourceLocation(path="/tmp/anything.zarr"), "zarr")
+
+    # An actual store on disk
+    target = tmp_path / "store_dir"
+    group = zarr.open_group(str(target), mode="w")
+    group["x"] = np.array([0, 1, 2])
+    assert handler.can_read_store(ResourceLocation(path=str(target)), None)
+
+    # A bare empty directory is not a zarr store
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert not handler.can_read_store(ResourceLocation(path=str(plain)), None)
+
+
+def test_metadata_blob_is_valid_jsonld_string(tmp_path):
+    """The root ``sunstone`` attr is a JSON string parseable as JSON-LD."""
+    handler = ZarrStoreHandler()
+    target = tmp_path / "jsonld.zarr"
+
+    meta = Metadata(slug="jsonld-demo", name="JSON-LD Demo")
+    asset = Asset(
+        payload={"x": np.array([1.0, 2.0])},
+        kind=AssetKind.ARRAY,
+        metadata=meta,
+    )
+    handler.write(asset, ResourceLocation(path=str(target)))
+
+    group = zarr.open_group(str(target), mode="r")
+    raw = group.attrs[handler._METADATA_KEY]
+    doc = json.loads(raw)
+    assert doc.get("@type") == "dcat:Distribution"
+    assert doc.get("dct:identifier") == "jsonld-demo"

--- a/uv.lock
+++ b/uv.lock
@@ -425,6 +425,18 @@ wheels = [
 ]
 
 [[package]]
+name = "donfig"
+version = "0.8.1.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1084,6 +1096,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numcodecs"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/cc/55420f3641a67f78392dc0bc5d02cb9eb0a9dcebf2848d1ac77253ca61fa/numcodecs-0.16.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:24e675dc8d1550cd976a99479b87d872cb142632c75cc402fea04c08c4898523", size = 1656287, upload-time = "2025-11-21T02:49:25.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/86644987505dcb90ba6d627d6989c27bafb0699f9fd00187e06d05ea8594/numcodecs-0.16.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:94ddfa4341d1a3ab99989d13b01b5134abb687d3dab2ead54b450aefe4ad5bd6", size = 1148899, upload-time = "2025-11-21T02:49:26.87Z" },
+    { url = "https://files.pythonhosted.org/packages/97/1e/98aaddf272552d9fef1f0296a9939d1487914a239e98678f6b20f8b0a5c8/numcodecs-0.16.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b554ab9ecf69de7ca2b6b5e8bc696bd9747559cb4dd5127bd08d7a28bec59c3a", size = 8534814, upload-time = "2025-11-21T02:49:28.547Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad1a379a45bd3491deab8ae6548313946744f868c21d5340116977ea3be5b1d6", size = 9173471, upload-time = "2025-11-21T02:49:30.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/20/2fdec87fc7f8cec950d2b0bea603c12dc9f05b4966dc5924ba5a36a61bf6/numcodecs-0.16.5-cp312-cp312-win_amd64.whl", hash = "sha256:845a9857886ffe4a3172ba1c537ae5bcc01e65068c31cf1fce1a844bd1da050f", size = 801412, upload-time = "2025-11-21T02:49:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/38/38/071ced5a5fd1c85ba0e14ba721b66b053823e5176298c2f707e50bed11d9/numcodecs-0.16.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25be3a516ab677dad890760d357cfe081a371d9c0a2e9a204562318ac5969de3", size = 1654359, upload-time = "2025-11-21T02:49:33.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/5f84ba7525577c1b9909fc2d06ef11314825fc4ad4378f61d0e4c9883b4a/numcodecs-0.16.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0107e839ef75b854e969cb577e140b1aadb9847893937636582d23a2a4c6ce50", size = 1144237, upload-time = "2025-11-21T02:49:35.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/00/787ea5f237b8ea7bc67140c99155f9c00b5baf11c49afc5f3bfefa298f95/numcodecs-0.16.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:015a7c859ecc2a06e2a548f64008c0ec3aaecabc26456c2c62f4278d8fc20597", size = 8483064, upload-time = "2025-11-21T02:49:36.454Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e6/d359fdd37498e74d26a167f7a51e54542e642ea47181eb4e643a69a066c3/numcodecs-0.16.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84230b4b9dad2392f2a84242bd6e3e659ac137b5a1ce3571d6965fca673e0903", size = 9126063, upload-time = "2025-11-21T02:49:38.018Z" },
+    { url = "https://files.pythonhosted.org/packages/27/72/6663cc0382ddbb866136c255c837bcb96cc7ce5e83562efec55e1b995941/numcodecs-0.16.5-cp313-cp313-win_amd64.whl", hash = "sha256:5088145502ad1ebf677ec47d00eb6f0fd600658217db3e0c070c321c85d6cf3d", size = 799275, upload-time = "2025-11-21T02:49:39.558Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9e/38e7ca8184c958b51f45d56a4aeceb1134ecde2d8bd157efadc98502cc42/numcodecs-0.16.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b05647b8b769e6bc8016e9fd4843c823ce5c9f2337c089fb5c9c4da05e5275de", size = 1654721, upload-time = "2025-11-21T02:49:40.602Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/37/260fa42e7b2b08e6e00ad632f8dd620961a60a459426c26cea390f8c68d0/numcodecs-0.16.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3832bd1b5af8bb3e413076b7d93318c8e7d7b68935006b9fa36ca057d1725a8f", size = 1146887, upload-time = "2025-11-21T02:49:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/15/e2e1151b5a8b14a15dfd4bb4abccce7fff7580f39bc34092780088835f3a/numcodecs-0.16.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f7b7d24f103187f53135bed28bb9f0ed6b2e14c604664726487bb6d7c882e1", size = 8476987, upload-time = "2025-11-21T02:49:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/30/16a57fc4d9fb0ba06c600408bd6634f2f1753c54a7a351c99c5e09b51ee2/numcodecs-0.16.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aec9736d81b70f337d89c4070ee3ffeff113f386fd789492fa152d26a15043e4", size = 9102377, upload-time = "2025-11-21T02:49:45.508Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a5/a0425af36c20d55a3ea884db4b4efca25a43bea9214ba69ca7932dd997b4/numcodecs-0.16.5-cp314-cp314-win_amd64.whl", hash = "sha256:b16a14303800e9fb88abc39463ab4706c037647ac17e49e297faa5f7d7dbbf1d", size = 819022, upload-time = "2025-11-21T02:49:47.39Z" },
 ]
 
 [[package]]
@@ -1907,6 +1946,9 @@ qudt = [
 s3 = [
     { name = "boto3" },
 ]
+zarr = [
+    { name = "zarr" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1939,8 +1981,9 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "typer", specifier = ">=0.15" },
+    { name = "zarr", marker = "extra == 'zarr'", specifier = ">=2.18" },
 ]
-provides-extras = ["gcs", "s3", "qudt"]
+provides-extras = ["gcs", "s3", "qudt", "zarr"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2101,4 +2144,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "donfig" },
+    { name = "google-crc32c" },
+    { name = "numcodecs" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/8d/aeb164004f87543b06ef54f885d02c342c31ceb274e2bbec470a98927621/zarr-3.2.1.tar.gz", hash = "sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035", size = 675161, upload-time = "2026-05-05T12:37:22.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl", hash = "sha256:f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7", size = 319617, upload-time = "2026-05-05T12:37:20.66Z" },
 ]


### PR DESCRIPTION
## Summary

- Adds `ZarrStoreHandler` (`StoreFormatHandler` v2) that reads/writes local Zarr directory stores into/from `Asset(kind=AssetKind.ARRAY)`.
- Embeds sunstone `Metadata` as JSON-LD in the root group's `.attrs["sunstone"]`.
- Also writes CF-convention per-variable attrs (`units`, `long_name`, `description`) for interop with xarray, Panoply, ncdump, etc.
- New optional dependency extra: `[zarr]` (`zarr>=2.18`).

## Notes

- **Zarr v2 vs v3:** pyproject pins `zarr>=2.18` but `uv` resolves to `3.2.1`. Handler is written version-agnostic (sniffs both `.zgroup`/`.zarray` and `zarr.json` markers, uses `group[name] = arr` shorthand). Only CI-tested against 3.2.1.
- **Remote stores (`gs://`, `s3://`) are not yet supported** — local directory only in v1. Routing through `URLHandler` is a follow-up.
- **CF attrs do double duty** as both ecosystem interop and the per-variable `ComponentSchema` round-trip path (since `Metadata.to_jsonld()` doesn't yet emit `component_metadata`).

## Test plan

- [x] `uv sync --extra zarr` succeeds
- [x] `uv run pytest tests/test_handlers_zarr.py -v` — 8 passed
- [x] `uv run pytest` — 1180 passed (full suite)
- [x] pre-commit hooks clean