### PR TITLE
feat(pandas): add read_json() wrapper to sunstone.pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: `pd.read_json()` wrapper in `sunstone.pandas` for parity with `read_csv`/`read_excel` (closes #67).
 - Fixed: `to_csv()`/`to_parquet()` fall back to session-accumulated sources when the DataFrame has empty lineage (#19).
 
 ## [1.11.0] - 2026-05-19

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -23,7 +23,7 @@ sidecar and still describe itself.
 
 ## Reading and writing
 
-The pandas-compatible wrapper exposes three readers, all of which dispatch
+The pandas-compatible wrapper exposes four readers, all of which dispatch
 to the right format handler by extension (or by an explicit `format=` for
 `read_dataset`):
 
@@ -32,6 +32,7 @@ from sunstone import pandas as pd
 
 df = pd.read_csv('inputs/data.csv')      # csv, tsv (via .tsv/.txt)
 df = pd.read_excel('inputs/data.xlsx')   # xlsx, xls
+df = pd.read_json('inputs/data.json')    # json
 df = pd.read_dataset('my-slug')          # any format; uses datasets.yaml location
 ```
 
@@ -149,7 +150,7 @@ Format detection follows this order:
 2. The file extension (`.csv` → csv, `.tsv`/`.txt` → tsv, `.json` →
    json, `.xlsx`/`.xls` → excel, `.parquet` → parquet).
 3. For `read_csv` the format is always `csv`; for `read_excel` always
-   `excel`.
+   `excel`; for `read_json` always `json`.
 
 URLs are supported wherever local paths are — the URL handler reads the
 bytes, then the format handler parses them.

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -672,6 +672,120 @@ class DataFrame:
         # Return wrapped DataFrame
         return cls(data=df, metadata=metadata, strict=strict, project_path=project_path)
 
+    @classmethod
+    def read_json(
+        cls,
+        filepath_or_buffer: Union[str, Path],
+        project_path: Optional[Union[str, Path]] = None,
+        strict: Optional[bool] = None,
+        fetch_from_url: bool = True,
+        **kwargs: Any,
+    ) -> "DataFrame":
+        """
+        Read a JSON file into a Sunstone DataFrame.
+
+        The file must be registered in datasets.yaml, otherwise this will fail
+        (or in relaxed mode, register it automatically).
+
+        Args:
+            filepath_or_buffer: Path to JSON file or dataset slug.
+                              If it's a slug (e.g., 'my-json-data'),
+                              the dataset will be looked up in datasets.yaml.
+            project_path: Path to project directory containing datasets.yaml.
+            strict: Whether to operate in strict mode.
+            fetch_from_url: If True and dataset has a source URL but no local file,
+                          automatically fetch from URL.
+            **kwargs: Additional arguments passed to pandas.read_json.
+
+        Returns:
+            A new Sunstone DataFrame with lineage metadata.
+
+        Raises:
+            DatasetNotFoundError: In strict mode, if dataset not found in datasets.yaml.
+            FileNotFoundError: If datasets.yaml doesn't exist.
+
+        Examples:
+            >>> # Load by slug
+            >>> df = DataFrame.read_json('my-json-data', project_path='/path/to/project')
+            >>>
+            >>> # Load by file path
+            >>> df = DataFrame.read_json('inputs/data.json', project_path='/path/to/project')
+        """
+        location = str(filepath_or_buffer)
+
+        # Determine if this is a slug or a file path
+        is_slug = "/" not in location and "\\" not in location and not Path(location).suffix
+
+        if is_slug:
+            return cls.read_dataset(
+                slug=location,
+                project_path=project_path,
+                strict=strict,
+                fetch_from_url=fetch_from_url,
+                format="json",
+                **kwargs,
+            )
+
+        # File path - handle with original logic
+        if project_path is None:
+            project_path = get_project_path()
+
+        manager = DatasetsManager(project_path)
+
+        # Look up by location
+        dataset = manager.find_dataset_by_location(location)
+        if dataset is None:
+            if strict or (strict is None and cls._get_default_strict_mode()):
+                raise DatasetNotFoundError(
+                    f"Dataset at '{location}' not found in datasets.yaml. "
+                    f"In strict mode, all datasets must be registered."
+                )
+            else:
+                raise DatasetNotFoundError(
+                    f"Dataset at '{location}' not found in datasets.yaml. Please add it to datasets.yaml first."
+                )
+
+        # Use the requested location
+        absolute_path = manager.get_absolute_path(location)
+
+        # If file doesn't exist and we have a source URL, fetch it
+        if not absolute_path.exists() and fetch_from_url:
+            if dataset.source and dataset.source.location.data:
+                absolute_path = manager.fetch_from_url(dataset)
+            else:
+                raise FileNotFoundError(
+                    f"File not found: {absolute_path}\nDataset '{dataset.slug}' has no source URL to fetch from."
+                )
+
+        # Read via format handler registry
+        from .plugins import PluginRegistry
+
+        registry = PluginRegistry.get(manager.project_path)
+        location = str(absolute_path)
+        format_handler = registry.find_format_reader(location, "json")
+        if format_handler is None:
+            raise ValueError("No format handler found for JSON files")
+
+        url_handler = registry.find_url_handler(location)
+        if url_handler is None:
+            raise ValueError(f"No URL handler found for '{location}'")
+
+        with url_handler.open(location, "rb") as stream:
+            df = format_handler.read(stream, format="json", path=location, **kwargs)
+
+        # Create lineage metadata
+        metadata = Metadata(lineage=LineageMetadata(project_path=str(manager.project_path)))
+        metadata.lineage.add_source(dataset)
+        metadata.lineage.populate_field_derivations(list(df.columns), dataset.slug)
+
+        # Record read in lineage session
+        from .session import DatasetRead, get_session
+
+        get_session().record_read(DatasetRead(slug=dataset.slug))
+
+        # Return wrapped DataFrame
+        return cls(data=df, metadata=metadata, strict=strict, project_path=project_path)
+
     @staticmethod
     def _get_default_strict_mode() -> bool:
         """Get the default strict mode from environment variable."""

--- a/src/sunstone/pandas.py
+++ b/src/sunstone/pandas.py
@@ -48,6 +48,7 @@ Series = _pd.Series  # Re-export pandas Series
 __all__ = [
     "read_csv",
     "read_excel",
+    "read_json",
     "read_dataset",
     "merge",
     "concat",
@@ -225,6 +226,56 @@ def read_excel(
         >>> df = pd.read_excel('data.xlsx', project_path='/path/to/project')
     """
     return DataFrame.read_excel(
+        filepath_or_buffer=filepath_or_buffer,
+        project_path=project_path,
+        strict=strict,
+        fetch_from_url=fetch_from_url,
+        **kwargs,
+    )
+
+
+def read_json(
+    filepath_or_buffer: str | Path,
+    project_path: str | Path | None = None,
+    strict: bool | None = None,
+    fetch_from_url: bool = True,
+    **kwargs: Any,
+) -> DataFrame:
+    """
+    Read a JSON file into a Sunstone DataFrame with lineage tracking.
+
+    This function provides a pandas-like interface while ensuring the dataset
+    is registered in datasets.yaml and lineage is tracked.
+
+    Args:
+        filepath_or_buffer: Path to JSON file or dataset slug.
+                          If it's a slug (e.g., 'my-json-data'),
+                          the dataset will be looked up in datasets.yaml.
+        project_path: Path to project directory containing datasets.yaml.
+                     Defaults to current working directory.
+        strict: Whether to operate in strict mode. If None, reads from
+               SUNSTONE_DATAFRAME_STRICT environment variable.
+        fetch_from_url: If True and dataset has a source URL but no local file,
+                      automatically fetch from URL.
+        **kwargs: Additional arguments passed to pandas.read_json.
+
+    Returns:
+        A Sunstone DataFrame with lineage metadata.
+
+    Raises:
+        DatasetNotFoundError: If dataset not found in datasets.yaml.
+        FileNotFoundError: If datasets.yaml doesn't exist.
+
+    Examples:
+        >>> from sunstone import pandas as pd
+        >>>
+        >>> # Load by slug (recommended, uses cwd as project path)
+        >>> df = pd.read_json('my-json-data')
+        >>>
+        >>> # Load by file path with explicit project path
+        >>> df = pd.read_json('data.json', project_path='/path/to/project')
+    """
+    return DataFrame.read_json(
         filepath_or_buffer=filepath_or_buffer,
         project_path=project_path,
         strict=strict,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,7 +417,7 @@ class TestDatasetLockUnlockCommands:
         """Test enabling strict mode for all datasets."""
         result = runner.invoke(app, ["dataset", "strict", "-f", str(test_project / "datasets.yaml")])
         assert result.exit_code == 0
-        assert "Strict mode enabled for 3 dataset(s)" in result.output
+        assert "Strict mode enabled for 4 dataset(s)" in result.output
 
     def test_unstrict_dataset(self, runner: CliRunner, test_project: Path) -> None:
         """Test disabling strict mode for a dataset."""

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -119,6 +119,70 @@ class TestReadExcel:
         assert isinstance(df, sunstone.DataFrame)
 
 
+class TestReadJson:
+    """Tests for reading JSON files."""
+
+    def test_read_json_by_path(self, project_path: Path) -> None:
+        """Test reading a JSON file by path."""
+        df = sunstone.DataFrame.read_json(
+            "inputs/un_member_states_sample.json",
+            project_path=project_path,
+            strict=False,
+        )
+
+        assert df is not None
+        assert len(df.data) == 5
+        assert len(df.data.columns) > 0
+        assert len(df.metadata.lineage.sources) > 0
+        assert "Member State" in df.data.columns
+
+    def test_read_json_by_slug(self, project_path: Path) -> None:
+        """Test reading a JSON file by slug."""
+        df = sunstone.DataFrame.read_json(
+            "un-member-states-sample-json",
+            project_path=project_path,
+            strict=False,
+        )
+
+        assert df is not None
+        assert len(df.data) == 5
+        assert len(df.metadata.lineage.sources) > 0
+
+    def test_read_json_preserves_lineage(self, project_path: Path) -> None:
+        """Test that read_json tracks lineage correctly."""
+        df = sunstone.DataFrame.read_json(
+            "inputs/un_member_states_sample.json",
+            project_path=project_path,
+            strict=False,
+        )
+
+        assert df.metadata.lineage.sources[0].slug == "un-member-states-sample-json"
+
+    def test_read_json_not_found(self, project_path: Path) -> None:
+        """Test that read_json raises error for unregistered file."""
+        from sunstone.exceptions import DatasetNotFoundError
+
+        with pytest.raises(DatasetNotFoundError):
+            sunstone.DataFrame.read_json(
+                "inputs/nonexistent.json",
+                project_path=project_path,
+                strict=True,
+            )
+
+    def test_read_json_via_pandas_module(self, project_path: Path) -> None:
+        """Test read_json via sunstone.pandas module."""
+        from sunstone import pandas as spd
+
+        df = spd.read_json(
+            "un-member-states-sample-json",
+            project_path=project_path,
+        )
+
+        assert df is not None
+        assert len(df.data) == 5
+        assert isinstance(df, sunstone.DataFrame)
+
+
 class TestDataFrameMerge:
     """Tests for DataFrame merge operations."""
 

--- a/tests/testdata/UNMembersProject/datasets.yaml
+++ b/tests/testdata/UNMembersProject/datasets.yaml
@@ -66,6 +66,16 @@ inputs:
         type: string
       - name: Russian
         type: string
+  - name: UN Member States Sample (JSON)
+    slug: un-member-states-sample-json
+    location: inputs/un_member_states_sample.json
+    fields:
+      - name: Member State
+        type: string
+      - name: ISO Code
+        type: string
+      - name: M49 Code
+        type: string
   - name: UN Member States Sample (Excel)
     slug: un-member-states-sample-excel
     location: inputs/un_member_states_sample.xlsx

--- a/tests/testdata/UNMembersProject/inputs/un_member_states_sample.json
+++ b/tests/testdata/UNMembersProject/inputs/un_member_states_sample.json
@@ -1,0 +1,7 @@
+[
+  {"Member State": "Afghanistan", "ISO Code": "AF", "M49 Code": "004"},
+  {"Member State": "Albania", "ISO Code": "AL", "M49 Code": "008"},
+  {"Member State": "Algeria", "ISO Code": "DZ", "M49 Code": "012"},
+  {"Member State": "Andorra", "ISO Code": "AD", "M49 Code": "020"},
+  {"Member State": "Angola", "ISO Code": "AO", "M49 Code": "024"}
+]


### PR DESCRIPTION
## Summary

- Adds `read_json()` to `sunstone.pandas` (and `DataFrame.read_json`) mirroring `read_csv` / `read_excel`. Supports slug or file-path lookup, dataset registration, and lineage tracking.
- The format handler already supported reading JSON via `read_dataset`; this restores the convenience wrapper the 1.4.0 changelog claimed but `main` was missing.
- Updates `docs/formats.md` overview table, reading/writing snippet, and format-detection list to include `read_json`.

## Test plan

- [x] `uv run pytest -q` → 1120 passed (5 new `TestReadJson` cases: by-path, by-slug, lineage, strict-not-found, via `sunstone.pandas`).
- [x] Updated `tests/test_cli.py::test_strict_all_datasets` count (3 → 4) for new JSON dataset in the UN members fixture.

Closes #67.