### PR TITLE
perf(cli): lazy-load pandas/pyarrow/numpy for ~7x faster startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Changed: `sunstone` CLI startup is ~7× faster (~500 ms → ~70 ms) by deferring pandas/pyarrow/numpy imports until actually needed.
 
 ## [1.12.1] - 2026-05-22
 

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -23,76 +23,35 @@ Example:
     ...     name='Filtered School Counts',
     ...     index=False
     ... )
+
+The public surface (classes, helpers, submodules) is imported lazily via PEP 562
+``__getattr__``. ``import sunstone`` is cheap; pandas, pyarrow, numpy, etc. are
+only loaded when an attribute that needs them is actually accessed.
 """
 
-from .asset import Asset, AssetKind
-from .component import ComponentSchema
-from .config import (
-    clear_project_path,
-    get_project_path,
-    set_project_path,
-    use_project_path,
-)
-from .dataframe import DataFrame
-from .datasets import DatasetsManager
-from .errors import IncompatibleAssetKindError
-from .exceptions import (
-    DatasetNotFoundError,
-    DatasetValidationError,
-    LineageError,
-    StrictModeError,
-    SunstoneError,
-    UnitError,
-)
-from .rdf import IRI, LangString, TypedLiteral
-from .lineage import (
-    Activity,
-    ActivityRef,
-    Agent,
-    AgentType,
-    Contributor,
-    DatasetMetadata,
-    EntityRef,
-    FieldDerivation,
-    FieldSchema,
-    LineageMetadata,
-    Metadata,
-    PackageMetadata,
-    Source,
-    SourceLocation,
-    UsageRecord,
-)
+from __future__ import annotations
 
-# Plugin system
-from .plugins import AuthProvider, CLIProvider, FormatHandler, PluginRegistry, URLHandler
+import importlib
+from typing import TYPE_CHECKING, Any
 
-# Environment config
-from .env import DataEnvironment, Environment, activate_environment, resolve_environment
-
-# Packaging (library functions for building and pushing data packages)
-from . import packaging
-
-# Import pandas module for pd-like interface
-from . import pandas
-
-# Import errors module (re-exports pandas.errors)
-from . import errors
-
-# Import validation utilities
-from .validation import (
-    ImportCheckResult,
-    check_notebook_imports,
-    check_script_imports,
-    validate_project_notebooks,
-)
-
-# Linter
-from .lint import LintReport, Severity as LintSeverity, Violation, lint_project
-
-# Lineage tracking modules
-from .context import ExecutionContext, detect_execution_context
-from .queries import LineageNode, display_lineage, get_upstream, lineage_to_dict
-from .session import DatasetRead, LineageSession, close_session, get_session
+# Standard RDF and DCAT prefixes for automatic type properties.
+# Eager because the dict is cheap and frequently consulted by the CLI.
+STANDARD_RDF_PREFIXES = {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "dwc": "http://rs.tdwg.org/dwc/terms/",
+    "gtio-i": "https://sunstone.institute/rdf/gtio/0.3/interventions#",
+    "gtio-t": "https://sunstone.institute/rdf/gtio/0.3/threats#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "qudt": "http://qudt.org/schema/qudt/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
+    "si": "https://sunstone.institute/rdf/vocab#",
+    "si30": "https://sunstone.institute/rdf/threat/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "sosa": "http://www.w3.org/ns/sosa/",
+}
 
 
 def read(
@@ -224,23 +183,185 @@ def write(asset: "Asset", path: str, *, format: str | None = None, **kw: object)
     raise ValueError(f"No handler for path={path!r} format={format!r}")
 
 
-# Standard RDF and DCAT prefixes for automatic type properties
-STANDARD_RDF_PREFIXES = {
-    "dcat": "http://www.w3.org/ns/dcat#",
-    "dct": "http://purl.org/dc/terms/",
-    "dwc": "http://rs.tdwg.org/dwc/terms/",
-    "gtio-i": "https://sunstone.institute/rdf/gtio/0.3/interventions#",
-    "gtio-t": "https://sunstone.institute/rdf/gtio/0.3/threats#",
-    "prov": "http://www.w3.org/ns/prov#",
-    "qudt": "http://qudt.org/schema/qudt/",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "schema": "http://schema.org/",
-    "si": "https://sunstone.institute/rdf/vocab#",
-    "si30": "https://sunstone.institute/rdf/threat/",
-    "skos": "http://www.w3.org/2004/02/skos/core#",
-    "sosa": "http://www.w3.org/ns/sosa/",
+# --- Lazy attribute machinery (PEP 562) -------------------------------------
+# Map of public attribute -> (submodule, attribute in submodule). Resolved on
+# first access via ``__getattr__``; the result is cached in this module's
+# globals so subsequent accesses are direct.
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    # Asset envelope
+    "Asset": ("sunstone.asset", "Asset"),
+    "AssetKind": ("sunstone.asset", "AssetKind"),
+    # Component
+    "ComponentSchema": ("sunstone.component", "ComponentSchema"),
+    # Project-path configuration
+    "clear_project_path": ("sunstone.config", "clear_project_path"),
+    "get_project_path": ("sunstone.config", "get_project_path"),
+    "set_project_path": ("sunstone.config", "set_project_path"),
+    "use_project_path": ("sunstone.config", "use_project_path"),
+    # DataFrame and datasets manager
+    "DataFrame": ("sunstone.dataframe", "DataFrame"),
+    "DatasetsManager": ("sunstone.datasets", "DatasetsManager"),
+    # Errors (sunstone-specific)
+    "IncompatibleAssetKindError": ("sunstone.errors", "IncompatibleAssetKindError"),
+    # Exceptions
+    "DatasetNotFoundError": ("sunstone.exceptions", "DatasetNotFoundError"),
+    "DatasetValidationError": ("sunstone.exceptions", "DatasetValidationError"),
+    "LineageError": ("sunstone.exceptions", "LineageError"),
+    "StrictModeError": ("sunstone.exceptions", "StrictModeError"),
+    "SunstoneError": ("sunstone.exceptions", "SunstoneError"),
+    "UnitError": ("sunstone.exceptions", "UnitError"),
+    # RDF types
+    "IRI": ("sunstone.rdf", "IRI"),
+    "LangString": ("sunstone.rdf", "LangString"),
+    "TypedLiteral": ("sunstone.rdf", "TypedLiteral"),
+    # Lineage
+    "Activity": ("sunstone.lineage", "Activity"),
+    "ActivityRef": ("sunstone.lineage", "ActivityRef"),
+    "Agent": ("sunstone.lineage", "Agent"),
+    "AgentType": ("sunstone.lineage", "AgentType"),
+    "Contributor": ("sunstone.lineage", "Contributor"),
+    "DatasetMetadata": ("sunstone.lineage", "DatasetMetadata"),
+    "EntityRef": ("sunstone.lineage", "EntityRef"),
+    "FieldDerivation": ("sunstone.lineage", "FieldDerivation"),
+    "FieldSchema": ("sunstone.lineage", "FieldSchema"),
+    "LineageMetadata": ("sunstone.lineage", "LineageMetadata"),
+    "Metadata": ("sunstone.lineage", "Metadata"),
+    "PackageMetadata": ("sunstone.lineage", "PackageMetadata"),
+    "Source": ("sunstone.lineage", "Source"),
+    "SourceLocation": ("sunstone.lineage", "SourceLocation"),
+    "UsageRecord": ("sunstone.lineage", "UsageRecord"),
+    # Plugin system
+    "AuthProvider": ("sunstone.plugins", "AuthProvider"),
+    "CLIProvider": ("sunstone.plugins", "CLIProvider"),
+    "FormatHandler": ("sunstone.plugins", "FormatHandler"),
+    "PluginRegistry": ("sunstone.plugins", "PluginRegistry"),
+    "URLHandler": ("sunstone.plugins", "URLHandler"),
+    # Environment config
+    "DataEnvironment": ("sunstone.env", "DataEnvironment"),
+    "Environment": ("sunstone.env", "Environment"),
+    "activate_environment": ("sunstone.env", "activate_environment"),
+    "resolve_environment": ("sunstone.env", "resolve_environment"),
+    # Validation
+    "ImportCheckResult": ("sunstone.validation", "ImportCheckResult"),
+    "check_notebook_imports": ("sunstone.validation", "check_notebook_imports"),
+    "check_script_imports": ("sunstone.validation", "check_script_imports"),
+    "validate_project_notebooks": ("sunstone.validation", "validate_project_notebooks"),
+    # Linter
+    "LintReport": ("sunstone.lint", "LintReport"),
+    "LintSeverity": ("sunstone.lint", "Severity"),
+    "Violation": ("sunstone.lint", "Violation"),
+    "lint_project": ("sunstone.lint", "lint_project"),
+    # Context / queries / session
+    "ExecutionContext": ("sunstone.context", "ExecutionContext"),
+    "detect_execution_context": ("sunstone.context", "detect_execution_context"),
+    "LineageNode": ("sunstone.queries", "LineageNode"),
+    "display_lineage": ("sunstone.queries", "display_lineage"),
+    "get_upstream": ("sunstone.queries", "get_upstream"),
+    "lineage_to_dict": ("sunstone.queries", "lineage_to_dict"),
+    "DatasetRead": ("sunstone.session", "DatasetRead"),
+    "LineageSession": ("sunstone.session", "LineageSession"),
+    "close_session": ("sunstone.session", "close_session"),
+    "get_session": ("sunstone.session", "get_session"),
 }
+
+# Submodules exposed via attribute access (`sunstone.<name>`).
+_LAZY_SUBMODULES: frozenset[str] = frozenset({"errors", "packaging", "pandas"})
+
+
+if TYPE_CHECKING:
+    # Eager-looking imports for the benefit of type checkers and IDEs. These
+    # statements are never executed at runtime; they only inform static
+    # analysis about the surface available on the `sunstone` namespace.
+    from . import errors, packaging, pandas  # noqa: F401
+    from .asset import Asset, AssetKind  # noqa: F401
+    from .component import ComponentSchema  # noqa: F401
+    from .config import (  # noqa: F401
+        clear_project_path,
+        get_project_path,
+        set_project_path,
+        use_project_path,
+    )
+    from .context import ExecutionContext, detect_execution_context  # noqa: F401
+    from .dataframe import DataFrame  # noqa: F401
+    from .datasets import DatasetsManager  # noqa: F401
+    from .env import (  # noqa: F401
+        DataEnvironment,
+        Environment,
+        activate_environment,
+        resolve_environment,
+    )
+    from .errors import IncompatibleAssetKindError  # noqa: F401
+    from .exceptions import (  # noqa: F401
+        DatasetNotFoundError,
+        DatasetValidationError,
+        LineageError,
+        StrictModeError,
+        SunstoneError,
+        UnitError,
+    )
+    from .lineage import (  # noqa: F401
+        Activity,
+        ActivityRef,
+        Agent,
+        AgentType,
+        Contributor,
+        DatasetMetadata,
+        EntityRef,
+        FieldDerivation,
+        FieldSchema,
+        LineageMetadata,
+        Metadata,
+        PackageMetadata,
+        Source,
+        SourceLocation,
+        UsageRecord,
+    )
+    from .lint import LintReport, Severity as LintSeverity, Violation, lint_project  # noqa: F401
+    from .plugins import (  # noqa: F401
+        AuthProvider,
+        CLIProvider,
+        FormatHandler,
+        PluginRegistry,
+        URLHandler,
+    )
+    from .queries import (  # noqa: F401
+        LineageNode,
+        display_lineage,
+        get_upstream,
+        lineage_to_dict,
+    )
+    from .rdf import IRI, LangString, TypedLiteral  # noqa: F401
+    from .session import (  # noqa: F401
+        DatasetRead,
+        LineageSession,
+        close_session,
+        get_session,
+    )
+    from .validation import (  # noqa: F401
+        ImportCheckResult,
+        check_notebook_imports,
+        check_script_imports,
+        validate_project_notebooks,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_ATTRS:
+        mod_name, attr = _LAZY_ATTRS[name]
+        module = importlib.import_module(mod_name)
+        value = getattr(module, attr)
+        globals()[name] = value
+        return value
+    if name in _LAZY_SUBMODULES:
+        module = importlib.import_module(f"sunstone.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module 'sunstone' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_ATTRS) | _LAZY_SUBMODULES)
+
 
 __all__ = [
     # Main classes

--- a/src/sunstone/errors.py
+++ b/src/sunstone/errors.py
@@ -1,26 +1,75 @@
 """
