### PR TITLE
feat: field-level RDF/custom properties in datasets.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: field-level RDF/custom properties in `datasets.yaml` (e.g. `sosa:observedProperty`) now round-trip and flow to `datapackage.json`.
 - Removed: `Metadata.identity` field and the auto-minted default identity. The value was never serialized (no format handler emitted it) or read by anything, and the field silently dropped user-supplied input at write time. **Breaking** for `Metadata(identity=...)` callers.
 
 ## [1.13.2] - 2026-06-03

--- a/src/sunstone/cli.py
+++ b/src/sunstone/cli.py
@@ -1211,6 +1211,9 @@ def _build_schema_from_yaml(ds: DatasetMetadata) -> Optional[dict[str, Any]]:
             field_dict["source"] = f.source
         if f.constraints:
             field_dict["constraints"] = f.constraints
+        if f.custom_properties:
+            prefixes = {**STANDARD_RDF_PREFIXES, **(ds.rdf_prefixes or {})}
+            field_dict.update(expand_custom_properties(f.custom_properties, prefixes))
         field_dicts.append(field_dict)
     return {"fields": field_dicts}
 
@@ -1343,6 +1346,9 @@ def build_resource_dict(
                         field_dict["unit"] = yaml_field.unit
                     if yaml_field.source:
                         field_dict["source"] = yaml_field.source
+                    if yaml_field.custom_properties:
+                        prefixes = {**STANDARD_RDF_PREFIXES, **(ds.rdf_prefixes or {})}
+                        field_dict.update(expand_custom_properties(yaml_field.custom_properties, prefixes))
 
         # Add automatic RDF type for resource
         resource_dict[f"{STANDARD_RDF_PREFIXES['rdf']}type"] = f"{STANDARD_RDF_PREFIXES['dcat']}Distribution"

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -204,6 +204,7 @@ class DataFrame:
         source: Optional[str] = None,
         type: Optional[str] = None,
         constraints: Optional[Dict[str, Any]] = None,
+        custom_properties: Optional[Dict[str, Any]] = None,
     ) -> "DataFrame":
         """Set metadata for a column. Returns self for chaining.
 
@@ -214,6 +215,9 @@ class DataFrame:
             source: Slug of the input dataset this field comes from.
             type: Data type override. If None, inferred from dtype at write time.
             constraints: Optional constraints (e.g., enum values).
+            custom_properties: Optional field-level RDF/custom properties
+                (e.g. ``{"sosa:observedProperty": "..."}``) that flow to
+                datasets.yaml and datapackage.json.
 
         Returns:
             self, for method chaining.
@@ -236,6 +240,10 @@ class DataFrame:
                 existing.type = type
             if constraints is not None:
                 existing.constraints = constraints
+            if custom_properties is not None:
+                merged = dict(existing.custom_properties or {})
+                merged.update(custom_properties)
+                existing.custom_properties = merged or None
         else:
             self.metadata.field_metadata[column] = FieldSchema(
                 name=column,
@@ -244,6 +252,7 @@ class DataFrame:
                 unit=unit,
                 source=source,
                 constraints=constraints,
+                custom_properties=custom_properties or None,
             )
 
         # When source is set, also create a FieldDerivation entry

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -78,6 +78,9 @@ def _field_schema_to_dict(field: FieldSchema) -> dict:
         d["unit"] = field.unit_source if field.unit_source else field.unit
     if field.source:
         d["source"] = field.source
+    if field.custom_properties:
+        for key, value in field.custom_properties.items():
+            d[key] = value
     return d
 
 
@@ -338,6 +341,8 @@ class DatasetsManager:
         """Parse field schema data from YAML."""
         from .units import is_qudt_uri, parse_unit_string
 
+        known_keys = {"name", "type", "constraints", "description", "unit", "source"}
+
         result = []
         for field in fields_data:
             unit_str = field.get("unit")
@@ -352,6 +357,15 @@ class DatasetsManager:
                     unit_value = unit_str
                     unit_source = unit_str
 
+            # Collect any remaining RDF property keys (e.g. sosa:observedProperty)
+            # as field-level custom properties. Non-RDF unknown keys are ignored,
+            # preserving current leniency.
+            custom_properties = {
+                key: value
+                for key, value in field.items()
+                if key not in known_keys and self._is_rdf_property_key(key)
+            }
+
             result.append(
                 FieldSchema(
                     name=field["name"],
@@ -361,6 +375,7 @@ class DatasetsManager:
                     unit=unit_value,
                     source=field.get("source"),
                     unit_source=unit_source,
+                    custom_properties=custom_properties or None,
                 )
             )
         return result

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -361,9 +361,7 @@ class DatasetsManager:
             # as field-level custom properties. Non-RDF unknown keys are ignored,
             # preserving current leniency.
             custom_properties = {
-                key: value
-                for key, value in field.items()
-                if key not in known_keys and self._is_rdf_property_key(key)
+                key: value for key, value in field.items() if key not in known_keys and self._is_rdf_property_key(key)
             }
 
             result.append(

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -239,6 +239,9 @@ class FieldSchema:
     unit_source: Optional[str] = None
     """Original unit string format for round-tripping (e.g. QUDT URI). None means Pint string."""
 
+    custom_properties: Optional[Dict[str, Any]] = None
+    """Field-level custom/RDF properties (e.g. sosa:observedProperty), expanded at build time."""
+
 
 @dataclass
 class Contributor:
@@ -690,6 +693,9 @@ class Metadata:
                     entry["si:unit"] = fs.unit
                 if fs.type is not None:
                     entry["si:type"] = fs.type
+                if fs.custom_properties:
+                    for key, value in fs.custom_properties.items():
+                        entry[key] = value
                 if col_name in fd_by_field:
                     fd = fd_by_field[col_name]
                     derivation: Dict[str, Any] = {"dct:identifier": fd.source_entity}
@@ -764,12 +770,15 @@ class Metadata:
         field_metadata: Dict[str, FieldSchema] = {}
         field_derivations: List[FieldDerivation] = []
         si_fields = doc.get("si:fields", {})
+        _field_known_keys = {"si:type", "dct:description", "si:unit", "prov:wasDerivedFrom"}
         for col_name, entry in si_fields.items():
+            field_custom = {k: v for k, v in entry.items() if k not in _field_known_keys}
             fs = FieldSchema(
                 name=col_name,
                 type=entry.get("si:type"),
                 description=entry.get("dct:description"),
                 unit=entry.get("si:unit"),
+                custom_properties=field_custom or None,
             )
             field_metadata[col_name] = fs
             derivation = entry.get("prov:wasDerivedFrom")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -731,6 +731,52 @@ class TestFieldMetadataInDatapackage:
         assert value_field["unit"] == "USD"
         assert value_field["source"] == "world-bank-data"
 
+    def test_field_rdf_custom_property_in_datapackage(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Field-level RDF properties (e.g. sosa:observedProperty) expand into datapackage.json."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "outputs").mkdir()
+        (project / "outputs" / "data.csv").write_text("county,n_tonnes\nOslo,12.5\n")
+        (project / "datasets.yaml").write_text(
+            "publish:\n"
+            "  enabled: true\n"
+            "  to: gs://bucket/test/\n"
+            "inputs: []\n"
+            "outputs:\n"
+            "  - name: Nutrient Data\n"
+            "    slug: nutrient-data\n"
+            "    location: outputs/data.csv\n"
+            "    fields:\n"
+            "      - name: county\n"
+            "        type: string\n"
+            "      - name: n_tonnes\n"
+            "        type: number\n"
+            "        unit: http://qudt.org/vocab/unit/TONNE\n"
+            "        qudt:hasQuantityKind: http://qudt.org/vocab/quantitykind/Mass\n"
+            "        sosa:observedProperty: http://vocab.nerc.ac.uk/collection/P01/current/TNITZZXX/\n"
+        )
+
+        result = runner.invoke(
+            app,
+            ["package", "build", "-f", str(project / "datasets.yaml"), "-o", str(project / "datapackage.json")],
+        )
+        assert result.exit_code == 0
+
+        import json
+
+        datapackage = json.loads((project / "datapackage.json").read_text())
+        fields = datapackage["resources"][0]["schema"]["fields"]
+        fields_by_name = {f["name"]: f for f in fields}
+        n_field = fields_by_name["n_tonnes"]
+        # Keys are expanded to full URIs via the standard prefix map.
+        assert n_field["http://qudt.org/schema/qudt/hasQuantityKind"] == "http://qudt.org/vocab/quantitykind/Mass"
+        assert (
+            n_field["http://www.w3.org/ns/sosa/observedProperty"]
+            == "http://vocab.nerc.ac.uk/collection/P01/current/TNITZZXX/"
+        )
+        # A field without custom props carries none of these keys.
+        assert "http://www.w3.org/ns/sosa/observedProperty" not in fields_by_name["county"]
+
 
 class TestPackagePushCommand:
     """Tests for the package push command."""

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -141,6 +141,53 @@ class TestFieldSchemaExtendedProperties:
         assert field.description is None
         assert field.unit is None
         assert field.source is None
+        assert field.custom_properties is None
+
+    def test_parse_fields_with_rdf_custom_properties(self, tmp_path: Path) -> None:
+        """RDF property keys on a field are collected into custom_properties."""
+        datasets_file = tmp_path / "datasets.yaml"
+        datasets_file.write_text(
+            "inputs: []\n"
+            "outputs:\n"
+            "  - name: Nutrient Data\n"
+            "    slug: nutrient-data\n"
+            "    location: outputs/data.csv\n"
+            "    fields:\n"
+            "      - name: n_tonnes\n"
+            "        type: number\n"
+            "        unit: http://qudt.org/vocab/unit/TONNE\n"
+            "        qudt:hasQuantityKind: http://qudt.org/vocab/quantitykind/Mass\n"
+            "        sosa:observedProperty: http://vocab.nerc.ac.uk/collection/P01/current/TNITZZXX/\n"
+        )
+        manager = sunstone.DatasetsManager(tmp_path)
+        dataset = manager.find_dataset_by_slug("nutrient-data")
+        assert dataset is not None
+        assert dataset.fields is not None
+        field = next(f for f in dataset.fields if f.name == "n_tonnes")
+        assert field.custom_properties == {
+            "qudt:hasQuantityKind": "http://qudt.org/vocab/quantitykind/Mass",
+            "sosa:observedProperty": "http://vocab.nerc.ac.uk/collection/P01/current/TNITZZXX/",
+        }
+
+    def test_parse_fields_ignores_non_rdf_unknown_keys(self, tmp_path: Path) -> None:
+        """Unknown non-RDF keys are still ignored (leniency preserved)."""
+        datasets_file = tmp_path / "datasets.yaml"
+        datasets_file.write_text(
+            "inputs: []\n"
+            "outputs:\n"
+            "  - name: Data\n"
+            "    slug: data\n"
+            "    location: outputs/data.csv\n"
+            "    fields:\n"
+            "      - name: x\n"
+            "        type: number\n"
+            "        bogus: ignored\n"
+        )
+        manager = sunstone.DatasetsManager(tmp_path)
+        dataset = manager.find_dataset_by_slug("data")
+        assert dataset is not None
+        assert dataset.fields is not None
+        assert dataset.fields[0].custom_properties is None
 
 
 class TestFieldSchemaSerialization:
@@ -189,6 +236,42 @@ class TestFieldSchemaSerialization:
         assert "source" not in d
         assert "constraints" not in d
         assert d["description"] == "A field"
+
+    def test_field_to_dict_includes_custom_properties(self) -> None:
+        """Field-level custom RDF properties are emitted for round-tripping."""
+        from sunstone.datasets import _field_schema_to_dict
+        from sunstone.lineage import FieldSchema
+
+        field = FieldSchema(
+            name="n_tonnes",
+            type="number",
+            custom_properties={"sosa:observedProperty": "http://example.org/total-n"},
+        )
+        d = _field_schema_to_dict(field)
+        assert d["sosa:observedProperty"] == "http://example.org/total-n"
+
+    def test_field_custom_properties_round_trip(self, tmp_path: Path) -> None:
+        """A field custom property survives parse -> serialize unchanged."""
+        from sunstone.datasets import _field_schema_to_dict
+
+        datasets_file = tmp_path / "datasets.yaml"
+        datasets_file.write_text(
+            "inputs: []\n"
+            "outputs:\n"
+            "  - name: Data\n"
+            "    slug: data\n"
+            "    location: outputs/data.csv\n"
+            "    fields:\n"
+            "      - name: x\n"
+            "        type: number\n"
+            "        sosa:observedProperty: http://example.org/total-n\n"
+        )
+        manager = sunstone.DatasetsManager(tmp_path)
+        dataset = manager.find_dataset_by_slug("data")
+        assert dataset is not None
+        assert dataset.fields is not None
+        d = _field_schema_to_dict(dataset.fields[0])
+        assert d["sosa:observedProperty"] == "http://example.org/total-n"
 
 
 class TestPackageMetadata:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -205,6 +205,61 @@ class TestSetFieldMetadata:
         df.set_field_metadata("val", source="input-data")
         assert df.metadata.field_metadata["val"].source == "input-data"
 
+    def test_set_field_metadata_with_custom_properties(self):
+        """Field-level RDF custom properties can be set and merged."""
+        df = sunstone.DataFrame({"n": [1]})
+        df.set_field_metadata("n", custom_properties={"sosa:observedProperty": "http://example.org/n"})
+        assert df.metadata.field_metadata["n"].custom_properties == {
+            "sosa:observedProperty": "http://example.org/n"
+        }
+        # A later call merges rather than replaces.
+        df.set_field_metadata("n", custom_properties={"qudt:hasQuantityKind": "http://example.org/mass"})
+        assert df.metadata.field_metadata["n"].custom_properties == {
+            "sosa:observedProperty": "http://example.org/n",
+            "qudt:hasQuantityKind": "http://example.org/mass",
+        }
+
+
+class TestFieldCustomPropertiesJsonLd:
+    """Field-level custom properties flow through Metadata JSON-LD round-trips."""
+
+    def test_to_jsonld_includes_field_custom_properties(self):
+        from sunstone.lineage import FieldSchema, Metadata
+
+        m = Metadata(
+            slug="data",
+            name="Data",
+            field_metadata={
+                "n": FieldSchema(
+                    name="n",
+                    type="number",
+                    custom_properties={"sosa:observedProperty": "http://example.org/n"},
+                )
+            },
+        )
+        doc = m.to_jsonld()
+        assert doc["si:fields"]["n"]["sosa:observedProperty"] == "http://example.org/n"
+
+    def test_jsonld_round_trip_preserves_field_custom_properties(self):
+        from sunstone.lineage import FieldSchema, Metadata
+
+        m = Metadata(
+            slug="data",
+            name="Data",
+            field_metadata={
+                "n": FieldSchema(
+                    name="n",
+                    type="number",
+                    unit="t",
+                    custom_properties={"sosa:observedProperty": "http://example.org/n"},
+                )
+            },
+        )
+        restored = Metadata.from_jsonld(m.to_jsonld())
+        assert restored.field_metadata["n"].custom_properties == {
+            "sosa:observedProperty": "http://example.org/n"
+        }
+
 
 class TestMetadataPropagation:
     """Tests for metadata flowing through pandas operations."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -209,9 +209,7 @@ class TestSetFieldMetadata:
         """Field-level RDF custom properties can be set and merged."""
         df = sunstone.DataFrame({"n": [1]})
         df.set_field_metadata("n", custom_properties={"sosa:observedProperty": "http://example.org/n"})
