### PR TITLE
fix(gcs): construct storage.Client lazily to avoid eager auth at discovery

### DIFF
--- a/src/sunstone/handlers_gcs.py
+++ b/src/sunstone/handlers_gcs.py
@@ -28,16 +28,30 @@ class GcsURLHandler:
     """Handles gs:// URLs using google-cloud-storage."""
 
     def __init__(self, config: dict | None = None) -> None:
-        from google.cloud import storage  # type: ignore[import-untyped]
+        # Import (but do NOT instantiate) the client here. The import raises
+        # ImportError when google-cloud-storage is missing, which the plugin
+        # registry relies on to skip this handler cleanly. Constructing
+        # storage.Client() eagerly would call google.auth.default() and raise
+        # DefaultCredentialsError in credential-less environments (e.g. CI),
+        # crashing plugin discovery. Defer client construction to first use.
+        from google.cloud import storage  # type: ignore[import-untyped] # noqa: F401
 
-        self._client = storage.Client()
+        self._client: object | None = None
 
     def can_handle(self, url: str) -> bool:
         return urlparse(url).scheme == "gs"
 
+    def _get_client(self) -> object:
+        """Lazily construct and cache the GCS client on first use."""
+        if self._client is None:
+            from google.cloud import storage  # type: ignore[import-untyped]
+
+            self._client = storage.Client()
+        return self._client
+
     def _get_blob(self, url: str) -> object:
         parsed = urlparse(url)
-        bucket = self._client.bucket(parsed.netloc)
+        bucket = self._get_client().bucket(parsed.netloc)  # type: ignore[attr-defined]
         blob_path = parsed.path.lstrip("/")
         return bucket.blob(blob_path)
 

--- a/tests/test_handlers_gcs.py
+++ b/tests/test_handlers_gcs.py
@@ -1,8 +1,35 @@
 """Tests for GCS URL handler (mocked — no real GCS calls)."""
 
+import sys
+import types
 from unittest.mock import MagicMock
 
 import pytest
+
+
+@pytest.fixture
+def fake_gcs_storage(monkeypatch):
+    """Inject a fake ``google.cloud.storage`` module whose ``Client`` raises
+    on instantiation, mimicking ``DefaultCredentialsError`` in a credential-less
+    environment. Lets us assert the handler never constructs a client eagerly.
+    """
+    storage = types.ModuleType("google.cloud.storage")
+
+    def _client_factory(*args, **kwargs):
+        raise AssertionError("storage.Client() must not be constructed eagerly")
+
+    storage.Client = MagicMock(side_effect=_client_factory)
+
+    # Build the package chain google -> google.cloud -> google.cloud.storage
+    google_mod = sys.modules.get("google") or types.ModuleType("google")
+    cloud_mod = sys.modules.get("google.cloud") or types.ModuleType("google.cloud")
+    cloud_mod.storage = storage
+    google_mod.cloud = cloud_mod
+
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage)
+    return storage
 
 
 @pytest.fixture
@@ -72,3 +99,53 @@ class TestGcsURLHandlerOpen:
         stream.close()
 
         mock_blob.upload_from_file.assert_called_once()
+
+
+class TestGcsURLHandlerLazyAuth:
+    """Regression tests: constructing the handler must not touch GCP credentials.
+
+    Eager ``storage.Client()`` in ``__init__`` calls ``google.auth.default()``,
+    which raises ``DefaultCredentialsError`` without Application Default
+    Credentials. That propagated out of plugin discovery and crashed every URL
+    handler — not just GCS — in credential-less environments (e.g. CI).
+    """
+
+    def test_construct_without_credentials(self, fake_gcs_storage):
+        """Instantiating the handler must NOT construct storage.Client()."""
+        from sunstone.handlers_gcs import GcsURLHandler
+
+        handler = GcsURLHandler()  # must not raise
+
+        fake_gcs_storage.Client.assert_not_called()
+        assert handler._client is None
+
+    def test_missing_dependency_raises_import_error(self, monkeypatch):
+        """With google-cloud-storage absent, construction raises ImportError so
+        the plugin registry's ``except ImportError`` cleanly skips the handler."""
+        monkeypatch.setitem(sys.modules, "google.cloud.storage", None)
+
+        from sunstone.handlers_gcs import GcsURLHandler
+
+        with pytest.raises(ImportError):
+            GcsURLHandler()
+
+    def test_client_constructed_on_first_use(self, fake_gcs_storage):
+        """The client is built lazily the first time a blob is resolved."""
+        from sunstone.handlers_gcs import GcsURLHandler
+
+        mock_client = MagicMock()
+        fake_gcs_storage.Client.side_effect = None
+        fake_gcs_storage.Client.return_value = mock_client
+        mock_blob = MagicMock()
+        mock_blob.download_as_bytes.return_value = b"x"
+        mock_client.bucket.return_value.blob.return_value = mock_blob
+
+        handler = GcsURLHandler()
+        fake_gcs_storage.Client.assert_not_called()
+
+        handler.open("gs://bucket/key", "rb")
+
+        fake_gcs_storage.Client.assert_called_once()
+        # Cached: a second access reuses the same client.
+        handler.open("gs://bucket/key", "rb")
+        fake_gcs_storage.Client.assert_called_once()


### PR DESCRIPTION
## The bug

`GcsURLHandler.__init__` eagerly constructed `storage.Client()`, which calls
`google.auth.default()`. In any environment without GCP Application Default
Credentials (e.g. CI), that raises `google.auth.exceptions.DefaultCredentialsError`.

`PluginRegistry._discover()` instantiates `GcsURLHandler()` inside a `try/except`
that **only catches `ImportError`**:

```python
try:
    from .handlers_gcs import GcsURLHandler
    self._url_handlers.append(GcsURLHandler())
except ImportError:
    pass  # google-cloud-storage not installed
```

So when `google-cloud-storage` is installed but no credentials are present, the
`DefaultCredentialsError` is **not** caught — it propagates out of discovery and
crashes the entire plugin registry, taking down every URL handler and
env-section provider, not just GCS. This broke CI for a downstream consumer whose
first `PluginRegistry.get()` call hit it.

## The fix

Make GCS auth lazy:

- **Keep** the `from google.cloud import storage` import inside `__init__`, so a
  genuinely missing dependency still raises `ImportError` and `_discover`'s
  `except ImportError` skips the handler cleanly (behavior preserved).
- **Remove** the eager `storage.Client()` call from `__init__`. The client is now
  constructed on first actual use via a cached `_get_client()` helper, so merely
  instantiating the handler never touches credentials.

Net effect:

| Scenario | Before | After |
| --- | --- | --- |
| google-cloud-storage not installed | `ImportError` → skipped | `ImportError` → skipped (unchanged) |
| installed, no creds | `DefaultCredentialsError` → discovery crash | constructs fine; auth deferred |
| installed, gs:// URL opened | `storage.Client()` runs | `storage.Client()` runs (unchanged) |

## Tests

Added `TestGcsURLHandlerLazyAuth` covering the regression:
- constructing the handler does **not** call `storage.Client()` / touch credentials;
- a missing `google-cloud-storage` still raises `ImportError`;
- the client is constructed lazily (and only once) on first `open()`.

`uv run pytest` → 1405 passed, 12 skipped. `ruff check`, `ruff format --check`,
and `mypy` over `src/sunstone` all clean.