### PR TITLE
Refactor env config to generic schema with plugin-owned sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-- Added: SPDX license registry and per-output `license:` field with write-time
-  compatibility checks on `to_csv`/`to_parquet` (closes #13).
-- Added: `sunstone license check [SLUG]` and `sunstone license list` CLI commands
-  (with `--json`).
-- Added: writers auto-derive a missing output license from sources (most restrictive wins);
-  incompatible sources now raise instead of warn.
-- Added: `NLOD-1.0`, `NLOD-2.0`, `CC-BY-3.0-IGO`, and `CC-BY-NC-SA-3.0-IGO` to the license
-  registry.
-- Changed: `sunstone dataset validate` flags non-SPDX license identifiers (LicenseRef-*
-  still accepted).
-- Added: attribution chain traversal and `sunstone lineage attribution` CLI (text, markdown,
-  HTML); source `attributedTo` and `license` denormalized into `datasets.lock.yaml` for
-  self-contained lineage (closes #15).
-- Added: per-dataset `dialect:` block (`delimiter`, `quoteChar`, `header`) for `text/csv`
-  reads and writes.
-- Added: `docs/formats.md` documenting supported file formats, metadata strategy, and the CSV
-  dialect block.
+- Added: SPDX license registry and per-output `license:` field with write-time compatibility checks on `to_csv`/`to_parquet` (closes #13).
+- Added: `sunstone license check [SLUG]` and `sunstone license list` CLI commands (with `--json`).
+- Added: writers auto-derive a missing output license from sources (most restrictive wins); incompatible sources now raise instead of warn.
+- Added: `NLOD-1.0`, `NLOD-2.0`, `CC-BY-3.0-IGO`, and `CC-BY-NC-SA-3.0-IGO` to the license registry.
+- Changed: `sunstone dataset validate` flags non-SPDX license identifiers (LicenseRef-* still accepted).
+- Added: attribution chain traversal and `sunstone lineage attribution` CLI (text, markdown, HTML); source `attributedTo` and `license` denormalized into `datasets.lock.yaml` for self-contained lineage (closes #15).
+- Added: per-dataset `dialect:` block (`delimiter`, `quoteChar`, `header`) for `text/csv` reads and writes.
+- Added: `docs/formats.md` documenting supported file formats, metadata strategy, and the CSV dialect block.
+- Changed: environments are a generic key-value bag; plugins register typed sections via `EnvSectionProvider`.
+- Added: active-environment keys flow into `os.environ`, so `${VAR}` substitution in `publish.as:` / `publish.to:` resolves to them.
+- Added: `sunstone.activate_environment()` helper for notebook/library use.
+- Added: `sunstone env set` and `sunstone env unset` accept `KEY=VAL` (dotted keys target plugin subtables).
+- Changed: `sunstone env add` takes positional `KEY=VAL` entries (dotted keys write to plugin subtables).
+- Removed: `DataEnvironment.{catalog_url,s3_endpoint,s3_access_key,s3_secret_key,auth}` (now a deprecated alias for `Environment`).
+- Removed: `SUNSTONE_DATA_CATALOG_URL` and `SUNSTONE_DATA_S3_*` per-field env-var overrides.
+- Removed: `--catalog-url`/`--s3-endpoint`/`--s3-*`/`--auth` flags on `env add`.
+- Removed: `sunstone env update` (use `env set`).
 
 ## [1.10.0] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added: active-environment keys flow into `os.environ`, so `${VAR}` substitution in `publish.as:` / `publish.to:` resolves to them.
 - Added: `sunstone.activate_environment()` helper for notebook/library use.
 - Added: `sunstone env set` and `sunstone env unset` accept `KEY=VAL` (dotted keys target plugin subtables).
+- Added: `--scope user|project|system` on `sunstone env add`/`set`/`unset`/`remove` (default user) to target any config layer.
 - Changed: `sunstone env add` takes positional `KEY=VAL` entries (dotted keys write to plugin subtables).
 - Removed: `DataEnvironment.{catalog_url,s3_endpoint,s3_access_key,s3_secret_key,auth}` (now a deprecated alias for `Environment`).
 - Removed: `SUNSTONE_DATA_CATALOG_URL` and `SUNSTONE_DATA_S3_*` per-field env-var overrides.

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -64,7 +64,7 @@ from .lineage import (
 from .plugins import AuthProvider, CLIProvider, FormatHandler, PluginRegistry, URLHandler
 
 # Environment config
-from .env import DataEnvironment, resolve_environment
+from .env import DataEnvironment, Environment, resolve_environment
 
 # Packaging (library functions for building and pushing data packages)
 from . import packaging
@@ -172,6 +172,7 @@ __all__ = [
     "PluginRegistry",
     # Environment config
     "DataEnvironment",
+    "Environment",
     "resolve_environment",
     # Packaging
     "packaging",

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -64,7 +64,7 @@ from .lineage import (
 from .plugins import AuthProvider, CLIProvider, FormatHandler, PluginRegistry, URLHandler
 
 # Environment config
-from .env import DataEnvironment, Environment, resolve_environment
+from .env import DataEnvironment, Environment, activate_environment, resolve_environment
 
 # Packaging (library functions for building and pushing data packages)
 from . import packaging
@@ -171,6 +171,7 @@ __all__ = [
     "FormatHandler",
     "PluginRegistry",
     # Environment config
+    "activate_environment",
     "DataEnvironment",
     "Environment",
     "resolve_environment",

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -421,9 +421,22 @@ _mount_plugin_cli_groups()
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version: bool = typer.Option(False, "--version", callback=_version_callback, is_eager=True, help="Show version"),
 ) -> None:
     """Sunstone dataset and package management CLI."""
+    # Best-effort: layer active-environment vars onto os.environ so that
+    # ${VAR} substitution in publish.as: / publish.to: and other places
+    # picks them up. Env subcommands must remain usable even when
+    # resolution fails (so the user can fix the config).
+    skip_activation = ctx.invoked_subcommand == "env"
+    if not skip_activation:
+        try:
+            from sunstone.env import activate_environment
+
+            activate_environment()
+        except Exception as e:
+            logger.debug("activate_environment failed during CLI startup: %s", e)
 
 
 # =============================================================================

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -465,7 +465,7 @@ def env_show(ctx: typer.Context) -> None:
 
 
 def _summarize_env_def(defn: dict) -> str:
-    """Build a one-line summary: 'N keys, sections: foo, bar' or 'empty'."""
+    """Build a one-line summary: 'N key(s), sections: foo, bar' or 'empty'."""
     plain_keys = [k for k, v in defn.items() if not isinstance(v, dict)]
     sections = sorted(k for k, v in defn.items() if isinstance(v, dict))
     parts: list[str] = []

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -530,86 +530,40 @@ def env_remove(
         raise typer.Exit(1)
 
 
-@env_app.command("update")
-def env_update(
-    name: str = typer.Argument(..., help="Environment name to update"),
-    catalog_url: str | None = typer.Option(None, "--catalog-url", help="Nessie catalog URL"),
-    s3_endpoint: str | None = typer.Option(None, "--s3-endpoint", help="S3/MinIO endpoint URL"),
-    s3_access_key: str | None = typer.Option(None, "--s3-access-key", help="S3 access key or op:// reference"),
-    s3_secret_key: str | None = typer.Option(None, "--s3-secret-key", help="S3 secret key or op:// reference"),
-    auth: str | None = typer.Option(None, "--auth", help="Auth method"),
+@env_app.command("set")
+def env_set(
+    name: str = typer.Argument(..., help="Environment name"),
+    entries: list[str] = typer.Argument(
+        ...,
+        help=(
+            "KEY=VAL entries to merge into the environment. Dotted keys "
+            "(e.g. data-platform.warehouse=main) target plugin subtables."
+        ),
+    ),
 ) -> None:
-    """Update fields on an existing environment in user config."""
-    from sunstone.env import (
-        _SYSTEM_CONFIG,
-        _find_project_config,
-        _get_user_config_path,
-        _load_toml,
-        _write_config,
-    )
+    """Merge KEY=VAL entries into an existing environment in user config.
+
+    Existing keys not touched by this invocation are preserved. Use
+    'env unset' to remove keys.
+    """
+    from sunstone.env import update_environment
 
     try:
-        user_config = _get_user_config_path(required=True)
-    except RuntimeError as e:
+        plain, sections = _parse_kv_entries(entries)
+    except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
-    user_data = _load_toml(user_config)
-    user_envs = user_data.get("environments", {})
-    project_config = _find_project_config()
-    project_data = _load_toml(project_config) if project_config else {}
-    system_data = _load_toml(_SYSTEM_CONFIG)
-
-    if name not in user_envs:
-        if name in project_data.get("environments", {}):
-            typer.echo(
-                f"Error: Environment '{name}' is defined in project config ({project_config}); "
-                "env update only modifies user config",
-                err=True,
-            )
-            raise typer.Exit(1)
-        if name in system_data.get("environments", {}):
-            typer.echo(
-                f"Error: Environment '{name}' is defined in system config ({_SYSTEM_CONFIG}); "
-                "env update only modifies user config",
-                err=True,
-            )
-            raise typer.Exit(1)
-        typer.echo(f"Error: Environment '{name}' not found in {user_config}", err=True)
-        raise typer.Exit(1)
-
-    if all(value is None for value in (catalog_url, s3_endpoint, s3_access_key, s3_secret_key, auth)):
-        typer.echo(
-            "Error: No fields to update. Use --catalog-url, --s3-endpoint, --s3-access-key, "
-            "--s3-secret-key, or --auth.",
-            err=True,
-        )
-        raise typer.Exit(1)
-
-    shadowed_by_project = name in project_data.get("environments", {})
-
-    if catalog_url is not None:
-        user_envs[name]["catalog_url"] = catalog_url
-    if s3_endpoint is not None:
-        user_envs[name]["s3_endpoint"] = s3_endpoint
-    if s3_access_key is not None:
-        user_envs[name]["s3_access_key"] = s3_access_key
-    if s3_secret_key is not None:
-        user_envs[name]["s3_secret_key"] = s3_secret_key
-    if auth is not None:
-        user_envs[name]["auth"] = auth
-
-    user_data["environments"] = user_envs
     try:
-        _write_config(user_config, user_data)
-    except OSError as e:
+        path, shadowed_by = update_environment(name, plain=plain, sections=sections)
+    except (OSError, RuntimeError, ValueError, KeyError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
-    typer.echo(f"Updated environment '{name}' in {user_config}")
-    if shadowed_by_project:
+    typer.echo(f"Updated environment '{name}' in {path}")
+    if shadowed_by:
         typer.echo(
-            f"Warning: Environment '{name}' is also defined in project config ({project_config}); "
-            "project config values will shadow this update",
+            f"Warning: environment '{name}' is also defined in {shadowed_by}; "
+            "values in that file will shadow this update",
             err=True,
         )
 

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -568,6 +568,27 @@ def env_set(
         )
 
 
+@env_app.command("unset")
+def env_unset(
+    name: str = typer.Argument(..., help="Environment name"),
+    keys: list[str] = typer.Argument(..., help="Keys to remove (dotted = subtable)"),
+) -> None:
+    """Remove KEYs from an environment in user config.
+
+    Dotted keys (e.g. data-platform.catalog_url) remove an entry from a
+    plugin subtable; the subtable is deleted if it ends up empty. Missing
+    keys are silently ignored.
+    """
+    from sunstone.env import unset_environment_keys
+
+    try:
+        path = unset_environment_keys(name, keys=keys)
+    except (OSError, RuntimeError, KeyError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+    typer.echo(f"Updated environment '{name}' in {path}")
+
+
 # =============================================================================
 # Dataset commands
 # =============================================================================

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -84,6 +84,33 @@ def expand_env_vars(text: str) -> str:
     return ENV_VAR_PATTERN.sub(replace_var, text)
 
 
+def _parse_kv_entries(entries: list[str]) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    """Parse `KEY=VAL` tokens into (plain, sections).
+
+    A token with no `=` raises ValueError. A KEY containing one or more
+    `.` is treated as `<section>.<sub-key>`; the part before the first
+    `.` becomes the section name (verbatim, no case change), the rest is
+    the sub-key.
+    """
+    plain: dict[str, str] = {}
+    sections: dict[str, dict[str, str]] = {}
+    for token in entries:
+        if "=" not in token:
+            raise ValueError(f"Expected KEY=VAL, got {token!r}")
+        key, value = token.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"Empty key in {token!r}")
+        if "." in key:
+            section, sub_key = key.split(".", 1)
+            if not section or not sub_key:
+                raise ValueError(f"Invalid dotted key {key!r}")
+            sections.setdefault(section, {})[sub_key] = value
+        else:
+            plain[key] = value
+    return plain, sections
+
+
 def expand_rdf_prefixes(value: str, prefixes: dict[str, str]) -> str:
     """
     Expand RDF prefix in a value.
@@ -455,23 +482,32 @@ def env_use(
 @env_app.command("add")
 def env_add(
     name: str = typer.Argument(..., help="Environment name"),
-    catalog_url: str = typer.Option(..., "--catalog-url", help="Nessie catalog URL"),
-    s3_endpoint: str = typer.Option(..., "--s3-endpoint", help="S3/MinIO endpoint URL"),
-    s3_access_key: str | None = typer.Option(None, "--s3-access-key", help="S3 access key or op:// reference"),
-    s3_secret_key: str | None = typer.Option(None, "--s3-secret-key", help="S3 secret key or op:// reference"),
-    auth: str | None = typer.Option(None, "--auth", help="Auth method (e.g. gcloud-adc)"),
+    entries: list[str] = typer.Argument(
+        None,
+        help=("KEY=VAL entries. Dotted keys (e.g. data-platform.warehouse=main) write to plugin-namespaced subtables."),
+    ),
+    overwrite: bool = typer.Option(False, "--overwrite", help="Replace existing entry"),
 ) -> None:
-    """Add a new environment to user config."""
+    """Add a new environment to user config.
+
+    Examples:
+        sunstone env add dev CATALOG_URL=https://data.dev.example.com
+        sunstone env add dev data-platform.warehouse=main GIT_BRANCH=main
+    """
     from sunstone.env import add_environment
+
+    try:
+        plain, sections = _parse_kv_entries(entries or [])
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(2)
 
     try:
         path = add_environment(
             name,
-            catalog_url=catalog_url,
-            s3_endpoint=s3_endpoint,
-            s3_access_key=s3_access_key,
-            s3_secret_key=s3_secret_key,
-            auth=auth,
+            plain=plain,
+            sections=sections,
+            overwrite=overwrite,
         )
         typer.echo(f"Added environment '{name}' to {path}")
     except (OSError, RuntimeError, ValueError) as e:

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -582,11 +582,15 @@ def env_unset(
     from sunstone.env import unset_environment_keys
 
     try:
-        path = unset_environment_keys(name, keys=keys)
+        path, removed = unset_environment_keys(name, keys=keys)
     except (OSError, RuntimeError, KeyError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
-    typer.echo(f"Updated environment '{name}' in {path}")
+    if removed == 0:
+        typer.echo(f"No matching keys to remove from environment '{name}' ({path})")
+    else:
+        noun = "key" if removed == 1 else "keys"
+        typer.echo(f"Removed {removed} {noun} from environment '{name}' in {path}")
 
 
 # =============================================================================

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -505,6 +505,12 @@ def env_use(
         raise typer.Exit(1)
 
 
+def _validate_scope(scope: str) -> None:
+    if scope not in ("user", "project", "system"):
+        typer.echo(f"Error: --scope must be one of user, project, system (got {scope!r})", err=True)
+        raise typer.Exit(2)
+
+
 @env_app.command("add")
 def env_add(
     name: str = typer.Argument(..., help="Environment name"),
@@ -513,6 +519,11 @@ def env_add(
         help=("KEY=VAL entries. Dotted keys (e.g. data-platform.warehouse=main) write to plugin-namespaced subtables."),
     ),
     overwrite: bool = typer.Option(False, "--overwrite", help="Replace existing entry"),
+    scope: str = typer.Option(
+        "user",
+        "--scope",
+        help="Config layer to write: user (default), project, or system.",
+    ),
 ) -> None:
     """Add a new environment to user config.
 
@@ -521,6 +532,8 @@ def env_add(
         sunstone env add dev data-platform.warehouse=main GIT_BRANCH=main
     """
     from sunstone.env import add_environment
+
+    _validate_scope(scope)
 
     try:
         plain, sections = _parse_kv_entries(entries or [])
@@ -534,6 +547,7 @@ def env_add(
             plain=plain,
             sections=sections,
             overwrite=overwrite,
+            scope=scope,
         )
         typer.echo(f"Added environment '{name}' to {path}")
     except (OSError, RuntimeError, ValueError) as e:
@@ -544,12 +558,19 @@ def env_add(
 @env_app.command("remove")
 def env_remove(
     name: str = typer.Argument(..., help="Environment name to remove"),
+    scope: str = typer.Option(
+        "user",
+        "--scope",
+        help="Config layer to write: user (default), project, or system.",
+    ),
 ) -> None:
     """Remove an environment from user config."""
     from sunstone.env import remove_environment
 
+    _validate_scope(scope)
+
     try:
-        path = remove_environment(name)
+        path = remove_environment(name, scope=scope)
         typer.echo(f"Removed environment '{name}' from {path}")
     except (OSError, RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
@@ -566,6 +587,11 @@ def env_set(
             "(e.g. data-platform.warehouse=main) target plugin subtables."
         ),
     ),
+    scope: str = typer.Option(
+        "user",
+        "--scope",
+        help="Config layer to write: user (default), project, or system.",
+    ),
 ) -> None:
     """Merge KEY=VAL entries into an existing environment in user config.
 
@@ -574,6 +600,8 @@ def env_set(
     """
     from sunstone.env import update_environment
 
+    _validate_scope(scope)
+
     try:
         plain, sections = _parse_kv_entries(entries)
     except ValueError as e:
@@ -581,7 +609,7 @@ def env_set(
         raise typer.Exit(2)
 
     try:
-        path, shadowed_by = update_environment(name, plain=plain, sections=sections)
+        path, shadowed_by = update_environment(name, plain=plain, sections=sections, scope=scope)
     except (OSError, RuntimeError, ValueError, KeyError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
@@ -598,6 +626,11 @@ def env_set(
 def env_unset(
     name: str = typer.Argument(..., help="Environment name"),
     keys: list[str] = typer.Argument(..., help="Keys to remove (dotted = subtable)"),
+    scope: str = typer.Option(
+        "user",
+        "--scope",
+        help="Config layer to write: user (default), project, or system.",
+    ),
 ) -> None:
     """Remove KEYs from an environment in user config.
 
@@ -607,8 +640,10 @@ def env_unset(
     """
     from sunstone.env import unset_environment_keys
 
+    _validate_scope(scope)
+
     try:
-        path, removed = unset_environment_keys(name, keys=keys)
+        path, removed = unset_environment_keys(name, keys=keys, scope=scope)
     except (OSError, RuntimeError, KeyError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -444,7 +444,7 @@ def env_show(ctx: typer.Context) -> None:
         all_envs = list_environments()
         if not all_envs and env is None:
             typer.echo("No environment configured.")
-            typer.echo("Run 'sunstone env add <name>' to create one.")
+            typer.echo("Run 'sunstone env add <name> KEY=VAL ...' to create one.")
             return
 
         if env:
@@ -456,11 +456,24 @@ def env_show(ctx: typer.Context) -> None:
         for name, defn in sorted(all_envs.items()):
             marker = "* " if env and name == env.name else "  "
             source = environment_source(name)
-            typer.echo(f"{marker}{name:<12} {defn.get('catalog_url', ''):<45} ({source})")
+            summary = _summarize_env_def(defn)
+            typer.echo(f"{marker}{name:<12} {summary:<45} ({source})")
     except (FileNotFoundError, KeyError, RuntimeError, ValueError) as e:
         message = e.args[0] if isinstance(e, KeyError) else str(e)
         typer.echo(f"Error: {message}", err=True)
         raise typer.Exit(1)
+
+
+def _summarize_env_def(defn: dict) -> str:
+    """Build a one-line summary: 'N keys, sections: foo, bar' or 'empty'."""
+    plain_keys = [k for k, v in defn.items() if not isinstance(v, dict)]
+    sections = sorted(k for k, v in defn.items() if isinstance(v, dict))
+    parts: list[str] = []
+    if plain_keys:
+        parts.append(f"{len(plain_keys)} key{'s' if len(plain_keys) != 1 else ''}")
+    if sections:
+        parts.append("sections: " + ", ".join(sections))
+    return ", ".join(parts) if parts else "empty"
 
 
 @env_app.command("use")

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -13,6 +13,7 @@ Config file precedence (highest wins):
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import tempfile
@@ -23,6 +24,8 @@ from types import MappingProxyType
 from typing import Any, Literal, Mapping, overload
 
 import tomli_w
+
+logger = logging.getLogger(__name__)
 
 _SYSTEM_CONFIG = Path("/etc/sunstone/data_platform.toml")
 _PROJECT_CONFIG_NAME = ".sunstone/data_platform.toml"
@@ -273,10 +276,34 @@ def _flatten_env_def(env_def: dict) -> tuple[dict[str, str], dict[str, dict]]:
     return vars_map, subtables
 
 
-def _build_sections(env_name: str, subtables: dict[str, dict]) -> dict:
-    """Construct typed section models from registered EnvSectionProviders."""
-    # Section building is implemented in Task 4. For now, return empty.
-    return {}
+def _build_sections(env_name: str, subtables: dict[str, dict]) -> dict[str, Any]:
+    """Construct typed section models from registered EnvSectionProviders.
+
+    Providers whose section is absent from the active env are omitted from
+    the result. Subtables without a matching provider are skipped (their
+    flattened keys still appear in `vars`).
+    """
+    from sunstone.plugins import PluginRegistry
+
+    providers = PluginRegistry.get().get_env_section_providers()
+    by_name = {p.env_section_name(): p for p in providers}
+
+    sections: dict[str, Any] = {}
+    for section_name, subtable in subtables.items():
+        provider = by_name.get(section_name)
+        if provider is None:
+            logger.debug(
+                "No EnvSectionProvider registered for subtable '%s' in environment '%s'",
+                section_name,
+                env_name,
+            )
+            continue
+        try:
+            model_cls = provider.env_section_model()
+            sections[section_name] = model_cls(**subtable)
+        except Exception as e:
+            raise ValueError(f"Environment '{env_name}' section '{section_name}': {e}") from e
+    return sections
 
 
 def resolve_environment(

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -611,6 +611,64 @@ def remove_environment(
     return usr_path
 
 
+def update_environment(
+    name: str,
+    *,
+    plain: dict[str, str] | None = None,
+    sections: dict[str, dict[str, str]] | None = None,
+    user_config: Path | None = None,
+) -> tuple[Path, str | None]:
+    """Merge plain / sections into an existing environment in user config.
+
+    Returns:
+        Tuple of (user config path, source-of-shadowing if any). The second
+        item is the path of a project/system config that also defines this
+        env (and will therefore shadow the update at resolve time).
+
+    Raises:
+        KeyError: If the environment is not present in the user config.
+    """
+    usr_path = _get_user_config_path(user_config, required=True)
+    user_data = _load_toml(usr_path)
+    user_envs = user_data.get("environments", {})
+    if name not in user_envs:
+        # Surface a clearer error when the env exists elsewhere in the cascade.
+        prj_path = _find_project_config()
+        if prj_path:
+            project_data = _load_toml(prj_path)
+            if name in project_data.get("environments", {}):
+                raise KeyError(
+                    f"Environment '{name}' is defined in project config ({prj_path}); env set only modifies user config"
+                )
+        system_data = _load_toml(_SYSTEM_CONFIG)
+        if name in system_data.get("environments", {}):
+            raise KeyError(
+                f"Environment '{name}' is defined in system config ({_SYSTEM_CONFIG}); "
+                "env set only modifies user config"
+            )
+        raise KeyError(f"Environment '{name}' not found in {usr_path}")
+
+    entry = user_envs[name]
+    if plain:
+        entry.update(plain)
+    if sections:
+        for section_name, sub_entries in sections.items():
+            existing = entry.get(section_name)
+            if not isinstance(existing, dict):
+                entry[section_name] = {}
+            entry[section_name].update(sub_entries)
+
+    user_data["environments"] = user_envs
+    _write_config(usr_path, user_data)
+
+    # Detect shadowing for the warning.
+    prj_path = _find_project_config()
+    project_data = _load_toml(prj_path) if prj_path else {}
+    if name in project_data.get("environments", {}):
+        return usr_path, str(prj_path)
+    return usr_path, None
+
+
 def _write_config(path: Path, data: dict) -> None:
     """Write a config dict as TOML, creating parent directories as needed."""
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -1,14 +1,17 @@
-"""Environment configuration for the Sunstone data platform.
+"""Environment configuration for sunstone-py.
 
-Resolves data platform environment settings from cascading TOML config
-files and environment variables.
+Resolves environment settings from cascading TOML config files and applies
+them as os.environ overlays via Environment.activate(). All keys are
+generic; plugins own typed schemas for their subtables via EnvSectionProvider.
 
-Config file precedence (highest wins):
-    1. Individual env vars (SUNSTONE_DATA_CATALOG_URL, etc.)
-    2. SUNSTONE_DATA_ENV env var (selects active environment name)
-    3. .sunstone/data_platform.toml (project config, walked up from cwd)
-    4. ~/.config/sunstone/data_platform.toml (user config)
-    5. /etc/sunstone/data_platform.toml (system config)
+Config file precedence (highest wins for active-environment selection):
+    1. SUNSTONE_DATA_ENV env var (selects active environment name)
+    2. .sunstone/data_platform.toml (project, walked up from cwd)
+    3. ~/.config/sunstone/data_platform.toml (user)
+    4. /etc/sunstone/data_platform.toml (system)
+
+Within a single environment definition, field-level merging follows the
+same precedence (project > user > system).
 """
 
 from __future__ import annotations

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -512,51 +512,41 @@ def set_active(
 def add_environment(
     name: str,
     *,
-    catalog_url: str,
-    s3_endpoint: str,
-    s3_access_key: str | None = None,
-    s3_secret_key: str | None = None,
-    auth: str | None = None,
+    plain: dict[str, str] | None = None,
+    sections: dict[str, dict[str, str]] | None = None,
     user_config: Path | None = None,
+    overwrite: bool = False,
 ) -> Path:
     """Add an environment to user config.
 
     Args:
         name: Environment name.
-        catalog_url: Nessie catalog URL.
-        s3_endpoint: S3-compatible endpoint URL.
-        s3_access_key: S3 access key or op:// reference.
-        s3_secret_key: S3 secret key or op:// reference.
-        auth: Authentication method (e.g. "gcloud-adc").
+        plain: Top-level key/value entries.
+        sections: Plugin-namespaced subtable entries (section_name -> dict).
         user_config: Override path for user config.
+        overwrite: Replace any existing entry with the same name.
 
     Returns:
         Path to the config file that was written.
 
     Raises:
-        ValueError: If the environment already exists.
+        ValueError: If the environment already exists and `overwrite` is False.
     """
     usr_path = _get_user_config_path(user_config, required=True)
     data = _load_toml(usr_path)
+    data.setdefault("environments", {})
 
-    if "environments" not in data:
-        data["environments"] = {}
-
-    if name in data.get("environments", {}):
+    if name in data["environments"] and not overwrite:
         raise ValueError(f"Environment '{name}' already exists in {usr_path}")
 
-    env_def: dict[str, str] = {
-        "catalog_url": catalog_url,
-        "s3_endpoint": s3_endpoint,
-    }
-    if s3_access_key is not None:
-        env_def["s3_access_key"] = s3_access_key
-    if s3_secret_key is not None:
-        env_def["s3_secret_key"] = s3_secret_key
-    if auth is not None:
-        env_def["auth"] = auth
+    entry: dict[str, Any] = {}
+    if plain:
+        entry.update(plain)
+    if sections:
+        for section_name, sub_entries in sections.items():
+            entry[section_name] = dict(sub_entries)
 
-    data["environments"][name] = env_def
+    data["environments"][name] = entry
     _write_config(usr_path, data)
     return usr_path
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -19,7 +19,7 @@ import tempfile
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, overload
+from typing import Any, Literal, Mapping, overload
 
 import tomli_w
 
@@ -75,6 +75,46 @@ class DataEnvironment:
     s3_secret_key: str | None
     auth: str | None
     source: str
+
+
+@dataclass(frozen=True)
+class Environment:
+    """Resolved environment configuration.
+
+    `vars` is the flattened set of keys (uppercase, hyphens->underscores)
+    from both top-level scalars and plugin-namespaced subtables. `sections`
+    holds typed models from registered EnvSectionProviders.
+    """
+
+    name: str
+    source: str
+    vars: Mapping[str, str]
+    sections: Mapping[str, Any]
+
+    def activate(self) -> dict[str, str]:
+        """Layer `vars` onto os.environ. Real env vars win.
+
+        Returns the dict of keys this call actually set (useful for tests
+        and verbose CLI output).
+        """
+        applied: dict[str, str] = {}
+        for key, value in self.vars.items():
+            if key not in os.environ:
+                os.environ[key] = value
+                applied[key] = value
+        return applied
+
+    def section(self, name: str) -> Any:
+        """Return the typed model registered for `name`.
+
+        Raises:
+            KeyError: if no `EnvSectionProvider` is registered for `name`
+                or the active environment did not declare that subtable.
+        """
+        try:
+            return self.sections[name]
+        except KeyError as e:
+            raise KeyError(f"No env section '{name}' on environment '{self.name}'") from e
 
 
 def _load_toml(path: Path) -> dict:

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -205,6 +205,16 @@ def _resolve_credential(value: str | None) -> str | None:
     return None
 
 
+def _apply_credential(value: str) -> str:
+    """Apply credential resolution to a single value.
+
+    Returns the resolved secret when `_resolve_credential` returns a
+    non-None result (including the empty string), otherwise the original.
+    """
+    resolved = _resolve_credential(value)
+    return value if resolved is None else resolved
+
+
 def _resolve_op_reference(ref: str) -> str:
     """Resolve a 1Password CLI reference.
 
@@ -248,8 +258,15 @@ def _flatten_env_def(env_def: dict) -> tuple[dict[str, str], dict[str, dict]]:
             subtables[key] = value
             section_prefix = key.upper().replace("-", "_")
             for sub_key, sub_value in value.items():
+                if isinstance(sub_value, (dict, list)):
+                    raise ValueError(
+                        f"Environment subtable '{key}' key '{sub_key}': "
+                        "nested tables and arrays are not supported in env vars"
+                    )
                 flat_key = f"{section_prefix}_{sub_key.upper().replace('-', '_')}"
                 vars_map[flat_key] = str(sub_value)
+        elif isinstance(value, list):
+            raise ValueError(f"Environment key '{key}': arrays are not supported in env vars")
         else:
             flat_key = key.upper().replace("-", "_")
             vars_map[flat_key] = str(value)
@@ -315,7 +332,7 @@ def resolve_environment(
         source = str(sys_path)
 
     vars_map, subtables = _flatten_env_def(env_def)
-    vars_map = {k: _resolve_credential(v) or v for k, v in vars_map.items()}
+    vars_map = {k: _apply_credential(v) for k, v in vars_map.items()}
 
     sections = _build_sections(active_name, subtables)
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -72,19 +72,6 @@ def _get_user_config_path(user_config: Path | None = None, *, required: bool = F
 
 
 @dataclass(frozen=True)
-class DataEnvironment:
-    """Resolved data platform environment configuration."""
-
-    name: str
-    catalog_url: str
-    s3_endpoint: str
-    s3_access_key: str | None
-    s3_secret_key: str | None
-    auth: str | None
-    source: str
-
-
-@dataclass(frozen=True)
 class Environment:
     """Resolved environment configuration.
 
@@ -623,3 +610,9 @@ def _write_config(path: Path, data: dict) -> None:
         except FileNotFoundError:
             pass
         raise
+
+
+# Deprecated alias for the old class name. Will be removed in the next
+# minor release. The catalog_url / s3_endpoint / auth attributes no longer
+# exist; callers that read them directly will fail explicitly.
+DataEnvironment = Environment

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -620,6 +620,11 @@ def update_environment(
 ) -> tuple[Path, str | None]:
     """Merge plain / sections into an existing environment in user config.
 
+    If an existing key with the section name is a non-dict scalar, it is
+    silently replaced with a fresh subtable before the new sub-entries are
+    merged. This is rare in practice (TOML enforces types at write time)
+    and should not happen unless the file was hand-edited.
+
     Returns:
         Tuple of (user config path, source-of-shadowing if any). The second
         item is the path of a project/system config that also defines this
@@ -663,9 +668,13 @@ def update_environment(
 
     # Detect shadowing for the warning.
     prj_path = _find_project_config()
-    project_data = _load_toml(prj_path) if prj_path else {}
-    if name in project_data.get("environments", {}):
-        return usr_path, str(prj_path)
+    if prj_path:
+        project_data = _load_toml(prj_path)
+        if name in project_data.get("environments", {}):
+            return usr_path, str(prj_path)
+    system_data = _load_toml(_SYSTEM_CONFIG)
+    if name in system_data.get("environments", {}):
+        return usr_path, str(_SYSTEM_CONFIG)
     return usr_path, None
 
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -695,6 +695,43 @@ def _write_config(path: Path, data: dict) -> None:
         raise
 
 
+def unset_environment_keys(
+    name: str,
+    *,
+    keys: list[str],
+    user_config: Path | None = None,
+) -> Path:
+    """Remove top-level and dotted keys from an env in user config.
+
+    Returns:
+        Path to the user config that was written.
+
+    Raises:
+        KeyError: If the environment is not present in the user config.
+    """
+    usr_path = _get_user_config_path(user_config, required=True)
+    data = _load_toml(usr_path)
+    user_envs = data.get("environments", {})
+    if name not in user_envs:
+        raise KeyError(f"Environment '{name}' not found in {usr_path}")
+
+    entry = user_envs[name]
+    for key in keys:
+        if "." in key:
+            section, sub_key = key.split(".", 1)
+            section_entry = entry.get(section)
+            if isinstance(section_entry, dict):
+                section_entry.pop(sub_key, None)
+                if not section_entry:
+                    entry.pop(section, None)
+        else:
+            entry.pop(key, None)
+
+    data["environments"] = user_envs
+    _write_config(usr_path, data)
+    return usr_path
+
+
 # Deprecated alias for the old class name. Will be removed in the next
 # minor release. The catalog_url / s3_endpoint / auth attributes no longer
 # exist; callers that read them directly will fail explicitly.

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -193,16 +193,16 @@ def _find_project_config(start: Path | None = None) -> Path | None:
 
 
 def _resolve_credential(value: str | None) -> str | None:
-    """Resolve a credential value.
+    """Resolve a credential value, or return None to indicate 'unchanged'.
 
-    Returns None for None/empty, calls _resolve_op_reference for op://
-    references, and returns the literal value otherwise.
+    Returns the resolved secret for `op://` references. For non-op
+    values returns None (the caller keeps the original).
     """
     if not value:
         return None
     if value.startswith("op://"):
         return _resolve_op_reference(value)
-    return value
+    return None
 
 
 def _resolve_op_reference(ref: str) -> str:
@@ -234,28 +234,59 @@ def _resolve_op_reference(ref: str) -> str:
     return result.stdout.strip()
 
 
+def _flatten_env_def(env_def: dict) -> tuple[dict[str, str], dict[str, dict]]:
+    """Split an env definition into flattened vars and raw subtables.
+
+    Top-level scalars become uppercase `vars` entries. Nested tables are
+    flattened to `<SECTION>_<KEY>` style and also returned as raw subtables
+    for section construction.
+    """
+    vars_map: dict[str, str] = {}
+    subtables: dict[str, dict] = {}
+    for key, value in env_def.items():
+        if isinstance(value, dict):
+            subtables[key] = value
+            section_prefix = key.upper().replace("-", "_")
+            for sub_key, sub_value in value.items():
+                flat_key = f"{section_prefix}_{sub_key.upper().replace('-', '_')}"
+                vars_map[flat_key] = str(sub_value)
+        else:
+            flat_key = key.upper().replace("-", "_")
+            vars_map[flat_key] = str(value)
+    return vars_map, subtables
+
+
+def _build_sections(env_name: str, subtables: dict[str, dict]) -> dict:
+    """Construct typed section models from registered EnvSectionProviders."""
+    # Section building is implemented in Task 4. For now, return empty.
+    return {}
+
+
 def resolve_environment(
     *,
     system_config: Path | None = None,
     user_config: Path | None = None,
     project_config: Path | None = None,
-) -> DataEnvironment | None:
-    """Resolve the active data platform environment.
+) -> Environment | None:
+    """Resolve the active environment.
 
-    Loads all config files, merges environments, resolves the active
-    environment name, applies env var field overrides, resolves credentials,
-    and returns a DataEnvironment.
+    Loads all config files, merges environments, resolves active name,
+    flattens keys (top-level and plugin-namespaced subtables) into a
+    single `vars` mapping, resolves `op://` references generically, and
+    constructs typed section models for any registered EnvSectionProviders
+    that have a matching subtable.
 
     Args:
-        system_config: Override path for system config (default: /etc/sunstone/data_platform.toml).
-        user_config: Override path for user config (default: ~/.config/sunstone/data_platform.toml).
-        project_config: Override path for project config (default: auto-discovered).
+        system_config: Override path for system config.
+        user_config: Override path for user config.
+        project_config: Override path for project config.
 
     Returns:
-        A DataEnvironment if an active environment is configured, or None.
+        An `Environment` if an active env is configured, otherwise None.
 
     Raises:
-        ValueError: If the active environment name doesn't match any defined environment.
+        ValueError: If the active environment name does not match any
+            defined environment, or a section model fails validation.
     """
     sys_path = system_config or _SYSTEM_CONFIG
     usr_path = _get_user_config_path(user_config)
@@ -266,52 +297,33 @@ def resolve_environment(
     project_data = _load_toml(prj_path) if prj_path else {}
 
     active_name, source_label = _resolve_active_name(project_data, user_data, system_data)
-
     if active_name is None:
         return None
 
     all_envs = _merge_environments(system_data, user_data, project_data)
-
     if active_name not in all_envs:
         raise ValueError(f"Active environment '{active_name}' is not defined in any config file")
-
     env_def = all_envs[active_name]
 
-    # Determine source file path
     if source_label == "SUNSTONE_DATA_ENV":
         source = "SUNSTONE_DATA_ENV"
     elif source_label == "project" and prj_path:
         source = str(prj_path)
-    elif source_label == "user":
+    elif source_label == "user" and usr_path:
         source = str(usr_path)
     else:
         source = str(sys_path)
 
-    # Start with values from config
-    catalog_url = env_def.get("catalog_url", "")
-    s3_endpoint = env_def.get("s3_endpoint", "")
-    s3_access_key = env_def.get("s3_access_key")
-    s3_secret_key = env_def.get("s3_secret_key")
-    auth = env_def.get("auth")
+    vars_map, subtables = _flatten_env_def(env_def)
+    vars_map = {k: _resolve_credential(v) or v for k, v in vars_map.items()}
 
-    # Apply env var field overrides (highest precedence)
-    catalog_url = os.environ.get("SUNSTONE_DATA_CATALOG_URL") or catalog_url
-    s3_endpoint = os.environ.get("SUNSTONE_DATA_S3_ENDPOINT") or s3_endpoint
-    s3_access_key = os.environ.get("SUNSTONE_DATA_S3_ACCESS_KEY") or s3_access_key
-    s3_secret_key = os.environ.get("SUNSTONE_DATA_S3_SECRET_KEY") or s3_secret_key
+    sections = _build_sections(active_name, subtables)
 
-    # Resolve credentials
-    s3_access_key = _resolve_credential(s3_access_key)
-    s3_secret_key = _resolve_credential(s3_secret_key)
-
-    return DataEnvironment(
+    return Environment(
         name=active_name,
-        catalog_url=catalog_url,
-        s3_endpoint=s3_endpoint,
-        s3_access_key=s3_access_key,
-        s3_secret_key=s3_secret_key,
-        auth=auth,
         source=source,
+        vars=vars_map,
+        sections=sections,
     )
 
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -283,10 +283,21 @@ def _build_sections(env_name: str, subtables: dict[str, dict]) -> dict[str, Any]
     the result. Subtables without a matching provider are skipped (their
     flattened keys still appear in `vars`).
     """
-    from sunstone.plugins import PluginRegistry
+    from sunstone.plugins import EnvSectionProvider, PluginRegistry  # local to avoid circular import
 
     providers = PluginRegistry.get().get_env_section_providers()
-    by_name = {p.env_section_name(): p for p in providers}
+    by_name: dict[str, EnvSectionProvider] = {}
+    for p in providers:
+        name = p.env_section_name()
+        if name in by_name:
+            logger.warning(
+                "Duplicate EnvSectionProvider for section %r (%r overrides %r); "
+                "only the last-registered provider is used",
+                name,
+                p,
+                by_name[name],
+            )
+        by_name[name] = p
 
     sections: dict[str, Any] = {}
     for section_name, subtable in subtables.items():

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -380,8 +380,10 @@ def activate_environment(
 ) -> dict[str, str]:
     """Convenience: resolve the active environment and call `.activate()`.
 
-    Returns the dict of keys this call actually set in os.environ
-    (an empty dict if no active environment is configured).
+    Pre-existing environment variables are not overwritten (real env vars
+    always win over config-file values). Returns the dict of keys this call
+    actually set in os.environ (an empty dict if no active environment is
+    configured or all keys were already set).
     """
     env = resolve_environment(
         system_config=system_config,

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -700,11 +700,13 @@ def unset_environment_keys(
     *,
     keys: list[str],
     user_config: Path | None = None,
-) -> Path:
+) -> tuple[Path, int]:
     """Remove top-level and dotted keys from an env in user config.
 
     Returns:
-        Path to the user config that was written.
+        Tuple of (path written, count of keys actually removed). The
+        count is zero when every requested key was already absent
+        (the file is still rewritten unchanged).
 
     Raises:
         KeyError: If the environment is not present in the user config.
@@ -716,20 +718,24 @@ def unset_environment_keys(
         raise KeyError(f"Environment '{name}' not found in {usr_path}")
 
     entry = user_envs[name]
+    removed = 0
     for key in keys:
         if "." in key:
             section, sub_key = key.split(".", 1)
             section_entry = entry.get(section)
-            if isinstance(section_entry, dict):
-                section_entry.pop(sub_key, None)
+            if isinstance(section_entry, dict) and sub_key in section_entry:
+                section_entry.pop(sub_key)
+                removed += 1
                 if not section_entry:
                     entry.pop(section, None)
         else:
-            entry.pop(key, None)
+            if key in entry:
+                entry.pop(key)
+                removed += 1
 
     data["environments"] = user_envs
     _write_config(usr_path, data)
-    return usr_path
+    return usr_path, removed
 
 
 # Deprecated alias for the old class name. Will be removed in the next

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -185,6 +185,38 @@ def _find_project_config(start: Path | None = None) -> Path | None:
     return None
 
 
+def _scope_to_target_path(
+    scope: str,
+    *,
+    user_config: Path | None = None,
+    project_config: Path | None = None,
+    system_config: Path | None = None,
+) -> Path:
+    """Return the TOML path to write for the requested scope.
+
+    - "user"    -> user_config or default user path (must be available).
+    - "project" -> project_config, else nearest .sunstone/data_platform.toml
+                   walking up from cwd, else cwd / .sunstone/data_platform.toml
+                   (caller is responsible for creating the directory on write).
+    - "system"  -> system_config or default system path.
+
+    Raises:
+        ValueError: If scope is not one of the three recognised values.
+    """
+    if scope == "user":
+        return _get_user_config_path(user_config, required=True)
+    if scope == "project":
+        if project_config is not None:
+            return project_config
+        found = _find_project_config()
+        if found is not None:
+            return found
+        return Path.cwd() / _PROJECT_CONFIG_NAME
+    if scope == "system":
+        return system_config or _SYSTEM_CONFIG
+    raise ValueError(f"Unknown scope {scope!r}; expected one of: user, project, system")
+
+
 def _resolve_credential(value: str | None) -> str | None:
     """Resolve a credential value, or return None to indicate 'unchanged'.
 
@@ -514,16 +546,22 @@ def add_environment(
     *,
     plain: dict[str, str] | None = None,
     sections: dict[str, dict[str, str]] | None = None,
+    scope: str = "user",
     user_config: Path | None = None,
+    project_config: Path | None = None,
+    system_config: Path | None = None,
     overwrite: bool = False,
 ) -> Path:
-    """Add an environment to user config.
+    """Add an environment to the specified config layer.
 
     Args:
         name: Environment name.
         plain: Top-level key/value entries.
         sections: Plugin-namespaced subtable entries (section_name -> dict).
+        scope: Which config layer to write to: "user" (default), "project", or "system".
         user_config: Override path for user config.
+        project_config: Override path for project config.
+        system_config: Override path for system config.
         overwrite: Replace any existing entry with the same name.
 
     Passing empty/None `plain` and `sections` creates an empty environment
@@ -533,9 +571,15 @@ def add_environment(
         Path to the config file that was written.
 
     Raises:
-        ValueError: If the environment already exists and `overwrite` is False.
+        ValueError: If the environment already exists and `overwrite` is False,
+            or if scope is not a recognised value.
     """
-    usr_path = _get_user_config_path(user_config, required=True)
+    usr_path = _scope_to_target_path(
+        scope,
+        user_config=user_config,
+        project_config=project_config,
+        system_config=system_config,
+    )
     data = _load_toml(usr_path)
     data.setdefault("environments", {})
 
@@ -557,14 +601,16 @@ def add_environment(
 def remove_environment(
     name: str,
     *,
+    scope: str = "user",
     user_config: Path | None = None,
     system_config: Path | None = None,
     project_config: Path | None = None,
 ) -> Path:
-    """Remove an environment from user config.
+    """Remove an environment from the specified config layer.
 
     Args:
         name: Environment name to remove.
+        scope: Which config layer to remove from: "user" (default), "project", or "system".
         user_config: Override path for user config.
         system_config: Override path for system config.
         project_config: Override path for project config (default: auto-discovered).
@@ -573,42 +619,63 @@ def remove_environment(
         Path to the config file that was modified.
 
     Raises:
-        ValueError: If the environment is only in system config or doesn't exist.
+        ValueError: If the environment is only in a different layer, or doesn't exist
+            in the targeted layer.
     """
-    usr_path = _get_user_config_path(user_config, required=True)
     sys_path = system_config or _SYSTEM_CONFIG
     prj_path = project_config or _find_project_config()
 
-    user_data = _load_toml(usr_path)
-    user_envs = user_data.get("environments", {})
+    if scope == "user":
+        usr_path = _get_user_config_path(user_config, required=True)
 
-    if name not in user_envs:
-        system_data = _load_toml(sys_path)
-        system_envs = system_data.get("environments", {})
-        if name in system_envs:
-            raise ValueError(
-                f"Environment '{name}' is defined in system config ({sys_path}), cannot remove from user config"
-            )
+        user_data = _load_toml(usr_path)
+        user_envs = user_data.get("environments", {})
+
+        if name not in user_envs:
+            system_data = _load_toml(sys_path)
+            system_envs = system_data.get("environments", {})
+            if name in system_envs:
+                raise ValueError(
+                    f"Environment '{name}' is defined in system config ({sys_path}), cannot remove from user config"
+                )
+            if prj_path:
+                project_data = _load_toml(prj_path)
+                if name in project_data.get("environments", {}):
+                    raise ValueError(
+                        f"Environment '{name}' is defined in project config ({prj_path}), cannot remove from user config"
+                    )
+            raise ValueError(f"Environment '{name}' not found in user config")
+
+        del user_data["environments"][name]
+        if user_data.get("active") == name:
+            del user_data["active"]
+        _write_config(usr_path, user_data)
+
         if prj_path:
             project_data = _load_toml(prj_path)
-            if name in project_data.get("environments", {}):
-                raise ValueError(
-                    f"Environment '{name}' is defined in project config ({prj_path}), cannot remove from user config"
-                )
-        raise ValueError(f"Environment '{name}' not found in user config")
+            if project_data.get("active") == name:
+                del project_data["active"]
+                _write_config(prj_path, project_data)
 
-    del user_data["environments"][name]
-    if user_data.get("active") == name:
-        del user_data["active"]
-    _write_config(usr_path, user_data)
+        return usr_path
 
-    if prj_path:
-        project_data = _load_toml(prj_path)
-        if project_data.get("active") == name:
-            del project_data["active"]
-            _write_config(prj_path, project_data)
+    target = _scope_to_target_path(
+        scope,
+        user_config=user_config,
+        project_config=project_config,
+        system_config=system_config,
+    )
+    data = _load_toml(target)
+    envs = data.get("environments", {})
 
-    return usr_path
+    if name not in envs:
+        raise ValueError(f"Environment '{name}' not found in {scope} config ({target})")
+
+    del data["environments"][name]
+    if data.get("active") == name:
+        del data["active"]
+    _write_config(target, data)
+    return target
 
 
 def update_environment(
@@ -616,44 +683,67 @@ def update_environment(
     *,
     plain: dict[str, str] | None = None,
     sections: dict[str, dict[str, str]] | None = None,
+    scope: str = "user",
     user_config: Path | None = None,
+    project_config: Path | None = None,
+    system_config: Path | None = None,
 ) -> tuple[Path, str | None]:
-    """Merge plain / sections into an existing environment in user config.
+    """Merge plain / sections into an existing environment in the specified config layer.
 
     If an existing key with the section name is a non-dict scalar, it is
     silently replaced with a fresh subtable before the new sub-entries are
     merged. This is rare in practice (TOML enforces types at write time)
     and should not happen unless the file was hand-edited.
 
+    Args:
+        name: Environment name.
+        plain: Top-level key/value entries to merge.
+        sections: Plugin-namespaced subtable entries to merge.
+        scope: Which config layer to write to: "user" (default), "project", or "system".
+        user_config: Override path for user config.
+        project_config: Override path for project config.
+        system_config: Override path for system config.
+
     Returns:
-        Tuple of (user config path, source-of-shadowing if any). The second
-        item is the path of a project/system config that also defines this
-        env (and will therefore shadow the update at resolve time).
+        Tuple of (target config path, source-of-shadowing if any). The second
+        item is the path of a higher-precedence config that also defines this
+        env (and will therefore shadow the update at resolve time). For
+        "project" scope, shadowing is not applicable (project is top of cascade),
+        so the second item is always None.
 
     Raises:
-        KeyError: If the environment is not present in the user config.
+        KeyError: If the environment is not present in the targeted config layer.
     """
-    usr_path = _get_user_config_path(user_config, required=True)
-    user_data = _load_toml(usr_path)
-    user_envs = user_data.get("environments", {})
-    if name not in user_envs:
-        # Surface a clearer error when the env exists elsewhere in the cascade.
-        prj_path = _find_project_config()
-        if prj_path:
-            project_data = _load_toml(prj_path)
-            if name in project_data.get("environments", {}):
-                raise KeyError(
-                    f"Environment '{name}' is defined in project config ({prj_path}); env set only modifies user config"
-                )
-        system_data = _load_toml(_SYSTEM_CONFIG)
-        if name in system_data.get("environments", {}):
-            raise KeyError(
-                f"Environment '{name}' is defined in system config ({_SYSTEM_CONFIG}); "
-                "env set only modifies user config"
-            )
-        raise KeyError(f"Environment '{name}' not found in {usr_path}")
+    target = _scope_to_target_path(
+        scope,
+        user_config=user_config,
+        project_config=project_config,
+        system_config=system_config,
+    )
+    target_data = _load_toml(target)
+    target_envs = target_data.get("environments", {})
 
-    entry = user_envs[name]
+    if name not in target_envs:
+        if scope == "user":
+            # Surface a clearer error when the env exists elsewhere in the cascade.
+            prj_path = _find_project_config()
+            if prj_path:
+                project_data = _load_toml(prj_path)
+                if name in project_data.get("environments", {}):
+                    raise KeyError(
+                        f"Environment '{name}' is defined in project config ({prj_path}); env set only modifies user config"
+                    )
+            sys_path = system_config or _SYSTEM_CONFIG
+            system_data = _load_toml(sys_path)
+            if name in system_data.get("environments", {}):
+                raise KeyError(
+                    f"Environment '{name}' is defined in system config ({sys_path}); env set only modifies user config"
+                )
+        elif scope == "system":
+            raise KeyError(f"Environment '{name}' not found in system config ({target})")
+        raise KeyError(f"Environment '{name}' not found in {target}")
+
+    entry = target_envs[name]
     if plain:
         entry.update(plain)
     if sections:
@@ -663,19 +753,39 @@ def update_environment(
                 entry[section_name] = {}
             entry[section_name].update(sub_entries)
 
-    user_data["environments"] = user_envs
-    _write_config(usr_path, user_data)
+    target_data["environments"] = target_envs
+    _write_config(target, target_data)
 
     # Detect shadowing for the warning.
-    prj_path = _find_project_config()
+    if scope == "project":
+        # Project is top of cascade — nothing shadows it.
+        return target, None
+
+    if scope == "system":
+        # Both project and user can shadow system; project takes precedence.
+        prj_path = project_config or _find_project_config()
+        if prj_path:
+            project_data = _load_toml(prj_path)
+            if name in project_data.get("environments", {}):
+                return target, str(prj_path)
+        usr_path = _get_user_config_path(user_config)
+        if usr_path:
+            user_data = _load_toml(usr_path)
+            if name in user_data.get("environments", {}):
+                return target, str(usr_path)
+        return target, None
+
+    # scope == "user": detect project/system shadows (existing behaviour).
+    prj_path = project_config or _find_project_config()
     if prj_path:
         project_data = _load_toml(prj_path)
         if name in project_data.get("environments", {}):
-            return usr_path, str(prj_path)
-    system_data = _load_toml(_SYSTEM_CONFIG)
+            return target, str(prj_path)
+    sys_path = system_config or _SYSTEM_CONFIG
+    system_data = _load_toml(sys_path)
     if name in system_data.get("environments", {}):
-        return usr_path, str(_SYSTEM_CONFIG)
-    return usr_path, None
+        return target, str(sys_path)
+    return target, None
 
 
 def _write_config(path: Path, data: dict) -> None:
@@ -699,9 +809,21 @@ def unset_environment_keys(
     name: str,
     *,
     keys: list[str],
+    scope: str = "user",
     user_config: Path | None = None,
+    project_config: Path | None = None,
+    system_config: Path | None = None,
 ) -> tuple[Path, int]:
-    """Remove top-level and dotted keys from an env in user config.
+    """Remove top-level and dotted keys from an env in the specified config layer.
+
+    Args:
+        name: Environment name.
+        keys: List of keys to remove. Use dotted notation (e.g. "section.key")
+            for subtable keys.
+        scope: Which config layer to write to: "user" (default), "project", or "system".
+        user_config: Override path for user config.
+        project_config: Override path for project config.
+        system_config: Override path for system config.
 
     Returns:
         Tuple of (path written, count of keys actually removed). The
@@ -709,9 +831,14 @@ def unset_environment_keys(
         (the file is still rewritten unchanged).
 
     Raises:
-        KeyError: If the environment is not present in the user config.
+        KeyError: If the environment is not present in the targeted config layer.
     """
-    usr_path = _get_user_config_path(user_config, required=True)
+    usr_path = _scope_to_target_path(
+        scope,
+        user_config=user_config,
+        project_config=project_config,
+        system_config=system_config,
+    )
     data = _load_toml(usr_path)
     user_envs = data.get("environments", {})
     if name not in user_envs:

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -19,6 +19,7 @@ import tempfile
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Literal, Mapping, overload
 
 import tomli_w
@@ -90,6 +91,12 @@ class Environment:
     source: str
     vars: Mapping[str, str]
     sections: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.vars, MappingProxyType):
+            object.__setattr__(self, "vars", MappingProxyType(dict(self.vars)))
+        if not isinstance(self.sections, MappingProxyType):
+            object.__setattr__(self, "sections", MappingProxyType(dict(self.sections)))
 
     def activate(self) -> dict[str, str]:
         """Layer `vars` onto os.environ. Real env vars win.

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -526,6 +526,9 @@ def add_environment(
         user_config: Override path for user config.
         overwrite: Replace any existing entry with the same name.
 
+    Passing empty/None `plain` and `sections` creates an empty environment
+    entry (useful to reserve the name; populate later with `env set`).
+
     Returns:
         Path to the config file that was written.
 

--- a/src/sunstone/env.py
+++ b/src/sunstone/env.py
@@ -372,6 +372,27 @@ def resolve_environment(
     )
 
 
+def activate_environment(
+    *,
+    system_config: Path | None = None,
+    user_config: Path | None = None,
+    project_config: Path | None = None,
+) -> dict[str, str]:
+    """Convenience: resolve the active environment and call `.activate()`.
+
+    Returns the dict of keys this call actually set in os.environ
+    (an empty dict if no active environment is configured).
+    """
+    env = resolve_environment(
+        system_config=system_config,
+        user_config=user_config,
+        project_config=project_config,
+    )
+    if env is None:
+        return {}
+    return env.activate()
+
+
 def list_environments(
     *,
     system_config: Path | None = None,

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import tomllib
 from pathlib import Path
-from typing import BinaryIO, Literal, Protocol, TextIO, overload, runtime_checkable
+from typing import Any, BinaryIO, Callable, Literal, Protocol, TextIO, overload, runtime_checkable
 
 import pandas as pd
 import typer
@@ -97,7 +97,7 @@ class EnvSectionProvider(Protocol):
         """Return the TOML subtable key (e.g. 'data-platform')."""
         ...
 
-    def env_section_model(self) -> type:
+    def env_section_model(self) -> Callable[..., Any]:
         """Return a callable that accepts the subtable as **kwargs."""
         ...
 

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -84,6 +84,24 @@ class CLIProvider(Protocol):
         ...
 
 
+@runtime_checkable
+class EnvSectionProvider(Protocol):
+    """Owns a typed slice of environment configuration.
+
+    Plugins implement this to claim a TOML subtable name and return a
+    callable (dataclass/Pydantic class/factory) that validates the
+    subtable's keys and returns a typed model.
+    """
+
+    def env_section_name(self) -> str:
+        """Return the TOML subtable key (e.g. 'data-platform')."""
+        ...
+
+    def env_section_model(self) -> type:
+        """Return a callable that accepts the subtable as **kwargs."""
+        ...
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -150,6 +168,7 @@ class PluginRegistry:
         self._url_handlers: list[URLHandler] = [LocalFileHandler()]
         self._format_handlers: list[FormatHandler] = []
         self._cli_providers: list[CLIProvider] = []
+        self._env_section_providers: list[EnvSectionProvider] = []
 
     @classmethod
     def get(cls, project_path: Path | str | None = None) -> PluginRegistry:
@@ -219,6 +238,9 @@ class PluginRegistry:
         if isinstance(plugin, CLIProvider):
             self._cli_providers.append(plugin)
             registered = True
+        if isinstance(plugin, EnvSectionProvider):
+            self._env_section_providers.append(plugin)
+            registered = True
         if not registered:
             logger.warning("Plugin '%s' does not implement any known plugin protocol", name)
 
@@ -243,6 +265,10 @@ class PluginRegistry:
             except Exception:
                 logger.exception("Failed to get CLI groups from provider %r", provider)
         return groups
+
+    def get_env_section_providers(self) -> list[EnvSectionProvider]:
+        """Return all registered env section providers."""
+        return self._env_section_providers
 
     def handler_supports_metadata(self, handler: FormatHandler) -> bool:
         """Check if a format handler supports metadata embedding.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2729,9 +2729,9 @@ class TestCallbackActivates:
         monkeypatch.setattr(env_mod, "_USER_CONFIG", path, raising=False)
 
     def test_callback_activates_environment_for_non_env_commands(self, tmp_path, monkeypatch):
-        # We use --version (a no-op that still runs the callback) as the
-        # smoke test: by the time the callback returns, os.environ should
-        # have picked up the active env vars.
+        # Smoke test: invoke a non-env subcommand (here `dataset list`); by
+        # the time the callback returns, os.environ should have picked up
+        # the active env vars regardless of the command's own exit status.
         user_cfg = tmp_path / "user.toml"
         user_cfg.write_text(
             """
@@ -2742,6 +2742,9 @@ class TestCallbackActivates:
             """
         )
         self._fake_user_config_path(monkeypatch, user_cfg)
+        # Set then clear to prove the assertion catches the activation
+        # side-effect, not a leftover from a prior test.
+        monkeypatch.setenv("MY_CALLBACK_VAR", "this-should-be-overwritten-or-cleared")
         monkeypatch.delenv("MY_CALLBACK_VAR", raising=False)
         monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2553,7 +2553,7 @@ class TestEnvSet:
         runner = CliRunner()
         result = runner.invoke(app, ["env", "set", "missing", "CATALOG_URL=x"])
         assert result.exit_code != 0
-        assert "missing" in result.output.lower()
+        assert "not found" in result.output.lower()
 
     def test_env_update_command_is_gone(self):
         runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2778,3 +2778,121 @@ class TestCallbackActivates:
         # `env add` must still succeed (does not call resolve).
         result_add = runner.invoke(app, ["env", "add", "newenv", "K=v"])
         assert result_add.exit_code == 0, result_add.output
+
+
+class TestEnvScopeFlag:
+    def _fake_user_config_path(self, monkeypatch, path):
+        import sunstone.env as env_mod
+
+        monkeypatch.setattr(env_mod, "_USER_CONFIG", path, raising=False)
+
+    def _fake_system_config_path(self, monkeypatch, path):
+        import sunstone.env as env_mod
+
+        monkeypatch.setattr(env_mod, "_SYSTEM_CONFIG", path, raising=False)
+
+    def test_env_add_to_project_scope(self, tmp_path, monkeypatch):
+        # Run from inside tmp_path so the auto-discovery falls back to cwd.
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "add", "dev", "--scope", "project", "CATALOG_URL=https://x"],
+        )
+        assert result.exit_code == 0, result.output
+
+        prj_path = tmp_path / ".sunstone" / "data_platform.toml"
+        assert prj_path.exists()
+        with open(prj_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["environments"]["dev"]["CATALOG_URL"] == "https://x"
+
+    def test_env_add_to_system_scope(self, tmp_path, monkeypatch):
+        sys_cfg = tmp_path / "etc" / "data_platform.toml"
+        self._fake_system_config_path(monkeypatch, sys_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "add", "dev", "--scope", "system", "K=v"],
+        )
+        assert result.exit_code == 0, result.output
+        assert sys_cfg.exists()
+
+    def test_env_set_project_scope_merges_in_project_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        prj_dir = tmp_path / ".sunstone"
+        prj_dir.mkdir()
+        (prj_dir / "data_platform.toml").write_text('[environments.dev]\nA = "1"\n')
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "set", "dev", "--scope", "project", "B=2"],
+        )
+        assert result.exit_code == 0, result.output
+
+        with open(prj_dir / "data_platform.toml", "rb") as f:
+            data = tomllib.load(f)
+        assert data["environments"]["dev"] == {"A": "1", "B": "2"}
+
+    def test_env_unset_project_scope_removes_key(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        prj_dir = tmp_path / ".sunstone"
+        prj_dir.mkdir()
+        (prj_dir / "data_platform.toml").write_text('[environments.dev]\nKEEP = "k"\nDROP = "d"\n')
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "unset", "dev", "--scope", "project", "DROP"],
+        )
+        assert result.exit_code == 0, result.output
+
+        with open(prj_dir / "data_platform.toml", "rb") as f:
+            data = tomllib.load(f)
+        assert data["environments"]["dev"] == {"KEEP": "k"}
+
+    def test_env_remove_system_scope(self, tmp_path, monkeypatch):
+        sys_cfg = tmp_path / "etc" / "data_platform.toml"
+        sys_cfg.parent.mkdir(parents=True)
+        sys_cfg.write_text('[environments.dev]\nX = "y"\n')
+        self._fake_system_config_path(monkeypatch, sys_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "remove", "dev", "--scope", "system"],
+        )
+        assert result.exit_code == 0, result.output
+
+        with open(sys_cfg, "rb") as f:
+            data = tomllib.load(f)
+        assert "dev" not in data.get("environments", {})
+
+    def test_invalid_scope_rejected(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "add", "dev", "--scope", "bogus", "K=v"],
+        )
+        assert result.exit_code == 2
+        assert "scope" in result.output.lower()
+
+    def test_default_scope_is_user(self, tmp_path, monkeypatch):
+        # No --scope flag should still write to user config (regression guard).
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "add", "dev", "K=v"])
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        assert data["environments"]["dev"]["K"] == "v"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2720,3 +2720,58 @@ class TestSummarizeEnvDef:
 
         result = _summarize_env_def({"zebra": {"x": 1}, "apple": {"y": 2}})
         assert result == "sections: apple, zebra"
+
+
+class TestCallbackActivates:
+    def _fake_user_config_path(self, monkeypatch, path):
+        import sunstone.env as env_mod
+
+        monkeypatch.setattr(env_mod, "_USER_CONFIG", path, raising=False)
+
+    def test_callback_activates_environment_for_non_env_commands(self, tmp_path, monkeypatch):
+        # We use --version (a no-op that still runs the callback) as the
+        # smoke test: by the time the callback returns, os.environ should
+        # have picked up the active env vars.
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            active = "dev"
+
+            [environments.dev]
+            MY_CALLBACK_VAR = "callback-wired"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+        monkeypatch.delenv("MY_CALLBACK_VAR", raising=False)
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        runner = CliRunner()
+        # `dataset list` (or any non-env command) should trigger activation.
+        # We expect the os.environ side-effect; the command itself may
+        # exit non-zero if the project isn't set up — only the side-effect
+        # matters here.
+        runner.invoke(app, ["dataset", "list"])
+        assert os.environ.get("MY_CALLBACK_VAR") == "callback-wired"
+
+    def test_callback_does_not_break_env_subcommands_when_resolve_fails(self, tmp_path, monkeypatch):
+        """Even if activation would fail, env subcommands must remain usable
+        so the user can fix the config."""
+        user_cfg = tmp_path / "user.toml"
+        # Active env points to one that does not exist — resolve raises.
+        user_cfg.write_text(
+            """
+            active = "missing"
+
+            [environments.dev]
+            X = "y"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env"])
+        assert result.exit_code != 0 or "missing" in result.output.lower()
+        # `env add` must still succeed (does not call resolve).
+        result_add = runner.invoke(app, ["env", "add", "newenv", "K=v"])
+        assert result_add.exit_code == 0, result_add.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2171,112 +2171,6 @@ def test_env_remove_deletes_environment(tmp_path):
     assert "Removed environment 'dev'" in result.output
 
 
-def test_env_update_modifies_environment(tmp_path):
-    """sunstone env update modifies an existing environment."""
-    user_config = tmp_path / "user.toml"
-    user_config.write_text(
-        '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
-    )
-
-    runner = CliRunner()
-    with (
-        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
-        patch("sunstone.env._USER_CONFIG", user_config),
-        patch("sunstone.env._find_project_config", return_value=None),
-    ):
-        result = runner.invoke(
-            app,
-            [
-                "env",
-                "update",
-                "dev",
-                "--catalog-url",
-                "http://newhost:19120/api/v1",
-            ],
-        )
-    assert result.exit_code == 0
-    assert "Updated environment 'dev'" in result.output
-    config_text = user_config.read_text()
-    assert "http://newhost:19120/api/v1" in config_text
-
-
-def test_env_update_reports_project_scoped_environment(tmp_path):
-    """sunstone env update explains when the env exists only in project config."""
-    user_config = tmp_path / "user.toml"
-    project_config = tmp_path / ".sunstone" / "data_platform.toml"
-    project_config.parent.mkdir(parents=True)
-    project_config.write_text(
-        '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
-    )
-
-    runner = CliRunner()
-    with (
-        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
-        patch("sunstone.env._USER_CONFIG", user_config),
-        patch("sunstone.env._find_project_config", return_value=project_config),
-    ):
-        result = runner.invoke(
-            app,
-            [
-                "env",
-                "update",
-                "dev",
-                "--catalog-url",
-                "http://newhost:19120/api/v1",
-            ],
-        )
-    assert result.exit_code == 1
-    assert "defined in project config" in result.output
-
-
-def test_env_update_requires_at_least_one_field(tmp_path):
-    """sunstone env update refuses no-op invocations without rewriting the file."""
-    user_config = tmp_path / "user.toml"
-    original = (
-        "# keep me\n"
-        "[environments.dev]\n"
-        'catalog_url = "http://localhost:19120/api/v1"\n'
-        's3_endpoint = "http://localhost:9000"\n'
-    )
-    user_config.write_text(original)
-
-    runner = CliRunner()
-    with (
-        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
-        patch("sunstone.env._USER_CONFIG", user_config),
-        patch("sunstone.env._find_project_config", return_value=None),
-    ):
-        result = runner.invoke(app, ["env", "update", "dev"])
-    assert result.exit_code == 1
-    assert "No fields to update" in result.output
-    assert user_config.read_text() == original
-
-
-def test_env_update_warns_when_project_config_shadows_user(tmp_path):
-    """sunstone env update warns when project config will shadow the updated user env."""
-    user_config = tmp_path / "user.toml"
-    user_config.write_text(
-        '[environments.dev]\ncatalog_url = "http://user-dev"\ns3_endpoint = "http://localhost:9000"\n'
-    )
-    project_config = tmp_path / ".sunstone" / "data_platform.toml"
-    project_config.parent.mkdir(parents=True)
-    project_config.write_text(
-        '[environments.dev]\ncatalog_url = "http://project-dev"\ns3_endpoint = "http://localhost:9001"\n'
-    )
-
-    runner = CliRunner()
-    with (
-        patch("sunstone.env._SYSTEM_CONFIG", tmp_path / "system.toml"),
-        patch("sunstone.env._USER_CONFIG", user_config),
-        patch("sunstone.env._find_project_config", return_value=project_config),
-    ):
-        result = runner.invoke(app, ["env", "update", "dev", "--catalog-url", "http://new-user-dev"])
-    assert result.exit_code == 0
-    assert "Updated environment 'dev'" in result.output
-    assert "project config values will shadow this update" in result.output
-    assert "http://new-user-dev" in user_config.read_text()
-
-
 def test_env_use_reports_write_errors():
     """sunstone env use reports config write failures cleanly."""
     runner = CliRunner()
@@ -2312,8 +2206,8 @@ def test_env_remove_reports_write_errors():
     assert "read-only filesystem" in result.output
 
 
-def test_env_update_reports_write_errors(tmp_path):
-    """sunstone env update reports config write failures cleanly."""
+def test_env_set_reports_write_errors(tmp_path):
+    """sunstone env set reports config write failures cleanly."""
     user_config = tmp_path / "user.toml"
     user_config.write_text(
         '[environments.dev]\ncatalog_url = "http://localhost:19120/api/v1"\ns3_endpoint = "http://localhost:9000"\n'
@@ -2326,7 +2220,7 @@ def test_env_update_reports_write_errors(tmp_path):
         patch("sunstone.env._find_project_config", return_value=None),
         patch("sunstone.env._write_config", side_effect=PermissionError("permission denied")),
     ):
-        result = runner.invoke(app, ["env", "update", "dev", "--catalog-url", "http://newhost:19120/api/v1"])
+        result = runner.invoke(app, ["env", "set", "dev", "CATALOG_URL=http://newhost:19120/api/v1"])
     assert result.exit_code == 1
     assert "permission denied" in result.output
 
@@ -2615,3 +2509,54 @@ class TestEnvAddGeneric:
         with open(user_cfg, "rb") as f:
             data = tomllib.load(f)
         assert data["environments"]["dev"] == {}
+
+
+class TestEnvSet:
+    def _fake_user_config_path(self, monkeypatch, path):
+        import sunstone.env as env_mod
+
+        monkeypatch.setattr(env_mod, "_USER_CONFIG", path, raising=False)
+
+    def test_env_set_merges_with_existing_entry(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            [environments.dev]
+            GIT_BRANCH = "main"
+
+            [environments.dev."data-platform"]
+            warehouse = "main"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "set", "dev", "CATALOG_URL=https://x", "data-platform.catalog_url=https://y"],
+        )
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        env = data["environments"]["dev"]
+        assert env["GIT_BRANCH"] == "main"  # preserved
+        assert env["CATALOG_URL"] == "https://x"  # added
+        assert env["data-platform"]["warehouse"] == "main"  # preserved
+        assert env["data-platform"]["catalog_url"] == "https://y"  # added
+
+    def test_env_set_fails_on_unknown_environment(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "set", "missing", "CATALOG_URL=x"])
+        assert result.exit_code != 0
+        assert "missing" in result.output.lower()
+
+    def test_env_update_command_is_gone(self):
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "update", "--help"])
+        # Typer prints "No such command" or similar; exit code != 0
+        assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2141,13 +2141,11 @@ def test_env_add_creates_environment(tmp_path):
                 "env",
                 "add",
                 "dev",
-                "--catalog-url",
-                "http://localhost:19120/api/v1",
-                "--s3-endpoint",
-                "http://localhost:9000",
+                "CATALOG_URL=http://localhost:19120/api/v1",
+                "S3_ENDPOINT=http://localhost:9000",
             ],
         )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert "Added environment 'dev'" in result.output
     config_text = user_config.read_text()
     assert "dev" in config_text
@@ -2297,10 +2295,7 @@ def test_env_add_reports_write_errors():
                 "env",
                 "add",
                 "dev",
-                "--catalog-url",
-                "http://localhost:19120/api/v1",
-                "--s3-endpoint",
-                "http://localhost:9000",
+                "CATALOG_URL=http://localhost:19120/api/v1",
             ],
         )
     assert result.exit_code == 1
@@ -2495,3 +2490,117 @@ class TestMigrateHashes:
         assert "content_hash" not in input_entry
         assert input_entry["file_hash"] == f"sha256:{bare_hex}"
         assert "Migrated hashes" in result.output
+
+
+import tomllib  # noqa: E402
+
+
+class TestEnvAddGeneric:
+    def _fake_user_config_path(self, monkeypatch, path):
+        # Force _USER_CONFIG to point at our tmp file.
+        import sunstone.env as env_mod
+
+        monkeypatch.setattr(env_mod, "_USER_CONFIG", path, raising=False)
+
+    def test_env_add_with_plain_keys(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "add", "dev", "CATALOG_URL=https://x", "GIT_BRANCH=main"])
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        assert data["environments"]["dev"]["CATALOG_URL"] == "https://x"
+        assert data["environments"]["dev"]["GIT_BRANCH"] == "main"
+
+    def test_env_add_with_dotted_keys_creates_subtable(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "add",
+                "dev",
+                "data-platform.catalog_url=https://data.dev.example.com",
+                "data-platform.warehouse=main",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        env = data["environments"]["dev"]
+        assert env["data-platform"]["catalog_url"] == "https://data.dev.example.com"
+        assert env["data-platform"]["warehouse"] == "main"
+
+    def test_env_add_mixed_plain_and_dotted(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "add", "dev", "GIT_BRANCH=main", "data-platform.warehouse=main"],
+        )
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        env = data["environments"]["dev"]
+        assert env["GIT_BRANCH"] == "main"
+        assert env["data-platform"]["warehouse"] == "main"
+
+    def test_env_add_rejects_token_without_equals(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "add", "dev", "BARE_KEY_NO_VALUE"])
+        assert result.exit_code != 0
+        assert "BARE_KEY_NO_VALUE" in result.output
+
+    def test_env_add_rejects_existing_without_overwrite(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            [environments.dev]
+            EXISTING = "y"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "add", "dev", "CATALOG_URL=z"])
+        assert result.exit_code != 0
+        assert "already exists" in result.output.lower()
+
+    def test_env_add_overwrite_replaces_entry(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            [environments.dev]
+            OLD_KEY = "y"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["env", "add", "dev", "--overwrite", "NEW_KEY=z"],
+        )
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        env = data["environments"]["dev"]
+        assert env == {"NEW_KEY": "z"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2651,3 +2651,39 @@ class TestEnvUnset:
         assert result.exit_code == 1
         assert "staging" in result.output
         assert "not found" in result.output.lower()
+
+
+class TestEnvShowGeneric:
+    def _fake_user_config_path(self, monkeypatch, path):
+        import sunstone.env as env_mod
+
+        monkeypatch.setattr(env_mod, "_USER_CONFIG", path, raising=False)
+
+    def test_show_lists_envs_with_generic_summary(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            active = "dev"
+
+            [environments.dev]
+            GIT_BRANCH = "main"
+
+            [environments.dev."data-platform"]
+            warehouse = "main"
+            catalog_url = "https://data.dev.example.com"
+
+            [environments.prod]
+            GIT_BRANCH = "main"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env"])
+        assert result.exit_code == 0, result.output
+        assert "Active: dev" in result.output
+        assert "dev" in result.output
+        assert "prod" in result.output
+        # Summary mentions section names rather than catalog_url specifically.
+        assert "data-platform" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2687,3 +2687,36 @@ class TestEnvShowGeneric:
         assert "prod" in result.output
         # Summary mentions section names rather than catalog_url specifically.
         assert "data-platform" in result.output
+
+
+class TestSummarizeEnvDef:
+    def test_empty(self):
+        from sunstone.cli import _summarize_env_def
+
+        assert _summarize_env_def({}) == "empty"
+
+    def test_plain_keys_singular(self):
+        from sunstone.cli import _summarize_env_def
+
+        assert _summarize_env_def({"A": "1"}) == "1 key"
+
+    def test_plain_keys_plural(self):
+        from sunstone.cli import _summarize_env_def
+
+        assert _summarize_env_def({"A": "1", "B": "2"}) == "2 keys"
+
+    def test_sections_only(self):
+        from sunstone.cli import _summarize_env_def
+
+        assert _summarize_env_def({"s": {"x": 1}}) == "sections: s"
+
+    def test_mixed(self):
+        from sunstone.cli import _summarize_env_def
+
+        assert _summarize_env_def({"A": "1", "s": {"x": 1}}) == "1 key, sections: s"
+
+    def test_sections_are_sorted(self):
+        from sunstone.cli import _summarize_env_def
+
+        result = _summarize_env_def({"zebra": {"x": 1}, "apple": {"y": 2}})
+        assert result == "sections: apple, zebra"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2560,3 +2560,83 @@ class TestEnvSet:
         result = runner.invoke(app, ["env", "update", "--help"])
         # Typer prints "No such command" or similar; exit code != 0
         assert result.exit_code != 0
+
+
+class TestEnvUnset:
+    def _fake_user_config_path(self, monkeypatch, path):
+        import sunstone.env as env_mod
+
+        monkeypatch.setattr(env_mod, "_USER_CONFIG", path, raising=False)
+
+    def test_unset_removes_top_level_key(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            [environments.dev]
+            KEEP = "k"
+            DROP = "d"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "unset", "dev", "DROP"])
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        env = data["environments"]["dev"]
+        assert env == {"KEEP": "k"}
+
+    def test_unset_dotted_removes_subtable_entry(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            [environments.dev."data-platform"]
+            warehouse = "main"
+            catalog_url = "https://x"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "unset", "dev", "data-platform.catalog_url"])
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        env = data["environments"]["dev"]
+        assert env["data-platform"] == {"warehouse": "main"}
+
+    def test_unset_removes_empty_subtable(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            [environments.dev."data-platform"]
+            warehouse = "main"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "unset", "dev", "data-platform.warehouse"])
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        env = data["environments"]["dev"]
+        assert "data-platform" not in env
+
+    def test_unset_unknown_key_is_no_op(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text(
+            """
+            [environments.dev]
+            KEEP = "k"
+            """
+        )
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "unset", "dev", "MISSING"])
+        assert result.exit_code == 0  # silent no-op

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import io
 import logging
 import os
 import shutil
+import tomllib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -2492,9 +2493,6 @@ class TestMigrateHashes:
         assert "Migrated hashes" in result.output
 
 
-import tomllib  # noqa: E402
-
-
 class TestEnvAddGeneric:
     def _fake_user_config_path(self, monkeypatch, path):
         # Force _USER_CONFIG to point at our tmp file.
@@ -2565,7 +2563,7 @@ class TestEnvAddGeneric:
 
         runner = CliRunner()
         result = runner.invoke(app, ["env", "add", "dev", "BARE_KEY_NO_VALUE"])
-        assert result.exit_code != 0
+        assert result.exit_code == 2
         assert "BARE_KEY_NO_VALUE" in result.output
 
     def test_env_add_rejects_existing_without_overwrite(self, tmp_path, monkeypatch):
@@ -2604,3 +2602,16 @@ class TestEnvAddGeneric:
             data = tomllib.load(f)
         env = data["environments"]["dev"]
         assert env == {"NEW_KEY": "z"}
+
+    def test_env_add_with_no_entries_creates_empty_environment(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text("")
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "add", "dev"])
+        assert result.exit_code == 0, result.output
+
+        with open(user_cfg, "rb") as f:
+            data = tomllib.load(f)
+        assert data["environments"]["dev"] == {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2640,3 +2640,14 @@ class TestEnvUnset:
         runner = CliRunner()
         result = runner.invoke(app, ["env", "unset", "dev", "MISSING"])
         assert result.exit_code == 0  # silent no-op
+
+    def test_unset_unknown_env_exits_nonzero(self, tmp_path, monkeypatch):
+        user_cfg = tmp_path / "user.toml"
+        user_cfg.write_text('[environments.dev]\nKEEP = "k"\n')
+        self._fake_user_config_path(monkeypatch, user_cfg)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["env", "unset", "staging", "KEEP"])
+        assert result.exit_code == 1
+        assert "staging" in result.output
+        assert "not found" in result.output.lower()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1287,3 +1287,31 @@ class TestEnvironmentSections:
         assert env is not None
         assert env.section("dup").tag == "second"
         assert any("Duplicate EnvSectionProvider" in rec.message for rec in caplog.records)
+
+
+class TestLegacyEnvVarOverridesRemoved:
+    """SUNSTONE_DATA_CATALOG_URL / SUNSTONE_DATA_S3_* used to override
+    individual fields on the resolved environment. They are removed; the
+    replacement is to set the bare env var (CATALOG_URL=...) directly or
+    via the section-flattened name (DATA_PLATFORM_CATALOG_URL=...). Real
+    env vars still win over config-file values via Environment.activate().
+    """
+
+    def test_old_overrides_have_no_effect(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "data_platform.toml"
+        cfg.write_text(
+            """
+            active = "dev"
+
+            [environments.dev]
+            CATALOG_URL = "from-config"
+            """
+        )
+        monkeypatch.setenv("SUNSTONE_DATA_CATALOG_URL", "from-old-override")
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        env = resolve_environment(user_config=cfg)
+        assert env is not None
+        # The old override env var must NOT bleed into resolved vars.
+        assert env.vars["CATALOG_URL"] == "from-config"
+        assert "SUNSTONE_DATA_CATALOG_URL" not in env.vars

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1235,7 +1235,55 @@ class TestEnvironmentSections:
             "get_env_section_providers",
             return_value=[StrictProvider()],
         ):
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match=r"Environment 'dev' section 'strict':"):
                 resolve_environment(user_config=cfg)
-        assert "environment 'dev'" in str(exc.value).lower()
-        assert "section 'strict'" in str(exc.value).lower()
+
+    def test_duplicate_providers_log_warning_and_last_wins(self, tmp_path, monkeypatch, caplog):
+        from sunstone.plugins import PluginRegistry
+
+        class FirstSection:
+            def __init__(self, **kwargs):
+                self.tag = "first"
+                self.kwargs = kwargs
+
+        class SecondSection:
+            def __init__(self, **kwargs):
+                self.tag = "second"
+                self.kwargs = kwargs
+
+        class FirstProvider:
+            def env_section_name(self):
+                return "dup"
+
+            def env_section_model(self):
+                return FirstSection
+
+        class SecondProvider:
+            def env_section_name(self):
+                return "dup"
+
+            def env_section_model(self):
+                return SecondSection
+
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev."dup"]
+            foo = "bar"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        with patch.object(
+            PluginRegistry.get(),
+            "get_env_section_providers",
+            return_value=[FirstProvider(), SecondProvider()],
+        ):
+            with caplog.at_level("WARNING", logger="sunstone.env"):
+                env = resolve_environment(user_config=cfg)
+
+        assert env is not None
+        assert env.section("dup").tag == "second"
+        assert any("Duplicate EnvSectionProvider" in rec.message for rec in caplog.records)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 import pytest
 
 from sunstone.env import (
-    DataEnvironment,
     _find_project_config,
     _load_toml,
     _merge_environments,
@@ -1097,7 +1096,7 @@ class TestLegacyEnvVarOverridesRemoved:
 
 class TestDataEnvironmentDeprecationAlias:
     def test_old_name_is_alias_for_environment(self):
-        from sunstone.env import Environment
+        from sunstone.env import DataEnvironment, Environment
 
         assert DataEnvironment is Environment
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1133,3 +1133,109 @@ class TestResolveEnvironmentGeneric:
         assert env is not None
         assert env.name == "dev"
         assert env.source == "SUNSTONE_DATA_ENV"
+
+
+# ---------------------------------------------------------------------------
+# _build_sections — typed sections from EnvSectionProviders (Task 4)
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentSections:
+    def _write_user_config(self, tmp_path: Path, body: str) -> Path:
+        cfg = tmp_path / "data_platform.toml"
+        cfg.write_text(body)
+        return cfg
+
+    def test_registered_provider_with_matching_subtable_builds_section(self, tmp_path, monkeypatch):
+        from sunstone.plugins import PluginRegistry
+
+        class FakeSection:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        class FakeSectionProvider:
+            def env_section_name(self):
+                return "data-platform"
+
+            def env_section_model(self):
+                return FakeSection
+
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev."data-platform"]
+            catalog_url = "https://data.dev.example.com"
+            warehouse = "main"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        # Patch the registry's getter so resolve_environment picks up our provider.
+        with patch.object(
+            PluginRegistry.get(),
+            "get_env_section_providers",
+            return_value=[FakeSectionProvider()],
+        ):
+            env = resolve_environment(user_config=cfg)
+
+        assert env is not None
+        section = env.section("data-platform")
+        assert isinstance(section, FakeSection)
+        assert section.kwargs == {
+            "catalog_url": "https://data.dev.example.com",
+            "warehouse": "main",
+        }
+
+    def test_unregistered_subtable_keys_still_flatten(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev."unknown-plugin"]
+            foo = "bar"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert env.vars["UNKNOWN_PLUGIN_FOO"] == "bar"
+        with pytest.raises(KeyError):
+            env.section("unknown-plugin")
+
+    def test_section_validation_error_wraps_with_context(self, tmp_path, monkeypatch):
+        from sunstone.plugins import PluginRegistry
+
+        class StrictSection:
+            def __init__(self, *, required_only: str):
+                self.required_only = required_only
+
+        class StrictProvider:
+            def env_section_name(self):
+                return "strict"
+
+            def env_section_model(self):
+                return StrictSection
+
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev."strict"]
+            unexpected = "x"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        with patch.object(
+            PluginRegistry.get(),
+            "get_env_section_providers",
+            return_value=[StrictProvider()],
+        ):
+            with pytest.raises(ValueError) as exc:
+                resolve_environment(user_config=cfg)
+        assert "environment 'dev'" in str(exc.value).lower()
+        assert "section 'strict'" in str(exc.value).lower()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -944,5 +944,17 @@ class TestEnvironment:
         from sunstone.env import Environment
 
         env = Environment(name="dev", source="user", vars={}, sections={})
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="No env section 'missing' on environment 'dev'"):
             env.section("missing")
+
+    def test_vars_and_sections_are_immutable_after_construction(self):
+        from sunstone.env import Environment
+        from types import MappingProxyType
+
+        env = Environment(name="dev", source="user", vars={"FOO": "bar"}, sections={"plug": object()})
+        assert isinstance(env.vars, MappingProxyType)
+        assert isinstance(env.sections, MappingProxyType)
+        with pytest.raises(TypeError):
+            env.vars["FOO"] = "x"  # type: ignore[index]
+        with pytest.raises(TypeError):
+            env.sections["plug"] = object()  # type: ignore[index]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -999,7 +999,7 @@ class TestResolveEnvironmentGeneric:
         assert env.vars["CATALOG_URL"] == "https://data.dev.example.com"
         assert env.vars["GIT_BRANCH"] == "main"
 
-    def test_uppercases_and_hyphenates_top_level_keys(self, tmp_path, monkeypatch):
+    def test_uppercases_and_converts_hyphens_to_underscores(self, tmp_path, monkeypatch):
         cfg = self._write_user_config(
             tmp_path,
             """
@@ -1061,3 +1061,75 @@ class TestResolveEnvironmentGeneric:
             project_config=tmp_path / "missing-project.toml",
         )
         assert env is None
+
+    def test_op_resolution_preserves_empty_secret(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev]
+            BLANK = "op://Engineering/dev/empty"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        with patch("sunstone.env._resolve_op_reference", return_value=""):
+            env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert env.vars["BLANK"] == ""  # not the original op:// reference
+
+    def test_rejects_nested_subtable_value(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev."data-platform".nested]
+            deep = "value"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        with pytest.raises(ValueError, match="nested tables"):
+            resolve_environment(user_config=cfg)
+
+    def test_rejects_list_value(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev]
+            TAGS = ["a", "b"]
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        with pytest.raises(ValueError, match="arrays"):
+            resolve_environment(user_config=cfg)
+
+    def test_raises_when_active_env_is_unknown(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "missing"
+
+            [environments.dev]
+            K = "v"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        with pytest.raises(ValueError, match="missing"):
+            resolve_environment(user_config=cfg)
+
+    def test_sunstone_data_env_sets_source_label(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            [environments.dev]
+            CATALOG_URL = "x"
+            """,
+        )
+        monkeypatch.setenv("SUNSTONE_DATA_ENV", "dev")
+        env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert env.name == "dev"
+        assert env.source == "SUNSTONE_DATA_ENV"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -360,33 +360,59 @@ class TestAddEnvironment:
 
         result = add_environment(
             "dev",
-            catalog_url="http://dev",
-            s3_endpoint="http://dev-s3",
-            s3_access_key="key",
-            auth="gcloud-adc",
+            plain={"CATALOG_URL": "http://dev", "AUTH": "gcloud-adc", "ACCESS_KEY": "key"},
             user_config=user,
         )
 
         assert result == user
         data = _load_toml(user)
-        assert data["environments"]["dev"]["catalog_url"] == "http://dev"
-        assert data["environments"]["dev"]["auth"] == "gcloud-adc"
-        assert data["environments"]["dev"]["s3_access_key"] == "key"
+        assert data["environments"]["dev"]["CATALOG_URL"] == "http://dev"
+        assert data["environments"]["dev"]["AUTH"] == "gcloud-adc"
+        assert data["environments"]["dev"]["ACCESS_KEY"] == "key"
         assert "s3_secret_key" not in data["environments"]["dev"]
+
+    def test_adds_sections(self, tmp_path: Path):
+        user = tmp_path / "user.toml"
+
+        result = add_environment(
+            "dev",
+            sections={"data-platform": {"catalog_url": "http://dev", "warehouse": "main"}},
+            user_config=user,
+        )
+
+        assert result == user
+        data = _load_toml(user)
+        assert data["environments"]["dev"]["data-platform"]["catalog_url"] == "http://dev"
+        assert data["environments"]["dev"]["data-platform"]["warehouse"] == "main"
 
     def test_rejects_duplicates(self, tmp_path: Path):
         user = _write_toml(
             tmp_path / "user.toml",
-            '[environments.dev]\ncatalog_url = "http://dev"\ns3_endpoint = "http://dev-s3"\n',
+            '[environments.dev]\nCATALOG_URL = "http://dev"\n',
         )
 
         with pytest.raises(ValueError, match="already exists"):
             add_environment(
                 "dev",
-                catalog_url="http://other",
-                s3_endpoint="http://other-s3",
+                plain={"CATALOG_URL": "http://other"},
                 user_config=user,
             )
+
+    def test_overwrite_replaces_entry(self, tmp_path: Path):
+        user = _write_toml(
+            tmp_path / "user.toml",
+            '[environments.dev]\nOLD_KEY = "y"\n',
+        )
+
+        add_environment(
+            "dev",
+            plain={"NEW_KEY": "z"},
+            user_config=user,
+            overwrite=True,
+        )
+
+        data = _load_toml(user)
+        assert data["environments"]["dev"] == {"NEW_KEY": "z"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import subprocess
 from dataclasses import FrozenInstanceError
 from pathlib import Path
@@ -877,3 +878,71 @@ class TestWriteConfig:
 
         assert path.read_text() == original
         assert not any(candidate.suffix == ".tmp" for candidate in tmp_path.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# Environment dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironment:
+    def test_frozen(self):
+        from sunstone.env import Environment
+
+        env = Environment(name="dev", source="/etc/sunstone/data_platform.toml", vars={}, sections={})
+        with pytest.raises(FrozenInstanceError):
+            env.name = "other"  # type: ignore[misc]
+
+    def test_vars_and_sections_are_mappings(self):
+        from sunstone.env import Environment
+
+        env = Environment(
+            name="dev",
+            source="user",
+            vars={"FOO": "bar"},
+            sections={"plug": object()},
+        )
+        assert dict(env.vars) == {"FOO": "bar"}
+        assert "plug" in env.sections
+
+    def test_activate_sets_unset_keys(self, monkeypatch):
+        from sunstone.env import Environment
+
+        monkeypatch.delenv("MY_CATALOG_URL", raising=False)
+        env = Environment(name="dev", source="user", vars={"MY_CATALOG_URL": "https://example.com"}, sections={})
+        applied = env.activate()
+        assert applied == {"MY_CATALOG_URL": "https://example.com"}
+        assert os.environ["MY_CATALOG_URL"] == "https://example.com"
+
+    def test_activate_does_not_overwrite_real_env_vars(self, monkeypatch):
+        from sunstone.env import Environment
+
+        monkeypatch.setenv("MY_CATALOG_URL", "from-shell")
+        env = Environment(name="dev", source="user", vars={"MY_CATALOG_URL": "from-config"}, sections={})
+        applied = env.activate()
+        assert applied == {}
+        assert os.environ["MY_CATALOG_URL"] == "from-shell"
+
+    def test_activate_is_idempotent(self, monkeypatch):
+        from sunstone.env import Environment
+
+        monkeypatch.delenv("MY_CATALOG_URL", raising=False)
+        env = Environment(name="dev", source="user", vars={"MY_CATALOG_URL": "x"}, sections={})
+        first = env.activate()
+        second = env.activate()
+        assert first == {"MY_CATALOG_URL": "x"}
+        assert second == {}  # already set on second call
+
+    def test_section_returns_typed_instance(self):
+        from sunstone.env import Environment
+
+        section = object()
+        env = Environment(name="dev", source="user", vars={}, sections={"data-platform": section})
+        assert env.section("data-platform") is section
+
+    def test_section_raises_keyerror_for_unknown(self):
+        from sunstone.env import Environment
+
+        env = Environment(name="dev", source="user", vars={}, sections={})
+        with pytest.raises(KeyError):
+            env.section("missing")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1151,3 +1151,22 @@ class TestActivateEnvironmentHelper:
             project_config=tmp_path / "missing-prj.toml",
         )
         assert applied == {}
+
+    def test_module_helper_does_not_overwrite_real_env_vars(self, tmp_path, monkeypatch):
+        import sunstone
+
+        cfg = tmp_path / "data_platform.toml"
+        cfg.write_text(
+            """
+            active = "dev"
+
+            [environments.dev]
+            MY_CATALOG_URL = "from-config"
+            """
+        )
+        monkeypatch.setenv("MY_CATALOG_URL", "from-shell")
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        applied = sunstone.activate_environment(user_config=cfg)
+        assert applied == {}
+        assert os.environ["MY_CATALOG_URL"] == "from-shell"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -258,8 +258,9 @@ class TestFindProjectConfig:
 
 
 class TestResolveCredential:
-    def test_literal(self):
-        assert _resolve_credential("my-secret") == "my-secret"
+    def test_literal_returns_none(self):
+        # Non-op values return None; caller uses `_resolve_credential(v) or v` to keep original.
+        assert _resolve_credential("my-secret") is None
 
     def test_none(self):
         assert _resolve_credential(None) is None
@@ -334,7 +335,8 @@ def _write_toml(path: Path, content: str) -> Path:
     return path
 
 
-class TestResolveEnvironment:
+class TestResolveEnvironmentLegacy:
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_full_cascade(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
@@ -354,9 +356,10 @@ class TestResolveEnvironment:
 
         assert env is not None
         assert env.name == "prod"
-        assert env.catalog_url == "http://sys-prod"
-        assert env.s3_endpoint == "http://sys-s3"
+        assert env.catalog_url == "http://sys-prod"  # type: ignore[attr-defined]
+        assert env.s3_endpoint == "http://sys-s3"  # type: ignore[attr-defined]
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_env_var_field_overrides(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
@@ -377,11 +380,12 @@ class TestResolveEnvironment:
             )
 
         assert env is not None
-        assert env.catalog_url == "http://overridden"
-        assert env.s3_endpoint == "http://overridden-s3"
-        assert env.s3_access_key == "env-key"
-        assert env.s3_secret_key == "env-secret"
+        assert env.catalog_url == "http://overridden"  # type: ignore[attr-defined]
+        assert env.s3_endpoint == "http://overridden-s3"  # type: ignore[attr-defined]
+        assert env.s3_access_key == "env-key"  # type: ignore[attr-defined]
+        assert env.s3_secret_key == "env-secret"  # type: ignore[attr-defined]
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_empty_env_vars_do_not_override_config(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
@@ -402,11 +406,12 @@ class TestResolveEnvironment:
             )
 
         assert env is not None
-        assert env.catalog_url == "http://original"
-        assert env.s3_endpoint == "http://original-s3"
-        assert env.s3_access_key == "configured-key"
-        assert env.s3_secret_key == "configured-secret"
+        assert env.catalog_url == "http://original"  # type: ignore[attr-defined]
+        assert env.s3_endpoint == "http://original-s3"  # type: ignore[attr-defined]
+        assert env.s3_access_key == "configured-key"  # type: ignore[attr-defined]
+        assert env.s3_secret_key == "configured-secret"  # type: ignore[attr-defined]
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_returns_none_when_nothing_configured(self, tmp_path: Path):
         with patch.dict("os.environ", {}, clear=True):
             env = resolve_environment(
@@ -416,6 +421,7 @@ class TestResolveEnvironment:
             )
         assert env is None
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_raises_for_unknown_active_env(self, tmp_path: Path):
         config = _write_toml(
             tmp_path / "user.toml",
@@ -429,6 +435,7 @@ class TestResolveEnvironment:
                     project_config=tmp_path / "no2.toml",
                 )
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_env_var_selects_environment(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
@@ -446,6 +453,7 @@ class TestResolveEnvironment:
         assert env.name == "staging"
         assert env.source == "SUNSTONE_DATA_ENV"
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_project_config_environments(self, tmp_path: Path):
         project = _write_toml(
             tmp_path / ".sunstone" / "data_platform.toml",
@@ -464,8 +472,9 @@ class TestResolveEnvironment:
 
         assert env is not None
         assert env.name == "local"
-        assert env.catalog_url == "http://localhost:19120"
+        assert env.catalog_url == "http://localhost:19120"  # type: ignore[attr-defined]
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_field_level_merge_across_layers(self, tmp_path: Path):
         system = _write_toml(
             tmp_path / "system.toml",
@@ -489,11 +498,12 @@ class TestResolveEnvironment:
 
         assert env is not None
         assert env.name == "dev"
-        assert env.catalog_url == "http://project-dev"
-        assert env.s3_endpoint == "http://sys-s3"
-        assert env.s3_access_key == "user-key"
-        assert env.auth == "basic"
+        assert env.catalog_url == "http://project-dev"  # type: ignore[attr-defined]
+        assert env.s3_endpoint == "http://sys-s3"  # type: ignore[attr-defined]
+        assert env.s3_access_key == "user-key"  # type: ignore[attr-defined]
+        assert env.auth == "basic"  # type: ignore[attr-defined]
 
+    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
     def test_credential_resolution(self, tmp_path: Path):
         config = _write_toml(
             tmp_path / "config.toml",
@@ -514,8 +524,8 @@ class TestResolveEnvironment:
                 )
 
         assert env is not None
-        assert env.s3_access_key == "resolved-key"
-        assert env.s3_secret_key == "literal-secret"
+        assert env.s3_access_key == "resolved-key"  # type: ignore[attr-defined]
+        assert env.s3_secret_key == "literal-secret"  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -958,3 +968,96 @@ class TestEnvironment:
             env.vars["FOO"] = "x"  # type: ignore[index]
         with pytest.raises(TypeError):
             env.sections["plug"] = object()  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# resolve_environment — generic Environment (Task 3)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEnvironmentGeneric:
+    def _write_user_config(self, tmp_path: Path, body: str) -> Path:
+        cfg = tmp_path / "data_platform.toml"
+        cfg.write_text(body)
+        return cfg
+
+    def test_returns_environment_with_flattened_top_level_keys(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev]
+            CATALOG_URL = "https://data.dev.example.com"
+            GIT_BRANCH = "main"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert env.name == "dev"
+        assert env.vars["CATALOG_URL"] == "https://data.dev.example.com"
+        assert env.vars["GIT_BRANCH"] == "main"
+
+    def test_uppercases_and_hyphenates_top_level_keys(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev]
+            "feature-flag" = "yes"
+            lowercase_key = "v"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert env.vars["FEATURE_FLAG"] == "yes"
+        assert env.vars["LOWERCASE_KEY"] == "v"
+
+    def test_flattens_plugin_namespaced_subtable(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev."data-platform"]
+            catalog_url = "https://data.dev.example.com"
+            warehouse = "main"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert env.vars["DATA_PLATFORM_CATALOG_URL"] == "https://data.dev.example.com"
+        assert env.vars["DATA_PLATFORM_WAREHOUSE"] == "main"
+
+    def test_resolves_op_references_generically(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(
+            tmp_path,
+            """
+            active = "dev"
+
+            [environments.dev."data-platform"]
+            s3_secret_key = "op://Engineering/dev/secret"
+            """,
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        with patch(
+            "sunstone.env._resolve_op_reference",
+            return_value="resolved-secret",
+        ):
+            env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert env.vars["DATA_PLATFORM_S3_SECRET_KEY"] == "resolved-secret"
+
+    def test_returns_none_when_no_active_environment(self, tmp_path, monkeypatch):
+        cfg = self._write_user_config(tmp_path, "[environments.dev]\n")
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        env = resolve_environment(
+            system_config=tmp_path / "missing-system.toml",
+            user_config=cfg,
+            project_config=tmp_path / "missing-project.toml",
+        )
+        assert env is None

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1196,3 +1196,137 @@ class TestActivateEnvironmentHelper:
         applied = sunstone.activate_environment(user_config=cfg)
         assert applied == {}
         assert os.environ["MY_CATALOG_URL"] == "from-shell"
+
+
+# ---------------------------------------------------------------------------
+# Scoped writes (Task 14)
+# ---------------------------------------------------------------------------
+
+
+class TestScopedWrites:
+    def _write_config(self, path, body):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_add_environment_to_project_scope(self, tmp_path):
+        from sunstone.env import add_environment
+
+        prj_cfg = tmp_path / ".sunstone" / "data_platform.toml"
+        path = add_environment(
+            "dev",
+            plain={"CATALOG_URL": "https://x"},
+            scope="project",
+            project_config=prj_cfg,
+        )
+        assert path == prj_cfg
+        import tomllib
+
+        with open(prj_cfg, "rb") as f:
+            data = tomllib.load(f)
+        assert data["environments"]["dev"]["CATALOG_URL"] == "https://x"
+
+    def test_add_environment_to_system_scope(self, tmp_path):
+        from sunstone.env import add_environment
+
+        sys_cfg = tmp_path / "etc" / "sunstone" / "data_platform.toml"
+        path = add_environment(
+            "dev",
+            plain={"K": "v"},
+            scope="system",
+            system_config=sys_cfg,
+        )
+        assert path == sys_cfg
+
+    def test_update_environment_project_scope_merges(self, tmp_path):
+        from sunstone.env import update_environment
+
+        prj_cfg = tmp_path / ".sunstone" / "data_platform.toml"
+        self._write_config(
+            prj_cfg,
+            """
+            [environments.dev]
+            EXISTING = "y"
+            """,
+        )
+        path, shadow = update_environment(
+            "dev",
+            plain={"NEW": "z"},
+            scope="project",
+            project_config=prj_cfg,
+        )
+        assert path == prj_cfg
+        assert shadow is None  # project is top of cascade
+
+    def test_unset_environment_keys_project_scope(self, tmp_path):
+        from sunstone.env import unset_environment_keys
+
+        prj_cfg = tmp_path / ".sunstone" / "data_platform.toml"
+        self._write_config(
+            prj_cfg,
+            """
+            [environments.dev]
+            KEEP = "k"
+            DROP = "d"
+            """,
+        )
+        path, removed = unset_environment_keys(
+            "dev",
+            keys=["DROP"],
+            scope="project",
+            project_config=prj_cfg,
+        )
+        assert path == prj_cfg
+        assert removed == 1
+
+    def test_remove_environment_from_system_scope(self, tmp_path):
+        from sunstone.env import remove_environment
+
+        sys_cfg = tmp_path / "etc" / "sunstone" / "data_platform.toml"
+        self._write_config(
+            sys_cfg,
+            """
+            [environments.dev]
+            X = "y"
+            """,
+        )
+        path = remove_environment(
+            "dev",
+            scope="system",
+            system_config=sys_cfg,
+        )
+        assert path == sys_cfg
+        import tomllib
+
+        with open(sys_cfg, "rb") as f:
+            data = tomllib.load(f)
+        assert "dev" not in data.get("environments", {})
+
+    def test_unknown_scope_raises(self):
+        from sunstone.env import add_environment
+
+        with pytest.raises(ValueError, match="Unknown scope"):
+            add_environment("dev", plain={"K": "v"}, scope="bogus")
+
+    def test_update_environment_system_scope_warns_project_and_user_shadow(self, tmp_path, monkeypatch):
+        from sunstone.env import update_environment
+
+        sys_cfg = tmp_path / "etc" / "data_platform.toml"
+        usr_cfg = tmp_path / "user" / "data_platform.toml"
+        prj_cfg = tmp_path / ".sunstone" / "data_platform.toml"
+        self._write_config(sys_cfg, '[environments.dev]\nX = "y"\n')
+        self._write_config(usr_cfg, '[environments.dev]\nX = "y"\n')
+        self._write_config(prj_cfg, '[environments.dev]\nX = "y"\n')
+
+        # Patch the auto-discovery so _find_project_config returns prj_cfg.
+        monkeypatch.setattr("sunstone.env._find_project_config", lambda: prj_cfg)
+
+        path, shadow = update_environment(
+            "dev",
+            plain={"NEW": "z"},
+            scope="system",
+            system_config=sys_cfg,
+            user_config=usr_cfg,
+        )
+        assert path == sys_cfg
+        # Project shadows over system; report project path.
+        assert shadow == str(prj_cfg)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -29,40 +29,6 @@ from sunstone.env import (
 )
 
 
-# ---------------------------------------------------------------------------
-# DataEnvironment dataclass
-# ---------------------------------------------------------------------------
-
-
-class TestDataEnvironment:
-    def test_frozen(self):
-        env = DataEnvironment(
-            name="test",
-            catalog_url="http://localhost:19120",
-            s3_endpoint="http://localhost:9000",
-            s3_access_key="key",
-            s3_secret_key="secret",
-            auth=None,
-            source="test",
-        )
-        with pytest.raises(FrozenInstanceError):
-            env.name = "other"  # type: ignore[misc]
-
-    def test_fields(self):
-        env = DataEnvironment(
-            name="prod",
-            catalog_url="https://nessie.prod.example.com",
-            s3_endpoint="https://s3.prod.example.com",
-            s3_access_key=None,
-            s3_secret_key=None,
-            auth="gcloud-adc",
-            source="/etc/sunstone/data_platform.toml",
-        )
-        assert env.name == "prod"
-        assert env.auth == "gcloud-adc"
-        assert env.s3_access_key is None
-
-
 def test_import_env_tolerates_missing_home(monkeypatch):
     """Reloading sunstone.env should not fail when Path.home() is unavailable."""
     import sunstone.env as env_mod
@@ -333,199 +299,6 @@ def _write_toml(path: Path, content: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
     return path
-
-
-class TestResolveEnvironmentLegacy:
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_full_cascade(self, tmp_path: Path):
-        system = _write_toml(
-            tmp_path / "system.toml",
-            '[environments.prod]\ncatalog_url = "http://sys-prod"\ns3_endpoint = "http://sys-s3"\n',
-        )
-        user = _write_toml(
-            tmp_path / "user.toml",
-            'active = "prod"\n',
-        )
-
-        with patch.dict("os.environ", {}, clear=True):
-            env = resolve_environment(
-                system_config=system,
-                user_config=user,
-                project_config=tmp_path / "nonexistent.toml",
-            )
-
-        assert env is not None
-        assert env.name == "prod"
-        assert env.catalog_url == "http://sys-prod"  # type: ignore[attr-defined]
-        assert env.s3_endpoint == "http://sys-s3"  # type: ignore[attr-defined]
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_env_var_field_overrides(self, tmp_path: Path):
-        system = _write_toml(
-            tmp_path / "system.toml",
-            'active = "dev"\n[environments.dev]\ncatalog_url = "http://original"\ns3_endpoint = "http://original-s3"\n',
-        )
-
-        overrides = {
-            "SUNSTONE_DATA_CATALOG_URL": "http://overridden",
-            "SUNSTONE_DATA_S3_ENDPOINT": "http://overridden-s3",
-            "SUNSTONE_DATA_S3_ACCESS_KEY": "env-key",
-            "SUNSTONE_DATA_S3_SECRET_KEY": "env-secret",
-        }
-        with patch.dict("os.environ", overrides, clear=True):
-            env = resolve_environment(
-                system_config=system,
-                user_config=tmp_path / "none.toml",
-                project_config=tmp_path / "none2.toml",
-            )
-
-        assert env is not None
-        assert env.catalog_url == "http://overridden"  # type: ignore[attr-defined]
-        assert env.s3_endpoint == "http://overridden-s3"  # type: ignore[attr-defined]
-        assert env.s3_access_key == "env-key"  # type: ignore[attr-defined]
-        assert env.s3_secret_key == "env-secret"  # type: ignore[attr-defined]
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_empty_env_vars_do_not_override_config(self, tmp_path: Path):
-        system = _write_toml(
-            tmp_path / "system.toml",
-            'active = "dev"\n[environments.dev]\ncatalog_url = "http://original"\ns3_endpoint = "http://original-s3"\ns3_access_key = "configured-key"\ns3_secret_key = "configured-secret"\n',
-        )
-
-        overrides = {
-            "SUNSTONE_DATA_CATALOG_URL": "",
-            "SUNSTONE_DATA_S3_ENDPOINT": "",
-            "SUNSTONE_DATA_S3_ACCESS_KEY": "",
-            "SUNSTONE_DATA_S3_SECRET_KEY": "",
-        }
-        with patch.dict("os.environ", overrides, clear=True):
-            env = resolve_environment(
-                system_config=system,
-                user_config=tmp_path / "none.toml",
-                project_config=tmp_path / "none2.toml",
-            )
-
-        assert env is not None
-        assert env.catalog_url == "http://original"  # type: ignore[attr-defined]
-        assert env.s3_endpoint == "http://original-s3"  # type: ignore[attr-defined]
-        assert env.s3_access_key == "configured-key"  # type: ignore[attr-defined]
-        assert env.s3_secret_key == "configured-secret"  # type: ignore[attr-defined]
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_returns_none_when_nothing_configured(self, tmp_path: Path):
-        with patch.dict("os.environ", {}, clear=True):
-            env = resolve_environment(
-                system_config=tmp_path / "no.toml",
-                user_config=tmp_path / "no2.toml",
-                project_config=tmp_path / "no3.toml",
-            )
-        assert env is None
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_raises_for_unknown_active_env(self, tmp_path: Path):
-        config = _write_toml(
-            tmp_path / "user.toml",
-            'active = "nonexistent"\n',
-        )
-        with patch.dict("os.environ", {}, clear=True):
-            with pytest.raises(ValueError, match="nonexistent"):
-                resolve_environment(
-                    system_config=tmp_path / "no.toml",
-                    user_config=config,
-                    project_config=tmp_path / "no2.toml",
-                )
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_env_var_selects_environment(self, tmp_path: Path):
-        system = _write_toml(
-            tmp_path / "system.toml",
-            '[environments.staging]\ncatalog_url = "http://staging"\ns3_endpoint = "http://staging-s3"\n',
-        )
-
-        with patch.dict("os.environ", {"SUNSTONE_DATA_ENV": "staging"}, clear=True):
-            env = resolve_environment(
-                system_config=system,
-                user_config=tmp_path / "no.toml",
-                project_config=tmp_path / "no2.toml",
-            )
-
-        assert env is not None
-        assert env.name == "staging"
-        assert env.source == "SUNSTONE_DATA_ENV"
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_project_config_environments(self, tmp_path: Path):
-        project = _write_toml(
-            tmp_path / ".sunstone" / "data_platform.toml",
-            'active = "local"\n'
-            "[environments.local]\n"
-            'catalog_url = "http://localhost:19120"\n'
-            's3_endpoint = "http://localhost:9000"\n',
-        )
-
-        with patch.dict("os.environ", {}, clear=True):
-            env = resolve_environment(
-                system_config=tmp_path / "no.toml",
-                user_config=tmp_path / "no2.toml",
-                project_config=project,
-            )
-
-        assert env is not None
-        assert env.name == "local"
-        assert env.catalog_url == "http://localhost:19120"  # type: ignore[attr-defined]
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_field_level_merge_across_layers(self, tmp_path: Path):
-        system = _write_toml(
-            tmp_path / "system.toml",
-            '[environments.dev]\nauth = "basic"\ns3_endpoint = "http://sys-s3"\n',
-        )
-        user = _write_toml(
-            tmp_path / "user.toml",
-            'active = "dev"\n[environments.dev]\ns3_access_key = "user-key"\n',
-        )
-        project = _write_toml(
-            tmp_path / "project.toml",
-            '[environments.dev]\ncatalog_url = "http://project-dev"\n',
-        )
-
-        with patch.dict("os.environ", {}, clear=True):
-            env = resolve_environment(
-                system_config=system,
-                user_config=user,
-                project_config=project,
-            )
-
-        assert env is not None
-        assert env.name == "dev"
-        assert env.catalog_url == "http://project-dev"  # type: ignore[attr-defined]
-        assert env.s3_endpoint == "http://sys-s3"  # type: ignore[attr-defined]
-        assert env.s3_access_key == "user-key"  # type: ignore[attr-defined]
-        assert env.auth == "basic"  # type: ignore[attr-defined]
-
-    @pytest.mark.skip(reason="Legacy DataEnvironment tests; removed in Task 6")
-    def test_credential_resolution(self, tmp_path: Path):
-        config = _write_toml(
-            tmp_path / "config.toml",
-            'active = "test"\n'
-            "[environments.test]\n"
-            'catalog_url = "http://test"\n'
-            's3_endpoint = "http://test-s3"\n'
-            's3_access_key = "op://vault/item/key"\n'
-            's3_secret_key = "literal-secret"\n',
-        )
-
-        with patch.dict("os.environ", {}, clear=True):
-            with patch("sunstone.env._resolve_op_reference", return_value="resolved-key"):
-                env = resolve_environment(
-                    system_config=config,
-                    user_config=tmp_path / "no.toml",
-                    project_config=tmp_path / "no2.toml",
-                )
-
-        assert env is not None
-        assert env.s3_access_key == "resolved-key"  # type: ignore[attr-defined]
-        assert env.s3_secret_key == "literal-secret"  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -1315,3 +1088,32 @@ class TestLegacyEnvVarOverridesRemoved:
         # The old override env var must NOT bleed into resolved vars.
         assert env.vars["CATALOG_URL"] == "from-config"
         assert "SUNSTONE_DATA_CATALOG_URL" not in env.vars
+
+
+# ---------------------------------------------------------------------------
+# DataEnvironment deprecation alias (Task 6)
+# ---------------------------------------------------------------------------
+
+
+class TestDataEnvironmentDeprecationAlias:
+    def test_old_name_is_alias_for_environment(self):
+        from sunstone.env import Environment
+
+        assert DataEnvironment is Environment
+
+    def test_old_typed_attrs_are_gone(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "data_platform.toml"
+        cfg.write_text(
+            """
+            active = "dev"
+
+            [environments.dev]
+            CATALOG_URL = "x"
+            """
+        )
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+        env = resolve_environment(user_config=cfg)
+        assert env is not None
+        assert not hasattr(env, "catalog_url")
+        assert not hasattr(env, "s3_endpoint")
+        assert not hasattr(env, "auth")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1116,3 +1116,38 @@ class TestDataEnvironmentDeprecationAlias:
         assert not hasattr(env, "catalog_url")
         assert not hasattr(env, "s3_endpoint")
         assert not hasattr(env, "auth")
+
+
+class TestActivateEnvironmentHelper:
+    def test_module_helper_resolves_and_activates(self, tmp_path, monkeypatch):
+        import sunstone
+
+        cfg = tmp_path / "data_platform.toml"
+        cfg.write_text(
+            """
+            active = "dev"
+
+            [environments.dev]
+            MY_CATALOG_URL = "https://data.dev.example.com"
+            """
+        )
+        monkeypatch.delenv("MY_CATALOG_URL", raising=False)
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        applied = sunstone.activate_environment(user_config=cfg)
+        assert applied == {"MY_CATALOG_URL": "https://data.dev.example.com"}
+        assert os.environ["MY_CATALOG_URL"] == "https://data.dev.example.com"
+
+    def test_module_helper_returns_empty_dict_when_no_active_env(self, tmp_path, monkeypatch):
+        import sunstone
+
+        empty = tmp_path / "data_platform.toml"
+        empty.write_text("")
+        monkeypatch.delenv("SUNSTONE_DATA_ENV", raising=False)
+
+        applied = sunstone.activate_environment(
+            system_config=tmp_path / "missing-sys.toml",
+            user_config=empty,
+            project_config=tmp_path / "missing-prj.toml",
+        )
+        assert applied == {}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -11,6 +11,7 @@ import typer
 from sunstone.plugins import (
     AuthProvider,
     CLIProvider,
+    EnvSectionProvider,
     FormatHandler,
     URLHandler,
     PluginRegistry,
@@ -861,3 +862,58 @@ def test_cli_provider_exception_does_not_hide_other_groups():
     groups = registry.get_cli_groups()
     assert len(groups) == 1
     assert groups[0][0] == "test"
+
+
+# --- EnvSectionProvider tests ---
+
+
+class FakeEnvSection:
+    """Validated model returned by FakeEnvSectionProvider."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class FakeEnvSectionProvider:
+    def env_section_name(self):
+        return "fake-platform"
+
+    def env_section_model(self):
+        return FakeEnvSection
+
+
+def test_registry_discovers_env_section_provider():
+
+    with patch(
+        "sunstone.plugins._get_entry_points",
+        return_value=[_make_entry_point("fake-section", FakeEnvSectionProvider)],
+    ):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            providers = registry.get_env_section_providers()
+            assert len(providers) == 1
+            assert isinstance(providers[0], EnvSectionProvider)
+            assert providers[0].env_section_name() == "fake-platform"
+
+
+def test_registry_multi_protocol_with_env_section():
+    """A single plugin can implement EnvSectionProvider plus other protocols."""
+
+    class MultiPlugin:
+        def authenticate(self, url, headers, dataset):
+            return headers
+
+        def env_section_name(self):
+            return "multi"
+
+        def env_section_model(self):
+            return FakeEnvSection
+
+    with patch(
+        "sunstone.plugins._get_entry_points",
+        return_value=[_make_entry_point("multi", MultiPlugin)],
+    ):
+        with patch("sunstone.plugins._load_plugin_config", return_value=None):
+            registry = PluginRegistry.get()
+            assert len(registry.get_auth_providers()) == 1
+            assert len(registry.get_env_section_providers()) == 1

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -894,6 +894,9 @@ def test_registry_discovers_env_section_provider():
             assert len(providers) == 1
             assert isinstance(providers[0], EnvSectionProvider)
             assert providers[0].env_section_name() == "fake-platform"
+            model_cls = providers[0].env_section_model()
+            instance = model_cls(key="val")
+            assert instance.kwargs == {"key": "val"}
 
 
 def test_registry_multi_protocol_with_env_section():


### PR DESCRIPTION
## Summary

- Replace typed `DataEnvironment(catalog_url, s3_endpoint, ...)` with generic `Environment(name, source, vars, sections)`; plugins register typed config sections via new `EnvSectionProvider` protocol. `DataEnvironment` survives as a deprecated alias.
- Active-environment keys flatten (top-level scalars + plugin-namespaced subtables) and layer onto `os.environ` so `${VAR}` substitution in `publish.as:` / `publish.to:` resolves naturally. Real env vars still win. New `sunstone.activate_environment()` helper for notebooks/library callers.
- CLI converges on `KEY=VAL` shape: `env add` / `env set` / `env unset` all generic, with dotted keys (`data-platform.warehouse=main`) writing to plugin subtables. `env update` removed (use `env set`). `env show` summary is generic. Top-level callback wires activation for non-`env` subcommands.

Removed: `--catalog-url`/`--s3-endpoint`/`--s3-*`/`--auth` flags on `env add`; `SUNSTONE_DATA_CATALOG_URL` and `SUNSTONE_DATA_S3_*` per-field overrides; `DataEnvironment.catalog_url`/`s3_endpoint`/`auth`/etc. attributes (the alias survives, the typed fields don't).

Design context: `docs/superpowers/specs/2026-05-19-generic-env-config-design.md`. Implementation plan: `docs/superpowers/plans/2026-05-19-generic-env-config.md`.

## Coordination note

The `data-platform` repo currently reads `env.catalog_url` etc. directly. A sibling plan in that repo needs to implement `EnvSectionProvider` and switch `discovery.py`/`config.py` to consume `env.section("data-platform")` (with `os.environ["CATALOG_URL"]` as a transparent fallback for old user configs). That work should land alongside or before a sunstone-py release that includes this PR.

## Test Plan

- [x] `uv run pytest -q` — 1156 passed
- [x] `uv run ruff check src/sunstone tests` — clean
- [x] `uv run mypy src/sunstone` — clean
- [ ] Smoke test: `[environments.dev] CATALOG_URL = "..."` + `${CATALOG_URL}` in `publish.as:` resolves at publish time
- [ ] Smoke test: `[environments.dev."data-platform"] catalog_url = "..."` flattens to `DATA_PLATFORM_CATALOG_URL` and is visible in `os.environ` after activation
- [ ] Cross-repo: data-platform's `EnvSectionProvider` PR lands and tests pass against this branch