### PR TITLE
feat: HDF5/NetCDF-4 store format handler for AssetKind.ARRAY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: HDF5 / NetCDF-4 store-format handler for `AssetKind.ARRAY` via the `[hdf5]` extra (#66).
+- Changed: `sunstone.read()` dispatches single-file paths to store-format handlers, enabling HDF5/NetCDF-4 routing.
 - Added: Zarr store-format handler for `AssetKind.ARRAY` via the `[zarr]` extra (#65).
 - Added: NumPy `.npz` format handler for `AssetKind.ARRAY` (#64).
 - Added: Asset envelope — generic format handler protocol supporting non-tabular kinds (raster/array/tile).

--- a/docs/tensors.md
+++ b/docs/tensors.md
@@ -8,8 +8,8 @@ is `dict[str, numpy.ndarray]` keyed by variable name.
 - **AssetKind:** `AssetKind.ARRAY`
 - **Payload:** `dict[str, numpy.ndarray]`
 - **Typed accessor:** `Asset.as_array() -> dict[str, numpy.ndarray]`
-- **Status:** Asset envelope ready. NumPy `.npz` and Zarr (local
-  directory store) are supported today; NetCDF/HDF5 is on the roadmap.
+- **Status:** Asset envelope ready. NumPy `.npz`, Zarr (local
+  directory store), and HDF5 / NetCDF-4 are all supported today.
 
 ## Why a dict, not a single ndarray
 
@@ -42,12 +42,20 @@ ARRAY is for many.
   variable's `units` / `long_name` / `description` onto the array's
   `.attrs` for ecosystem interop (xarray, Panoply, ncview, ...).
   Works with both zarr v2 (`>=2.18`) and zarr v3.
+- **HDF5 / NetCDF-4 handler** (`sunstone.handlers_hdf5.Hdf5StoreHandler`)
+  round-trips `dict[str, numpy.ndarray]` payloads plus the full
+  sunstone `Metadata` blob (stored as JSON-LD in the root HDF5
+  attribute `sunstone`). Supports `.h5`, `.hdf5`, `.he5`, `.nc`,
+  `.nc4` extensions. Install with `sunstone-py[hdf5]`. NetCDF-3
+  (classic) is out of scope — only NetCDF-4, which is HDF5
+  underneath, is supported. Per-variable `ComponentSchema.units`
+  and `ComponentSchema.description` are also written as CF-style
+  HDF5 attributes (`units`, `long_name`, `description`) so xarray,
+  ncdump, Panoply, MATLAB and other CF-aware tools read the same
+  file without sunstone in the loop.
 
 ## What's coming
 
-- **NetCDF** / HDF5 — single-file with random-access semantics;
-  handler choice depends on whether the underlying library is
-  stream-friendly.
 - **Remote Zarr stores** (`gs://`, `s3://`) — the v1 Zarr handler is
   local-directory only. Object-store routing through the URLHandler
   registry is planned.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ qudt = [
 zarr = [
     "zarr>=2.18",
 ]
+hdf5 = [
+    "h5py>=3.10",
+]
 
 [project.license]
 text = "MIT"
@@ -93,6 +96,7 @@ overrides = [
     { module = "tests.*", disallow_untyped_defs = false },
     { module = "ontopint", ignore_missing_imports = true },
     { module = "zarr", ignore_missing_imports = true },
+    { module = "h5py", ignore_missing_imports = true },
 ]
 
 [tool.pytest.ini_options]

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -135,6 +135,14 @@ def read(
             return handler.read(loc, **kw)  # type: ignore[attr-defined,no-any-return]
         # Fall through to stream path so single-file handlers can still claim
         # directory-like paths via can_read.
+    else:
+        # Single-file store handlers (HDF5, NetCDF-4, ...) live behind the
+        # store-format protocol because their libraries need a real path, not
+        # a stream. Give them a shot before falling through to the tabular
+        # stream path.
+        handler = registry.find_store_format_reader(loc, format)
+        if handler is not None:
+            return handler.read(loc, **kw)  # type: ignore[attr-defined,no-any-return]
 
     return _read_tabular_asset(path, format=format, **kw)
 

--- a/src/sunstone/handlers_hdf5.py
+++ b/src/sunstone/handlers_hdf5.py
@@ -1,0 +1,204 @@
+"""HDF5 / NetCDF-4 store-format handler.
+
+Reads and writes ``AssetKind.ARRAY`` assets (a ``dict[str, numpy.ndarray]``
+payload) backed by an HDF5 file. Embeds sunstone :class:`Metadata` as a
+JSON-LD blob in the file root's ``sunstone`` attribute, and writes
+CF-convention per-variable attributes (``units``, ``long_name``,
+``description``) for ecosystem interop with xarray, ncdump, Panoply, etc.
+
+NetCDF-4 files (``.nc`` / ``.nc4``) are HDF5 underneath and are handled
+through the same code path. NetCDF-3 (classic) is out of scope.
+
+This is a :class:`~sunstone.resource.StoreFormatHandler` (protocol v2)
+because h5py needs a real filesystem path, not a stream.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from .asset import Asset, AssetKind
+from .component import ComponentSchema
+from .errors import IncompatibleAssetKindError
+from .lineage import Metadata
+
+if TYPE_CHECKING:
+    from .resource import ResourceLocation
+
+
+class Hdf5StoreHandler:
+    """HDF5 / NetCDF-4 store-format handler for ``AssetKind.ARRAY`` payloads."""
+
+    __sunstone_handler_protocol__ = 2
+
+    _METADATA_KEY = "sunstone"
+    _EXTENSIONS = (".h5", ".hdf5", ".he5", ".nc", ".nc4")
+
+    # ---- Capability predicates --------------------------------------------------
+
+    def supports_native_metadata_extraction(self) -> bool:
+        """CF-convention per-variable attrs (``units``, ``long_name``) are
+        treated as native sidecar metadata."""
+        return True
+
+    def supports_sunstone_metadata_embedding(self) -> bool:
+        """The full sunstone :class:`Metadata` is round-tripped as JSON-LD in
+        the file root's ``sunstone`` attribute."""
+        return True
+
+    def supports_metadata(self) -> bool:
+        """Legacy alias for :meth:`supports_sunstone_metadata_embedding`."""
+        return self.supports_sunstone_metadata_embedding()
+
+    def supported_kinds(self) -> tuple[AssetKind, ...]:
+        return (AssetKind.ARRAY,)
+
+    # ---- Format detection -------------------------------------------------------
+
+    def _matches(self, location: "ResourceLocation", format: str | None) -> bool:
+        if format is not None:
+            return format.lower() in ("hdf5", "h5", "netcdf4", "netcdf", "nc")
+        suffix = PurePosixPath(location.path).suffix.lower()
+        return suffix in self._EXTENSIONS
+
+    def can_read_store(self, location: "ResourceLocation", format: str | None) -> bool:
+        if not self._matches(location, format):
+            return False
+        # The file must exist for a read.
+        return location.as_path().is_file()
+
+    def can_write_store(self, location: "ResourceLocation", format: str | None) -> bool:
+        # Writes do not require the file to exist yet.
+        return self._matches(location, format)
+
+    # ---- Read -------------------------------------------------------------------
+
+    def read(self, location: "ResourceLocation", **kwargs: Any) -> Asset:
+        import h5py  # type: ignore[import-untyped]
+        import numpy as np
+
+        # Drop dispatch-only kwargs we forward from sunstone.read/write.
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+
+        payload: dict[str, np.ndarray] = {}
+        metadata = Metadata()
+
+        with h5py.File(location.path, "r") as f:
+            # Root-level sunstone metadata blob (JSON-LD).
+            raw = f.attrs.get(self._METADATA_KEY)
+            if raw is not None:
+                try:
+                    if isinstance(raw, (bytes, bytearray)):
+                        doc = json.loads(raw.decode("utf-8"))
+                    elif isinstance(raw, np.ndarray):
+                        # h5py may return scalar string attrs as 0-d arrays.
+                        item = raw.item()
+                        if isinstance(item, bytes):
+                            item = item.decode("utf-8")
+                        doc = json.loads(item)
+                    else:
+                        doc = json.loads(str(raw))
+                    metadata = Metadata.from_jsonld(doc)
+                except Exception:
+                    metadata = Metadata()
+
+            # Walk top-level datasets only (v1 — no nested groups).
+            for name, obj in f.items():
+                if isinstance(obj, h5py.Dataset):
+                    payload[name] = np.asarray(obj[()])
+
+                    # Synthesize ComponentSchema from CF attrs if the JSON-LD
+                    # blob didn't already restore one.
+                    if name not in metadata.component_metadata:
+                        cs = _component_from_attrs(name, obj.attrs)
+                        if cs is not None:
+                            metadata.component_metadata[name] = cs
+
+        return Asset(payload=payload, kind=AssetKind.ARRAY, metadata=metadata)
+
+    # ---- Write ------------------------------------------------------------------
+
+    def write(self, asset: Asset, location: "ResourceLocation", **kwargs: Any) -> None:
+        import h5py  # type: ignore[import-untyped]
+
+        # Drop dispatch-only kwargs.
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+
+        if asset.kind is not AssetKind.ARRAY:
+            raise IncompatibleAssetKindError(expected=AssetKind.ARRAY, actual=asset.kind)
+
+        payload = asset.as_array()
+
+        # Ensure parent directory exists for nested write locations.
+        target = location.as_path()
+        if target.parent:
+            target.parent.mkdir(parents=True, exist_ok=True)
+
+        with h5py.File(target, "w") as f:
+            for name, arr in payload.items():
+                ds = f.create_dataset(name, data=arr, **kwargs)
+                cs = asset.metadata.component_metadata.get(name)
+                if cs is not None:
+                    _write_cf_attrs(ds, cs)
+
+            # Root attr: full sunstone metadata as JSON-LD.
+            doc = asset.metadata.to_jsonld()
+            f.attrs[self._METADATA_KEY] = json.dumps(doc)
+
+
+def _component_from_attrs(name: str, attrs: Any) -> ComponentSchema | None:
+    """Build a :class:`ComponentSchema` from CF-style HDF5 attrs.
+
+    Returns ``None`` if no recognised attrs are present.
+    """
+    units = _str_attr(attrs.get("units"))
+    long_name = _str_attr(attrs.get("long_name"))
+    description = _str_attr(attrs.get("description"))
+    if units is None and long_name is None and description is None:
+        return None
+    # Prefer description over long_name when both are present.
+    desc = description if description is not None else long_name
+    return ComponentSchema(
+        name=name,
+        component_kind="variable",
+        units=units,
+        description=desc,
+    )
+
+
+def _write_cf_attrs(dataset: Any, cs: ComponentSchema) -> None:
+    """Write CF-convention per-variable attributes to an HDF5 dataset."""
+    if cs.units is not None:
+        dataset.attrs["units"] = cs.units
+    if cs.description is not None:
+        # CF convention: long_name is the human-readable label.
+        dataset.attrs["long_name"] = cs.description
+        # Also mirror to "description" for tools that prefer that key.
+        dataset.attrs["description"] = cs.description
+
+
+def _str_attr(value: Any) -> str | None:
+    """Decode an h5py attribute value into a plain ``str`` or ``None``."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    try:
+        import numpy as np
+    except ImportError:  # pragma: no cover - numpy is a hard dep
+        np = None  # type: ignore[assignment]
+    if np is not None and isinstance(value, np.ndarray):
+        if value.shape == ():
+            item = value.item()
+            if isinstance(item, bytes):
+                return item.decode("utf-8")
+            return str(item)
+        return None
+    return str(value)

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -231,6 +231,13 @@ class PluginRegistry:
         except ImportError:
             pass  # zarr not installed
 
+        try:
+            from .handlers_hdf5 import Hdf5StoreHandler
+
+            self._store_format_handlers.append(Hdf5StoreHandler())
+        except ImportError:
+            pass  # h5py extra not installed
+
         # Internal handlers last (fallback)
         from .handlers import BuiltinFormatHandler, HttpURLHandler, ParquetFormatHandler
 

--- a/tests/test_handlers_hdf5.py
+++ b/tests/test_handlers_hdf5.py
@@ -1,0 +1,178 @@
+"""Tests for the HDF5 / NetCDF-4 store-format handler."""
+
+from __future__ import annotations
+
+import pytest
+
+h5py = pytest.importorskip("h5py")
+
+import numpy as np  # noqa: E402
+
+import sunstone  # noqa: E402
+from sunstone.asset import Asset, AssetKind  # noqa: E402
+from sunstone.component import ComponentSchema  # noqa: E402
+from sunstone.errors import IncompatibleAssetKindError  # noqa: E402
+from sunstone.handlers_hdf5 import Hdf5StoreHandler  # noqa: E402
+from sunstone.lineage import Metadata  # noqa: E402
+from sunstone.resource import ResourceLocation  # noqa: E402
+
+
+def _make_array_asset(payload: dict[str, np.ndarray], *, metadata: Metadata | None = None) -> Asset:
+    return Asset(
+        payload=payload,
+        kind=AssetKind.ARRAY,
+        metadata=metadata or Metadata(),
+    )
+
+
+def test_round_trip_arrays_only(tmp_path):
+    payload = {
+        "temperature": np.array([[273.15, 280.5], [290.0, 295.25]], dtype="float32"),
+        "pressure": np.array([1013, 1009, 1005, 1001], dtype="int32"),
+        "humidity": np.linspace(0.0, 1.0, 8, dtype="float64"),
+    }
+    asset = _make_array_asset(payload)
+
+    target = tmp_path / "vars.h5"
+    handler = Hdf5StoreHandler()
+    loc = ResourceLocation(path=str(target))
+
+    assert handler.can_write_store(loc, None) is True
+    handler.write(asset, loc)
+    assert target.exists()
+
+    assert handler.can_read_store(loc, None) is True
+    read_back = handler.read(loc)
+
+    assert read_back.kind is AssetKind.ARRAY
+    arrays = read_back.as_array()
+    assert set(arrays.keys()) == set(payload.keys())
+    for name, original in payload.items():
+        np.testing.assert_array_equal(arrays[name], original)
+        assert arrays[name].dtype == original.dtype
+
+
+def test_round_trip_with_metadata(tmp_path):
+    payload = {
+        "temperature": np.array([273.15, 290.0, 305.0], dtype="float32"),
+        "wind_speed": np.array([1.5, 2.3, 0.8], dtype="float32"),
+    }
+    metadata = Metadata(
+        slug="weather-sample",
+        name="Weather Sample",
+        description="Tiny synthetic weather sample for round-trip testing.",
+    )
+    metadata.component_metadata["temperature"] = ComponentSchema(
+        name="temperature",
+        component_kind="variable",
+        units="kelvin",
+        description="2-metre air temperature",
+    )
+    asset = _make_array_asset(payload, metadata=metadata)
+
+    target = tmp_path / "weather.h5"
+    handler = Hdf5StoreHandler()
+    loc = ResourceLocation(path=str(target))
+    handler.write(asset, loc)
+
+    read_back = handler.read(loc)
+    assert read_back.metadata.slug == "weather-sample"
+    assert read_back.metadata.name == "Weather Sample"
+    assert read_back.metadata.description.startswith("Tiny synthetic")
+
+    cs = read_back.metadata.component_metadata.get("temperature")
+    assert cs is not None
+    assert cs.component_kind == "variable"
+    assert cs.units == "kelvin"
+    assert cs.description == "2-metre air temperature"
+
+
+def test_cf_attrs_visible_on_disk(tmp_path):
+    payload = {"temperature": np.array([273.15, 290.0], dtype="float32")}
+    metadata = Metadata(slug="cf-demo", name="CF demo")
+    metadata.component_metadata["temperature"] = ComponentSchema(
+        name="temperature",
+        component_kind="variable",
+        units="kelvin",
+        description="2-metre air temperature",
+    )
+    asset = _make_array_asset(payload, metadata=metadata)
+
+    target = tmp_path / "cf.h5"
+    Hdf5StoreHandler().write(asset, ResourceLocation(path=str(target)))
+
+    # Open with raw h5py to verify on-disk CF attrs are present.
+    with h5py.File(target, "r") as f:
+        ds = f["temperature"]
+        units = ds.attrs["units"]
+        long_name = ds.attrs["long_name"]
+        if isinstance(units, bytes):
+            units = units.decode("utf-8")
+        if isinstance(long_name, bytes):
+            long_name = long_name.decode("utf-8")
+        assert units == "kelvin"
+        assert long_name == "2-metre air temperature"
+        # Root-level sunstone JSON-LD blob also there.
+        assert "sunstone" in f.attrs
+
+
+def test_read_unknown_hdf5_without_sunstone_attr(tmp_path):
+    target = tmp_path / "plain.h5"
+    # Build a plain HDF5 file with raw h5py and no sunstone attr.
+    with h5py.File(target, "w") as f:
+        f.create_dataset("alpha", data=np.arange(6, dtype="int16"))
+        f.create_dataset("beta", data=np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float64"))
+
+    asset = Hdf5StoreHandler().read(ResourceLocation(path=str(target)))
+    assert asset.kind is AssetKind.ARRAY
+    assert asset.metadata.slug is None
+    assert asset.metadata.name is None
+    arrays = asset.as_array()
+    np.testing.assert_array_equal(arrays["alpha"], np.arange(6, dtype="int16"))
+    np.testing.assert_array_equal(arrays["beta"], np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float64"))
+
+
+def test_write_rejects_non_array_kind(tmp_path):
+    import pandas as pd
+
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    tabular_asset = Asset(payload=df, kind=AssetKind.TABULAR, metadata=Metadata())
+
+    target = tmp_path / "wrong.h5"
+    with pytest.raises(IncompatibleAssetKindError):
+        Hdf5StoreHandler().write(tabular_asset, ResourceLocation(path=str(target)))
+
+
+def test_top_level_read_dispatches_to_hdf5(tmp_path):
+    # Sanity check: top-level sunstone.read() routes a single-file HDF5 path
+    # through the store-handler path even though it's not a directory.
+    payload = {"counts": np.array([10, 20, 30], dtype="int64")}
+    asset = _make_array_asset(payload, metadata=Metadata(slug="top-level", name="Top level"))
+
+    target = tmp_path / "single.h5"
+    Hdf5StoreHandler().write(asset, ResourceLocation(path=str(target)))
+
+    result = sunstone.read(str(target))
+    assert result.kind is AssetKind.ARRAY
+    arrays = result.as_array()
+    np.testing.assert_array_equal(arrays["counts"], payload["counts"])
+
+
+def test_nc_extension_also_works(tmp_path):
+    # NetCDF-4 files are HDF5 underneath — the .nc extension must also be
+    # recognised by the handler.
+    payload = {"temperature": np.array([280.0, 290.0, 300.0], dtype="float32")}
+    asset = _make_array_asset(payload)
+
+    target = tmp_path / "sample.nc"
+    handler = Hdf5StoreHandler()
+    loc = ResourceLocation(path=str(target))
+
+    assert handler.can_write_store(loc, None) is True
+    handler.write(asset, loc)
+
+    assert handler.can_read_store(loc, None) is True
+    read_back = sunstone.read(str(target))
+    assert read_back.kind is AssetKind.ARRAY
+    arrays = read_back.as_array()
+    np.testing.assert_array_equal(arrays["temperature"], payload["temperature"])

--- a/uv.lock
+++ b/uv.lock
@@ -627,6 +627,49 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3c/7fcd9b4c9eed82e91fb15568992561019ae7a829d1f696b2c844355d95dd/h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65", size = 3678608, upload-time = "2026-03-06T13:48:35.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b7/9366ed44ced9b7ef357ab48c94205280276db9d7f064aa3012a97227e966/h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210", size = 3054773, upload-time = "2026-03-06T13:48:37.139Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/4964bc0e91e86340c2bbda83420225b2f770dcf1eb8a39464871ad769436/h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965", size = 5198886, upload-time = "2026-03-06T13:48:38.879Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/16/d905e7f53e661ce2c24686c38048d8e2b750ffc4350009d41c4e6c6c9826/h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd", size = 5404883, upload-time = "2026-03-06T13:48:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f2/58f34cb74af46d39f4cd18ea20909a8514960c5a3e5b92fd06a28161e0a8/h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c", size = 5192039, upload-time = "2026-03-06T13:48:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ca/934a39c24ce2e2db017268c08da0537c20fa0be7e1549be3e977313fc8f5/h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc", size = 5421526, upload-time = "2026-03-06T13:48:44.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/14/615a450205e1b56d16c6783f5ccd116cde05550faad70ae077c955654a75/h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab", size = 3183263, upload-time = "2026-03-06T13:48:47.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/a6faef5ed632cae0c65ac6b214a6614a0b510c3183532c521bdb0055e117/h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63", size = 2663450, upload-time = "2026-03-06T13:48:48.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/0c8bb8aedb62c772cf7c1d427c7d1951477e8c2835f872bc0a13d1f85f86/h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491", size = 3760693, upload-time = "2026-03-06T13:48:50.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/fcc5977d32d6387c5c9a694afee716a5e20658ac08b3ff24fdec79fb05f2/h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618", size = 3181305, upload-time = "2026-03-06T13:48:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/af87f64b9f986889884243643621ebbd4ac72472ba8ec8cec891ac8e2ca1/h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242", size = 5074061, upload-time = "2026-03-06T13:48:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d0/146f5eaff3dc246a9c7f6e5e4f42bd45cc613bce16693bcd4d1f7c958bf5/h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16", size = 5279216, upload-time = "2026-03-06T13:48:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/12a13424f1e604fc7df9497b73c0356fb78c2fb206abd7465ce47226e8fd/h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7", size = 5070068, upload-time = "2026-03-06T13:48:59.169Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1940,6 +1983,9 @@ dependencies = [
 gcs = [
     { name = "google-cloud-storage" },
 ]
+hdf5 = [
+    { name = "h5py" },
+]
 qudt = [
     { name = "ontopint" },
 ]
@@ -1972,6 +2018,7 @@ requires-dist = [
     { name = "frictionless", specifier = ">=5.18.1" },
     { name = "google-auth", specifier = ">=2.43.0" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.0" },
+    { name = "h5py", marker = "extra == 'hdf5'", specifier = ">=3.10" },
     { name = "ontopint", marker = "extra == 'qudt'", specifier = ">=0.1" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
@@ -1983,7 +2030,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.15" },
     { name = "zarr", marker = "extra == 'zarr'", specifier = ">=2.18" },
 ]
-provides-extras = ["gcs", "s3", "qudt", "zarr"]
+provides-extras = ["gcs", "s3", "qudt", "zarr", "hdf5"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Adds `Hdf5StoreHandler` (`StoreFormatHandler` v2) that reads/writes `.h5`/`.hdf5`/`.nc`/`.nc4` files into/from `Asset(kind=AssetKind.ARRAY)`.
- Embeds sunstone `Metadata` as JSON-LD in the root HDF5 attribute `sunstone`.
- Also writes CF-convention per-variable attrs (`units`, `long_name`, `description`) for interop with h5dump, ncdump, xarray, Panoply, MATLAB, etc.
- Small surgical patch to `sunstone.read()`: non-directory paths now also consult store-format handlers before falling through to the tabular stream path. This is what enables single-file store handlers like HDF5.
- New optional dependency extra: `[hdf5]` (`h5py>=3.10`).
- Closes #8 (HDF5 lineage JSON sidecars) — obsoleted by native attribute embedding.

## Notes

- **Top-level datasets only in v1.** Nested HDF5 groups (NetCDF dimension scales, hierarchical layouts) are silently ignored on read. A "groups → nested dict" extension is a separate piece of work.
- **Local paths only.** Remote HDF5 (`gs://foo.h5`, `s3://bar.nc`) is out of scope; h5py supports neither natively without `ros3`/`fsspec`.
- **NetCDF-3 (classic) is out of scope.** Only NetCDF-4 (which is HDF5 underneath) is supported.

## Test plan

- [x] `uv sync --extra hdf5` succeeds
- [x] `uv run pytest tests/test_handlers_hdf5.py -v` — 7 passed
- [x] `uv run pytest` — 1179 passed (full suite)
- [x] pre-commit hooks clean