-Re-export pandas.errors for use as sunstone.errors.
+Re-export pandas.errors for use as sunstone.errors, lazily.
 
-This module allows users who do ``from sunstone import pandas as pd``
-to also access ``from sunstone import errors`` (or ``from sunstone.errors
-import ParserError``, etc.) without importing pandas directly.
+Importing ``sunstone.errors`` does **not** import pandas. Pandas is imported
+only the first time a re-exported name is actually accessed. This keeps
+``sunstone --help`` (and other lightweight code paths that only need
+``IncompatibleAssetKindError``) fast.
 
-All public names from ``pandas.errors`` are re-exported here.
+Users still get the full pandas-errors surface via either explicit access
+(``sunstone.errors.ParserError``) or star-import (``from sunstone.errors
+import *``); both transparently trigger the pandas import on first use.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from pandas.errors import *  # noqa: F401,F403
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    # Make the re-exported names visible to type checkers / IDEs.
+    from pandas.errors import *  # noqa: F401,F403
     from sunstone.asset import AssetKind
 
-# Build __all__ from the names the star import actually brought in,
-# rather than relying on pandas.errors.__all__ (which doesn't exist).
-# Exclude TYPE_CHECKING and annotations which are not re-exports from pandas.
-__all__ = [name for name in dir() if not name.startswith("_") and name not in ("TYPE_CHECKING", "annotations")]
+# Snapshot of names re-exported from pandas.errors.
+# Drift versus the upstream package is caught by tests/test_errors.py.
+_PANDAS_ERROR_NAMES: tuple[str, ...] = (
+    "AbstractMethodError",
+    "AttributeConflictWarning",
+    "CSSWarning",
+    "CategoricalConversionWarning",
+    "ChainedAssignmentError",
+    "ClosedFileError",
+    "DataError",
+    "DatabaseError",
+    "DtypeWarning",
+    "DuplicateLabelError",
+    "EmptyDataError",
+    "IncompatibilityWarning",
+    "IncompatibleFrequency",
+    "IndexingError",
+    "IntCastingNaNError",
+    "InvalidColumnName",
+    "InvalidComparison",
+    "InvalidIndexError",
+    "InvalidVersion",
+    "LossySetitemError",
+    "MergeError",
+    "NoBufferPresent",
+    "NullFrequencyError",
+    "NumExprClobberingError",
+    "NumbaUtilError",
+    "OptionError",
+    "OutOfBoundsDatetime",
+    "OutOfBoundsTimedelta",
+    "Pandas4Warning",
+    "Pandas5Warning",
+    "PandasChangeWarning",
+    "PandasDeprecationWarning",
+    "PandasFutureWarning",
+    "PandasPendingDeprecationWarning",
+    "ParserError",
+    "ParserWarning",
+    "PerformanceWarning",
+    "PossibleDataLossError",
+    "PossiblePrecisionLoss",
+    "PyperclipException",
+    "PyperclipWindowsException",
+    "SpecificationError",
+    "UndefinedVariableError",
+    "UnsortedIndexError",
+    "UnsupportedFunctionCall",
+    "ValueLabelTypeMismatch",
+)
 
 
 class IncompatibleAssetKindError(ValueError):