-        assert df.metadata.field_metadata["n"].custom_properties == {
-            "sosa:observedProperty": "http://example.org/n"
-        }
+        assert df.metadata.field_metadata["n"].custom_properties == {"sosa:observedProperty": "http://example.org/n"}
         # A later call merges rather than replaces.
         df.set_field_metadata("n", custom_properties={"qudt:hasQuantityKind": "http://example.org/mass"})
         assert df.metadata.field_metadata["n"].custom_properties == {
@@ -256,9 +254,7 @@ class TestFieldCustomPropertiesJsonLd:
             },
         )
         restored = Metadata.from_jsonld(m.to_jsonld())
-        assert restored.field_metadata["n"].custom_properties == {
-            "sosa:observedProperty": "http://example.org/n"
-        }
+        assert restored.field_metadata["n"].custom_properties == {"sosa:observedProperty": "http://example.org/n"}
 
 
 class TestMetadataPropagation:


### PR DESCRIPTION
Implements the field-observed-property spec: field mappings in datasets.yaml
can now carry arbitrary RDF property keys (e.g. sosa:observedProperty,
qudt:hasQuantityKind), mirroring the existing dataset-level custom-property
mechanism.

- FieldSchema gains a custom_properties field
- _parse_fields collects remaining RDF property keys per field; non-RDF
  unknown keys are still ignored
- _field_schema_to_dict emits them for lossless datasets.yaml round-trip
- Metadata.to_jsonld/from_jsonld carry per-field custom properties
- datapackage build expands field custom properties (frictionless and
  non-frictionless paths) using the dataset's effective prefix map
- DataFrame.set_field_metadata accepts custom_properties