### PR TITLE
refactor: mint scheme-less identity path (stop emitting data-platform's sunstone: scheme)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Changed: the default identity URI template is now `sunstone:<pkg>/<slug>@<version>` (no `//`) to match the data-platform `sunstone:` URL scheme, whose namespace lives in the URL path rather than the authority. **Breaking** for anything that pinned the old `sunstone://` form.
+
 ## [1.13.1] - 2026-05-30
 
 - Fixed: `gs://` handler no longer authenticates at discovery time — the GCS storage client is now constructed lazily on first use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-- Changed: the default identity URI template is now `sunstone:<pkg>/<slug>@<version>` (no `//`) to match the data-platform `sunstone:` URL scheme, whose namespace lives in the URL path rather than the authority. **Breaking** for anything that pinned the old `sunstone://` form.
+- Changed: the default materialised identity is now a scheme-less path `<pkg>/<slug>@<version>` instead of a `sunstone:`-schemed URI. The `sunstone:` URL scheme is defined and owned by the data platform; minting it here coupled this package to a scheme it does not define. The minted value now carries only what this package owns (name, slug, version), and the consumer binds it to a scheme (a `sunstone:` authoring handle or an absolute `https://` graph IRI). **Breaking** for anything that pinned the old `sunstone://` or `sunstone:` form.
 
 ## [1.13.1] - 2026-05-30
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -150,7 +150,7 @@ Write an `Asset` to `path`. Dispatches via the plugin registry.
 
 When `asset.metadata.identity` is `None` and a project `pyproject.toml`
 is discoverable, `write()` materialises the default identity URI
-`sunstone://<package-name>/<slug>@<package-version>` before delegating.
+`sunstone:<package-name>/<slug>@<package-version>` before delegating.
 User-supplied templates are preserved verbatim.
 
 ---
@@ -1195,7 +1195,7 @@ from sunstone.lineage import Metadata
 - `component_metadata` (dict[str, ComponentSchema]): Per-component metadata keyed by component name (column, band, variable, layer)
 - `slug` (str | None): Dataset slug, used at write time
 - `name` (str | None): Human-readable dataset name, used at write time
-- `identity` (str | None): URI template or materialised URI for this asset. When `None` and a project `pyproject.toml` is discoverable, `sunstone.write()` fills in the default `sunstone://<package-name>/<slug>@<package-version>` and the value is reused on subsequent writes. User-supplied templates are preserved verbatim.
+- `identity` (str | None): URI template or materialised URI for this asset. When `None` and a project `pyproject.toml` is discoverable, `sunstone.write()` fills in the default `sunstone:<package-name>/<slug>@<package-version>` and the value is reused on subsequent writes. User-supplied templates are preserved verbatim.
 
 ## Plugin System
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -149,9 +149,10 @@ Write an `Asset` to `path`. Dispatches via the plugin registry.
 - `ValueError`: If no handler matches `path` and `format`.
 
 When `asset.metadata.identity` is `None` and a project `pyproject.toml`
-is discoverable, `write()` materialises the default identity URI
-`sunstone:<package-name>/<slug>@<package-version>` before delegating.
-User-supplied templates are preserved verbatim.
+is discoverable, `write()` materialises the default identity as the
+scheme-less path `<package-name>/<slug>@<package-version>` before
+delegating; the consumer binds it to a scheme. User-supplied templates
+are preserved verbatim.
 
 ---
 
@@ -1195,7 +1196,7 @@ from sunstone.lineage import Metadata
 - `component_metadata` (dict[str, ComponentSchema]): Per-component metadata keyed by component name (column, band, variable, layer)
 - `slug` (str | None): Dataset slug, used at write time
 - `name` (str | None): Human-readable dataset name, used at write time
-- `identity` (str | None): URI template or materialised URI for this asset. When `None` and a project `pyproject.toml` is discoverable, `sunstone.write()` fills in the default `sunstone:<package-name>/<slug>@<package-version>` and the value is reused on subsequent writes. User-supplied templates are preserved verbatim.
+- `identity` (str | None): Identity template or materialised identity for this asset. When `None` and a project `pyproject.toml` is discoverable, `sunstone.write()` fills in the default scheme-less path `<package-name>/<slug>@<package-version>` (the consumer binds it to a scheme) and the value is reused on subsequent writes. User-supplied templates are preserved verbatim.
 
 ## Plugin System
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -340,12 +340,12 @@ print(df.metadata.lineage.sources)
 `Metadata.identity` is a URI template (or fully materialised URI) for
 the asset. When it is `None` and a project `pyproject.toml` is
 discoverable, `sunstone.write()` materialises the default
-`sunstone://<package-name>/<slug>@<package-version>` before writing and
+`sunstone:<package-name>/<slug>@<package-version>` before writing and
 reuses the value on subsequent writes. User-supplied templates are
 preserved verbatim — set `df.metadata.identity` to override.
 
 ```python
-df.metadata.identity = 'sunstone://my-project/my-slug@1.0.0'
+df.metadata.identity = 'sunstone:my-project/my-slug@1.0.0'
 ```
 
 Without a `pyproject.toml` at the resolved project path the default is

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -335,17 +335,20 @@ df.metadata.custom_properties = {'schema:about': 'Education'}
 print(df.metadata.lineage.sources)
 ```
 
-### Identity URI
+### Identity
 
-`Metadata.identity` is a URI template (or fully materialised URI) for
-the asset. When it is `None` and a project `pyproject.toml` is
-discoverable, `sunstone.write()` materialises the default
-`sunstone:<package-name>/<slug>@<package-version>` before writing and
-reuses the value on subsequent writes. User-supplied templates are
+`Metadata.identity` is an identity template (or fully materialised
+identity) for the asset. When it is `None` and a project `pyproject.toml`
+is discoverable, `sunstone.write()` materialises the default scheme-less
+path `<package-name>/<slug>@<package-version>` before writing and reuses
+the value on subsequent writes. The path carries only what this package
+owns (its name, the asset slug, its version); the consumer binds it to a
+scheme — e.g. the data platform resolves it to a `sunstone:` authoring
+handle or an absolute `https://` graph IRI. User-supplied templates are
 preserved verbatim — set `df.metadata.identity` to override.
 
 ```python
-df.metadata.identity = 'sunstone:my-project/my-slug@1.0.0'
+df.metadata.identity = 'my-project/my-slug@1.0.0'
 ```
 
 Without a `pyproject.toml` at the resolved project path the default is

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -127,9 +127,16 @@ def read(
 
 def _materialise_default_identity(asset: "Asset") -> None:
     """If `asset.metadata.identity` is None and the asset has a slug, fill in
-    the default `sunstone:<package-name>/<slug>@<package-version>` URI using
-    the active project's pyproject.toml. No-op otherwise — user-supplied
-    templates are preserved verbatim.
+    the default `<package-name>/<slug>@<package-version>` path using the active
+    project's pyproject.toml. No-op otherwise — user-supplied templates are
+    preserved verbatim.
+
+    The minted value is a scheme-less, environment-relative path: it carries
+    only what this package owns (its name, the asset slug, its version). The
+    consumer is responsible for binding it to a scheme — e.g. the data platform
+    resolves it to a `sunstone:` authoring handle or an absolute `https://`
+    graph IRI. Minting a `sunstone:`-schemed URI here would couple this package
+    to a URL scheme it does not define.
 
     Skipped entirely when no `pyproject.toml` is discoverable at the resolved
     project path: otherwise the bare cwd fallback in `get_project_path()`
@@ -162,7 +169,7 @@ def _materialise_default_identity(asset: "Asset") -> None:
 
     pkg_name = get_project_slug(project_path)
     pkg_version = get_project_version(project_path) or "0.0.0"
-    asset.metadata.identity = f"sunstone:{pkg_name}/{asset.metadata.slug}@{pkg_version}"
+    asset.metadata.identity = f"{pkg_name}/{asset.metadata.slug}@{pkg_version}"
 
 
 def write(asset: "Asset", path: str, *, format: str | None = None, **kw: object) -> None:

--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -127,7 +127,7 @@ def read(
 
 def _materialise_default_identity(asset: "Asset") -> None:
     """If `asset.metadata.identity` is None and the asset has a slug, fill in
-    the default `sunstone://<package-name>/<slug>@<package-version>` URI using
+    the default `sunstone:<package-name>/<slug>@<package-version>` URI using
     the active project's pyproject.toml. No-op otherwise — user-supplied
     templates are preserved verbatim.
 
@@ -162,7 +162,7 @@ def _materialise_default_identity(asset: "Asset") -> None:
 
     pkg_name = get_project_slug(project_path)
     pkg_version = get_project_version(project_path) or "0.0.0"
-    asset.metadata.identity = f"sunstone://{pkg_name}/{asset.metadata.slug}@{pkg_version}"
+    asset.metadata.identity = f"sunstone:{pkg_name}/{asset.metadata.slug}@{pkg_version}"
 
 
 def write(asset: "Asset", path: str, *, format: str | None = None, **kw: object) -> None:

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -588,7 +588,7 @@ class Metadata:
     identity: str | None = None
     """Globally stable URI template for this asset. Supports env-var
     interpolation (e.g., `https://${DATASET_BASE_URL}/table@1.0.0` or
-    `sunstone://${PACKAGE_NAME}/${SLUG}@${PACKAGE_VERSION}`). Materialised into
+    `sunstone:${PACKAGE_NAME}/${SLUG}@${PACKAGE_VERSION}`). Materialised into
     the concrete `@id` at write time. None means the writer derives one from
     the package + slug + version defaults."""
 

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -586,11 +586,12 @@ class Metadata:
     """Human-readable dataset name, used at write time."""
 
     identity: str | None = None
-    """Globally stable URI template for this asset. Supports env-var
-    interpolation (e.g., `https://${DATASET_BASE_URL}/table@1.0.0` or
-    `sunstone:${PACKAGE_NAME}/${SLUG}@${PACKAGE_VERSION}`). Materialised into
-    the concrete `@id` at write time. None means the writer derives one from
-    the package + slug + version defaults."""
+    """Stable identity template for this asset. Supports env-var interpolation
+    (e.g., `https://${DATASET_BASE_URL}/table@1.0.0` or
+    `${PACKAGE_NAME}/${SLUG}@${PACKAGE_VERSION}`). Materialised at write time.
+    None means the writer derives a scheme-less `<package>/<slug>@<version>`
+    path from the project defaults; the consumer binds that path to a scheme
+    (e.g. a `sunstone:` handle or an absolute `https://` IRI)."""
 
     component_metadata: Dict[str, "ComponentSchema"] = field(default_factory=dict)
     """Per-component metadata (columns, bands, variables, layers). The

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -901,8 +901,8 @@ class TestMetadataIdentityAndComponentMetadata:
 
     def test_metadata_identity_accepts_uri_template(self):
         """Metadata.identity accepts a URI template string."""
-        m = Metadata(identity="sunstone://acme/sales@1.0.0")
-        assert m.identity == "sunstone://acme/sales@1.0.0"
+        m = Metadata(identity="sunstone:acme/sales@1.0.0")
+        assert m.identity == "sunstone:acme/sales@1.0.0"
 
     def test_metadata_component_metadata_defaults_to_empty_dict(self):
         """Metadata.component_metadata defaults to an empty dict."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -901,8 +901,8 @@ class TestMetadataIdentityAndComponentMetadata:
 
     def test_metadata_identity_accepts_uri_template(self):
         """Metadata.identity accepts a URI template string."""
-        m = Metadata(identity="sunstone:acme/sales@1.0.0")
-        assert m.identity == "sunstone:acme/sales@1.0.0"
+        m = Metadata(identity="acme/sales@1.0.0")
+        assert m.identity == "acme/sales@1.0.0"
 
     def test_metadata_component_metadata_defaults_to_empty_dict(self):
         """Metadata.component_metadata defaults to an empty dict."""

--- a/tests/test_top_level_read_write.py
+++ b/tests/test_top_level_read_write.py
@@ -91,7 +91,8 @@ def test_top_level_write_materialises_default_identity_when_none(tmp_path, monke
     assert asset.metadata.identity is None
 
     sunstone.write(asset, str(tmp_path / "out.csv"), format="csv")
-    assert asset.metadata.identity == "sunstone:demo-pkg/my-output@1.2.3"
+    # Scheme-less, environment-relative path — the consumer binds the scheme.
+    assert asset.metadata.identity == "demo-pkg/my-output@1.2.3"
 
 
 def test_top_level_write_preserves_user_supplied_identity(tmp_path, monkeypatch):

--- a/tests/test_top_level_read_write.py
+++ b/tests/test_top_level_read_write.py
@@ -91,7 +91,7 @@ def test_top_level_write_materialises_default_identity_when_none(tmp_path, monke
     assert asset.metadata.identity is None
 
     sunstone.write(asset, str(tmp_path / "out.csv"), format="csv")
-    assert asset.metadata.identity == "sunstone://demo-pkg/my-output@1.2.3"
+    assert asset.metadata.identity == "sunstone:demo-pkg/my-output@1.2.3"
 
 
 def test_top_level_write_preserves_user_supplied_identity(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Stops `sunstone.write()` from minting a `sunstone:`-schemed default identity. The `sunstone:` URL scheme is **defined and owned by the data platform** (ADR 0001 in `data-platform`); minting it here coupled sunstone-py to a scheme it does not define — a dependency-inversion / layering violation introduced by the Asset envelope work in eb68ebcb.

`sunstone.write()` now materialises the bare, environment-relative path:

```
sunstone://<pkg>/<slug>@<version>   (old)
sunstone:<pkg>/<slug>@<version>     (interim, first commit)
<pkg>/<slug>@<version>              (now)
```

The minted value carries only what this package legitimately owns — its name, the asset slug, its version. The **consumer** binds it to a scheme: per ADR 0001 §4, resolution is "prepend the env's base to the path", yielding a `sunstone:` authoring handle or an absolute `https://` graph IRI. sunstone-py no longer names the `sunstone:` scheme anywhere.

## Changes

- `src/sunstone/__init__.py` — `_materialise_default_identity()` mints the scheme-less path; docstring explains why (no scheme this package doesn't define).
- `src/sunstone/lineage.py` — `Metadata.identity` field docstring.
- `tests/test_top_level_read_write.py`, `tests/test_metadata.py` — assertions updated to the scheme-less form.
- `docs/api.md`, `docs/concepts.md` — default-form references and the user-override example.
- `CHANGELOG.md` — `Changed:` entry under `[Unreleased]` describing the de-coupling. Version bump left to the release process.

## Notes

- sunstone-py only **writes** the identity string — it never parses it back — so there is no parser to update here. `identity` is stored, not emitted as JSON-LD `@id` (that uses `dct:identifier`), so the scheme-less form has no internal RDF-resolution fallout.
- **Cross-repo follow-up (not in scope):** `data-platform` does not consume `asset.metadata.identity` today (its `url.py` parses user-facing table refs only). When it eventually ingests minted identities, it owns prepending the scheme.
- **Breaking** for anything that pinned the old `sunstone://` or interim `sunstone:` form. Identity strings already persisted in downstream lock files / catalogs keep their old value and would need a separate migration if consumed by a strict parser.
- `uv run pytest` → 1405 passed, 12 skipped. `uv run ruff check` + mypy clean.