@@ -32,4 +81,18 @@ class IncompatibleAssetKindError(ValueError):
         super().__init__(f"Asset kind mismatch: expected {expected.value!r}, got {actual.value!r}")
 
 
-__all__.append("IncompatibleAssetKindError")
+__all__ = list(_PANDAS_ERROR_NAMES) + ["IncompatibleAssetKindError"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in _PANDAS_ERROR_NAMES:
+        import pandas.errors
+
+        value = getattr(pandas.errors, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module 'sunstone.errors' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/sunstone/handlers.py
+++ b/src/sunstone/handlers.py
@@ -13,14 +13,14 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Literal, TextIO, cast
 from urllib.parse import urljoin, urlparse
 
 if TYPE_CHECKING:
+    import pandas as pd  # for type annotations only
+
     from .asset import Asset
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 from http.client import HTTPMessage
 
 from sunstone.lineage import CsvDialect
 from sunstone.ssrf import is_public_url
-
-import pandas as pd
 
 
 def _apply_csv_dialect_read(kwargs: dict, dialect: CsvDialect | None) -> dict:
@@ -67,18 +67,34 @@ _EXTENSION_MAP: dict[str, str] = {
     ".txt": "tsv",
 }
 
-# Format string -> pandas reader function
-_READER_MAP: dict[str, Callable[..., pd.DataFrame]] = {
-    "csv": pd.read_csv,
-    "json": pd.read_json,
-    "excel": pd.read_excel,
-    "tsv": lambda path, **kw: pd.read_csv(path, sep="\t", **kw),
-}
+# Format strings supported for reads (kept module-level so existence checks
+# don't drag pandas in). The actual reader callables are resolved lazily by
+# ``_get_reader`` below to keep ``import sunstone.handlers`` free of pandas.
+_READER_FORMATS: frozenset[str] = frozenset({"csv", "json", "excel", "tsv"})
 
 # Format string -> pandas writer method name on DataFrame
 _WRITER_MAP: dict[str, str] = {
     "csv": "to_csv",
 }
+
+
+def _get_reader(fmt: str) -> Callable[..., "pd.DataFrame"]:
+    """Resolve a pandas reader callable lazily.
+
+    Importing pandas costs ~400 ms; pushing it behind a function keeps
+    ``import sunstone.handlers`` cheap for callers that never actually read.
+    """
+    import pandas as _pd
+
+    if fmt == "csv":
+        return _pd.read_csv
+    if fmt == "json":
+        return _pd.read_json
+    if fmt == "excel":
+        return _pd.read_excel
+    if fmt == "tsv":
+        return lambda path, **kw: _pd.read_csv(path, sep="\t", **kw)
+    raise KeyError(fmt)
 
 
 class BuiltinFormatHandler:
@@ -110,7 +126,7 @@ class BuiltinFormatHandler:
     def _resolve_format(self, path: str, format: str | None) -> str | None:
         """Resolve a format string from explicit format or file extension."""
         if format is not None:
-            return format if format in _READER_MAP or format in _WRITER_MAP else None
+            return format if format in _READER_FORMATS or format in _WRITER_MAP else None
         # Extract extension from path or URL
         parsed = urlparse(path)
         file_path = parsed.path if parsed.scheme else path
@@ -119,7 +135,7 @@ class BuiltinFormatHandler:
 
     def can_read(self, path: str, format: str | None) -> bool:
         fmt = self._resolve_format(path, format)
-        return fmt is not None and fmt in _READER_MAP
+        return fmt is not None and fmt in _READER_FORMATS
 
     def _read_to_dataframe(self, stream: BinaryIO | Path, **kwargs: object) -> pd.DataFrame:
         fmt = kwargs.pop("format", None)
@@ -134,7 +150,7 @@ class BuiltinFormatHandler:
             fmt = "csv"  # safe default
         if fmt == "csv" and isinstance(dialect, CsvDialect):
             kwargs = _apply_csv_dialect_read(kwargs, dialect)
-        reader = _READER_MAP[str(fmt)]
+        reader = _get_reader(str(fmt))
         return reader(stream, **kwargs)
 
     def read(self, stream: BinaryIO | Path, **kwargs: object) -> "Asset":
@@ -242,6 +258,7 @@ class ParquetFormatHandler:
     def write(self, asset: object, stream: BinaryIO, **kwargs: object) -> None:
         import json as _json
 
+        import pandas as pd
         import pyarrow as pa  # type: ignore[import-untyped]
         import pyarrow.parquet as pq  # type: ignore[import-untyped]
 


### PR DESCRIPTION
## Summary

- `sunstone --help` drops from ~500 ms to ~70 ms (−86%) by deferring all heavy scientific-stack imports until first use
- Pandas is no longer imported at all during CLI startup
- Full test suite benefits too: 1281 tests finish in ~7 s instead of ~60 s

## Changes

**`sunstone/errors.py`** — PEP 562 `__getattr__` for lazy re-export of `pandas.errors`. Only `IncompatibleAssetKindError` is defined eagerly. A hardcoded name snapshot drives `__all__`; `tests/test_errors.py` catches upstream drift.

**`sunstone/__init__.py`** — all 70+ eager `from .X import Y` lines replaced by a `_LAZY_ATTRS` dispatch table + `__getattr__`. Constants (`STANDARD_RDF_PREFIXES`) and function bodies (`read`, `write`) stay eager — they're cheap and use string annotations. A `TYPE_CHECKING` block preserves full static-analysis / IDE visibility.

**`sunstone/handlers.py`** — top-level `import pandas as pd` removed. The `_READER_MAP` dict (which captured `pd.read_csv` etc. at import time) is replaced by `_get_reader(fmt)` that imports pandas on first call. `ParquetFormatHandler.write` imports pandas locally for the `cast(pd.DataFrame, …)` expression.

## Before / After

| | Before | After |
|---|---:|---:|
| `sunstone --help` | ~499 ms | ~71 ms |
| Pandas imported by CLI? | yes | no |
| Test suite | 60.6 s | 6.8 s |

## Test plan

- [x] 1281 / 1283 tests pass (2 skipped, same as before)
- [x] mypy clean on all three changed files
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] `sunstone --help` works and produces correct output
- [x] Lazy attrs resolve correctly: `sunstone.Asset`, `sunstone.DataFrame`, `sunstone.errors.ParserError`, etc.