### PR TITLE
feat: GeoJSON/TopoJSON vector support via optional [geo] extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: GeoJSON and TopoJSON read/write via the optional `[geo]` extra.
 - Added: Extensible field value-types (registry) for structured columns.
 - Added: field-level RDF/custom properties in `datasets.yaml` (e.g. `sosa:observedProperty`) now round-trip and flow to `datapackage.json`.
 - Removed: `Metadata.identity` field and the auto-minted default identity. The value was never serialized (no format handler emitted it) or read by anything, and the field silently dropped user-supplied input at write time. **Breaking** for `Metadata(identity=...)` callers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Added: Extensible field value-types (registry) for structured columns.
 - Added: field-level RDF/custom properties in `datasets.yaml` (e.g. `sosa:observedProperty`) now round-trip and flow to `datapackage.json`.
 - Removed: `Metadata.identity` field and the auto-minted default identity. The value was never serialized (no format handler emitted it) or read by anything, and the field silently dropped user-supplied input at write time. **Breaking** for `Metadata(identity=...)` callers.
 

--- a/docs/references/geojson.md
+++ b/docs/references/geojson.md
@@ -1,0 +1,121 @@
+# GeoJSON Reference (RFC 7946)
+
+Source: RFC 7946, IETF — https://datatracker.ietf.org/doc/html/rfc7946
+Agent-oriented spec for implementing/validating GeoJSON read/write.
+
+## Core rules
+
+- Every GeoJSON object MUST have a `"type"` member.
+- `"type"` values are **case-sensitive** and exact (e.g. `Point`, not `point`).
+- Valid `"type"` values: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `GeometryCollection`, `Feature`, `FeatureCollection`.
+- Three top-level kinds: **Geometry** (7 types), **Feature**, **FeatureCollection**.
+
+## CRS / coordinate system
+
+- CRS is **fixed to WGS 84**, equivalent to `urn:ogc:def:crs:OGC::CRS84`. No CRS member exists.
+- Units: **decimal degrees**. Order is **longitude, latitude, [altitude]** = **(x, y, z)**.
+- COMMON BUG: lon comes first, not lat.
+- The legacy GeoJSON-2008 `"crs"` member is **removed** by RFC 7946. Do not emit it; assume WGS84 on read.
+
+## Position
+
+- A position is an array of numbers.
+- MUST have **two or more** elements: `[lon, lat]` or `[lon, lat, altitude]`.
+- 3rd element (optional) = height in meters above/below WGS84 ellipsoid.
+- Implementations SHOULD NOT use more than 3 elements (extras are undefined).
+- Latitude MUST be in [-90, 90]; values outside MUST NOT be used to imply non-spherical-cap extent.
+
+## Geometry types — `"coordinates"` nesting
+
+Required members per geometry: `"type"` + `"coordinates"` (except GeometryCollection, which uses `"geometries"`).
+
+| Type | coordinates structure | constraints |
+|------|----------------------|-------------|
+| Point | position | single `[lon,lat]` |
+| MultiPoint | array of positions | |
+| LineString | array of positions | **>= 2** positions |
+| MultiLineString | array of LineString coords | each line >= 2 positions |
+| Polygon | array of linear rings | ring[0] = exterior, rest = holes |
+| MultiPolygon | array of Polygon coords | |
+| GeometryCollection | (uses `"geometries"`: array of Geometry objects) | array may be empty |
+
+Nesting depth of `coordinates`: Point=1, MultiPoint/LineString=2, MultiLineString/Polygon=3, MultiPolygon=4.
+
+```json
+{"type":"Point","coordinates":[100.0,0.0]}
+{"type":"MultiPoint","coordinates":[[100.0,0.0],[101.0,1.0]]}
+{"type":"LineString","coordinates":[[100.0,0.0],[101.0,1.0]]}
+{"type":"MultiLineString","coordinates":[[[100.0,0.0],[101.0,1.0]],[[102.0,2.0],[103.0,3.0]]]}
+{"type":"Polygon","coordinates":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}
+{"type":"MultiPolygon","coordinates":[[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,0.0]]]]}
+{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[100.0,0.0]}]}
+```
+
+## Linear rings (Polygon / MultiPolygon)
+
+- A linear ring is a **closed** LineString with **four or more** positions.
+- First and last positions MUST be identical values (representation SHOULD also be identical).
+- Right-hand rule: ring MUST follow it w.r.t. the area it bounds — **exterior ring counterclockwise, holes clockwise**.
+- Backward compat: parsers SHOULD NOT reject Polygons that violate the right-hand rule.
+
+## Feature
+
+Required members:
+- `"type": "Feature"`
+- `"geometry"`: a Geometry object **or JSON `null`** (null = unlocated feature).
+- `"properties"`: a JSON object **or JSON `null`**.
+
+Optional:
+- `"id"`: a JSON **string or number**.
+
+```json
+{"type":"Feature","id":"x1","geometry":{"type":"Point","coordinates":[100.0,0.0]},"properties":{"name":"A"}}
+```
+
+## FeatureCollection
+
+Required members:
+- `"type": "FeatureCollection"`
+- `"features"`: a JSON array of Feature objects (MAY be empty).
+
+```json
+{"type":"FeatureCollection","features":[]}
+```
+
+## bbox
+
+- Any GeoJSON object MAY have a `"bbox"` member.
+- Value is an array of length **2*n** (n = number of dimensions, usually 2 → length 4, or 3 → length 6).
+- Order: **all axes of the southwesterly-most point first, then all axes of the northeasterly-most point**, same axis order as positions (lon, lat, [alt]).
+- 2D example: `[west, south, east, north]`.
+- Antimeridian-crossing bbox: the northeast longitude is **less than** the southwest longitude, e.g. Fiji `[177.0,-20.0,-178.0,-16.0]`.
+- Pole caps: North `[-180.0, minlat, 180.0, 90.0]`; South `[-180.0, -90.0, 180.0, maxlat]`.
+
+## Foreign members
+
+- Any GeoJSON object MAY carry additional ("foreign") members beyond those in the spec.
+- GeoJSON semantics do NOT apply to foreign members or their descendants; no normative processing model; support varies — interoperability caveat.
+- Feature / FeatureCollection / Geometry MUST NOT contain the defining members of another type. In particular a FeatureCollection MUST NOT carry `"geometry"`, `"properties"`, or `"coordinates"` with their GeoJSON meaning.
+
+## Antimeridian & poles
+
+- Any geometry crossing the antimeridian (180° lon) SHOULD be cut in two so neither part crosses it (line → MultiLineString; polygon → MultiPolygon).
+- Regions touching a pole: represent as a spherical cap; do not abuse latitude values to imply otherwise (see bbox pole forms above).
+
+## Precision
+
+- Implementations SHOULD weigh the cost of excess precision; ~6 decimal places ≈ 10 cm, enough for most uses. Excess precision inflates size.
+
+## Validation checklist (MUST rules)
+
+- [ ] `"type"` present, exact-case, one of the 9 valid values.
+- [ ] Geometry has `"coordinates"` (or `"geometries"` for GeometryCollection).
+- [ ] Position arrays have >= 2 numbers; coordinate order is lon, lat, [alt].
+- [ ] LineString >= 2 positions.
+- [ ] Each Polygon ring: closed (first == last), >= 4 positions.
+- [ ] Latitude within [-90, 90].
+- [ ] bbox length == 2*n; SW axes before NE axes.
+- [ ] Feature has `"type":"Feature"`, `"geometry"` (object or null), `"properties"` (object or null); `"id"` if present is string/number.
+- [ ] FeatureCollection has `"type":"FeatureCollection"` and a `"features"` array of Features.
+- [ ] FeatureCollection does NOT carry GeoJSON `"geometry"`/`"properties"`/`"coordinates"`.
+- [ ] No `"crs"` member emitted (RFC 7946 forbids it).

--- a/docs/references/topojson.md
+++ b/docs/references/topojson.md
@@ -1,0 +1,161 @@
+> Source: TopoJSON specification — https://github.com/topojson/topojson-specification
+
+# TopoJSON Reference (for implementers)
+
+Agent-oriented spec for implementing TopoJSON **decode** (topology → GeoJSON-like features) and **encode** (features → topology).
+
+## Core concept (vs GeoJSON)
+
+- GeoJSON embeds coordinates directly in every geometry.
+- TopoJSON factors all shared line segments into one top-level **`arcs`** array. Line/polygon geometries reference arcs **by integer index** instead of embedding coordinates. Shared boundaries between adjacent shapes reference the same arc once → no coordinate duplication.
+- Point/MultiPoint still embed coordinates directly (no arcs).
+- TopoJSON has **no Feature object**: feature-level data (`properties`, `id`) lives on geometry objects.
+- Coordinate order: x, y, z = (longitude, latitude, altitude) for geographic / (easting, northing, altitude) for projected. Same CRS expectations as GeoJSON (default WGS84).
+
+## Top-level Topology object
+
+| Member | Req | Value |
+|---|---|---|
+| `type` | MUST | `"Topology"` |
+| `objects` | MUST | object: map of name → geometry object (usually GeometryCollection) |
+| `arcs` | MUST | array of arcs; each arc = array of **≥2 positions** |
+| `transform` | optional | quantization transform (see below) |
+| `bbox` | optional | bounding box |
+
+- `objects` is the named map; e.g. `objects.counties`, `objects.states`. Each value is a geometry object.
+- `bbox`: `2*n` array `[minX, minY, ..., maxX, maxY, ...]` (n = dimensions): all min axes then all max axes. **MUST NOT** be transformed by the topology's transform (bbox values are absolute).
+
+## Geometry objects
+
+Types: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `GeometryCollection`. A geometry with `type: null` (or no coordinates/arcs) represents a null geometry.
+
+Every geometry object MAY have: `properties` (JSON object or null), `id`, `bbox`.
+
+Coordinate vs arc reference, and exact nesting:
+
+| Type | Member | Shape | Example |
+|---|---|---|---|
+| Point | `coordinates` | one position | `[x, y]` |
+| MultiPoint | `coordinates` | array of positions | `[[x,y], [x,y]]` |
+| LineString | `arcs` | array of arc indexes | `[0, 1, -2]` |
+| MultiLineString | `arcs` | array of (array of arc indexes) | `[[0,1], [2]]` |
+| Polygon | `arcs` | array of rings; ring = array of arc indexes | `[[0,1,2], [3]]` |
+| MultiPolygon | `arcs` | array of polygons (one level deeper) | `[[[0,1]], [[2,3]]]` |
+| GeometryCollection | `geometries` | array of geometry objects | — |
+
+- Polygon `arcs`: first ring = exterior, rest = holes (interior).
+- A LinearRing is a closed LineString with ≥4 positions; first == last after stitching.
+
+## Arc indexing semantics
+
+- An arc index is an integer into the top-level `arcs` array.
+- **Negative index** means the arc is **reversed**. Index `~i` (i.e. `-i - 1`) refers to arc `i` reversed: `-1`→arc 0 reversed, `-2`→arc 1 reversed, `-3`→arc 2 reversed, …
+- Dereference: if index `idx >= 0` use `arcs[idx]` as-is; else use `arcs[~idx]` reversed, where `~idx == -idx - 1`.
+
+```
+def deref(arcs, idx):
+    if idx >= 0: return arcs[idx]
+    else:        return reversed(arcs[~idx])   # ~idx = -idx - 1
+```
+
+## Arcs array + stitching (de-duplication rule)
+
+- Each arc is an array of ≥2 positions.
+- When a line/ring is built from multiple arcs, **the first position of each subsequent arc MUST equal the last position of the previous arc** (arcs overlap by one shared endpoint).
+- On reconstruction, drop the duplicate: the first position of each arc **except the first** is dropped (equivalently, last of each arc except the last). Concatenate the rest.
+
+```
+def stitch(arc_indexes, arcs):
+    line = []
+    for k, idx in enumerate(arc_indexes):
+        pts = deref(arcs, idx)
+        if k > 0: pts = pts[1:]   # drop shared first point
+        line.extend(pts)
+    return line
+```
+
+## Transform (quantization + delta-encoding)
+
+Present only when coordinates are quantized. If absent, **all arc positions are absolute floats and NOT delta-encoded**.
+
+```json
+"transform": { "scale": [sx, sy], "translate": [tx, ty] }
+```
+
+When `transform` is present:
+- Every quantized position's first two elements MUST be **integers**.
+- Within each arc, positions are **delta-encoded**: position[0] is absolute (integer); each later position stores the delta from the previous: `xₖ = xₖ₋₁ + Δxₖ`, `yₖ = yₖ₋₁ + Δyₖ`.
+
+**Decode (quantized integer deltas → absolute float coordinate)** — per arc, accumulate deltas then apply scale/translate:
+
+```js
+function decodeArc(transform, arc) {
+  let x = 0, y = 0;
+  return arc.map(p => {
+    x += p[0]; y += p[1];                       // delta-decode
+    return [ x * transform.scale[0] + transform.translate[0],
+             y * transform.scale[1] + transform.translate[1] ];
+  });
+}
+```
+
+**Encode (absolute float → quantized integer deltas)** — inverse, per arc:
+
+```
+prevX = prevY = 0
+for each position [X, Y] in arc:           # X,Y absolute floats
+    qx = round((X - translate[0]) / scale[0])   # quantized integer
+    qy = round((Y - translate[1]) / scale[1])
+    emit [qx - prevX, qy - prevY]               # delta
+    prevX, prevY = qx, qy
+```
+
+Note: `transform` affects only positions inside `arcs` and `coordinates`; it does NOT affect `bbox`.
+
+## Decode algorithm (Topology → features)
+
+1. For each arc in `topology.arcs`: if `transform` present, run `decodeArc` (delta-decode + scale/translate) to get absolute positions; else use positions as-is. Cache decoded arcs.
+2. For each named object in `topology.objects`, recursively convert each geometry:
+   - **Point/MultiPoint**: take `coordinates`; if `transform` present, decode each position absolutely (`x*scale+translate`) — Point/MultiPoint coords are quantized but NOT delta-encoded across points; each is standalone integer scaled directly.
+   - **LineString**: `stitch(geom.arcs, decodedArcs)`.
+   - **MultiLineString**: stitch each sub-array → list of lines.
+   - **Polygon**: stitch each ring → list of rings (ensure closed).
+   - **MultiPolygon**: one level deeper.
+   - **GeometryCollection**: recurse into `geometries`.
+3. Carry `properties` and `id` onto the resulting GeoJSON Feature.
+
+## Encode algorithm (features → Topology)
+
+1. Extract all line segments (LineString/ring sequences) from input geometries.
+2. Cut/merge shared sequences into **arcs**; arrange so consecutive arcs in a line/ring share endpoints (last of one == first of next). Build geometry `arcs` index arrays; use negative indexes (`~i`) where an arc is traversed in reverse.
+3. (Optional) Choose a quantization grid; compute `scale`/`translate` so that `q = round((coord - translate)/scale)` maps coordinates to integers; set `transform`.
+4. For each arc, quantize positions, then **delta-encode** (store first position absolute, then successive deltas).
+5. Assemble `{ type: "Topology", transform?, bbox?, objects, arcs }`. Move feature `properties`/`id` onto geometry objects.
+
+## Complete example (with transform)
+
+```json
+{
+  "type": "Topology",
+  "transform": {
+    "scale": [0.0005000500050005, 0.00010001000100010001],
+    "translate": [100, 0]
+  },
+  "objects": {
+    "example": {
+      "type": "GeometryCollection",
+      "geometries": [
+        { "type": "Point", "properties": {"prop0": "value0"}, "coordinates": [4000, 5000] },
+        { "type": "LineString", "properties": {"prop0": "value0", "prop1": 0}, "arcs": [0] },
+        { "type": "Polygon", "properties": {"prop0": "value0", "prop1": {"this": "that"}}, "arcs": [[1]] }
+      ]
+    }
+  },
+  "arcs": [
+    [[4000, 0], [1999, 9999], [2000, -9999], [2000, 9999]],
+    [[0, 0], [0, 9999], [2000, 0], [0, -9999], [-2000, 0]]
+  ]
+}
+```
+
+Arc 0 first position `[4000,0]` is absolute (integer); `[1999,9999]` etc. are deltas. Decode via `decodeArc` to recover absolute lon/lat.

--- a/docs/superpowers/plans/2026-06-17-geo-phase1-field-types-and-format-resolution.md
+++ b/docs/superpowers/plans/2026-06-17-geo-phase1-field-types-and-format-resolution.md
@@ -1,0 +1,396 @@
+# Geo Phase 1: Field-Type Registry + Format-Driven Resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a plugin-extensible field (column) value-type registry and make `datasets.yaml` `format` drive handler resolution — the core seam geo (Phase 2) builds on, with no geospatial dependency.
+
+**Architecture:** A new `FieldTypeRegistry` holds `FieldTypeDescriptor`s (built-in Frictionless scalar types pre-registered; plugins add structured types like `geometry` later). `PluginRegistry` discovers a plugin's `field_types()` during registration. `DatasetMetadata` gains a `format` field; `read_dataset` threads it into `find_format_reader` so a pinned `format` overrides extension detection.
+
+**Tech Stack:** Python 3.11+, dataclasses, pytest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md` (D2, D4).
+
+---
+
+### Task 1: Add `format` to `DatasetMetadata` and parse it
+
+**Files:**
+- Modify: `src/sunstone/lineage.py` (the `DatasetMetadata` dataclass, ~line 371 after `resource_type`)
+- Modify: `src/sunstone/datasets.py` (`_parse_dataset`, the `return DatasetMetadata(...)` block ~line 693)
+- Test: `tests/test_datasets.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_dataset_format_field_parsed(tmp_path):
+    from sunstone.datasets import DatasetsManager
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n"
+        "  - name: World Borders\n"
+        "    slug: world-borders\n"
+        "    location: inputs/world.json\n"
+        "    format: geojson\n"
+    )
+    mgr = DatasetsManager(tmp_path)
+    ds = mgr.find_dataset_by_slug("world-borders")
+    assert ds is not None
+    assert ds.format == "geojson"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_datasets.py::test_dataset_format_field_parsed -v --no-cov`
+Expected: FAIL — `AttributeError: 'DatasetMetadata' object has no attribute 'format'`
+
+- [ ] **Step 3: Add the field to `DatasetMetadata`**
+
+In `src/sunstone/lineage.py`, immediately after the `resource_type` field:
+
+```python
+    format: Optional[str] = None
+    """Serialization format (e.g. 'geojson', 'topojson', 'csv'). Drives handler
+    resolution when set; otherwise the file extension is used."""
+```
+
+- [ ] **Step 4: Parse it in `_parse_dataset`**
+
+In `src/sunstone/datasets.py`, in the `return DatasetMetadata(...)` call, add after `resource_type=dataset_data.get("type"),`:
+
+```python
+            format=dataset_data.get("format"),
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_datasets.py::test_dataset_format_field_parsed -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/lineage.py src/sunstone/datasets.py tests/test_datasets.py
+git commit -m "feat: add format field to dataset metadata"
+```
+
+---
+
+### Task 2: Field-type registry and descriptor
+
+**Files:**
+- Create: `src/sunstone/field_types.py`
+- Test: `tests/test_field_types.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+from sunstone.field_types import (
+    FieldTypeDescriptor, FieldTypeRegistry, validate_field_value, FieldTypeValidationError,
+)
+
+
+def test_builtin_scalar_types_present():
+    reg = FieldTypeRegistry()
+    for name in ("string", "integer", "number", "boolean", "date", "datetime", "any"):
+        assert reg.get(name) is not None
+
+
+def test_register_and_get_custom_type():
+    reg = FieldTypeRegistry()
+    desc = FieldTypeDescriptor(name="geometry", validate=lambda v: hasattr(v, "geom_type"))
+    reg.register(desc)
+    assert reg.get("geometry") is desc
+    assert "geometry" in reg.known()
+
+
+def test_validate_is_mode_gated():
+    reg = FieldTypeRegistry()
+    reg.register(FieldTypeDescriptor(name="geometry", validate=lambda v: v == "ok"))
+    # lenient: bad value does not raise
+    validate_field_value(reg, "geometry", "bad", strict=False)
+    # strict: bad value raises
+    with pytest.raises(FieldTypeValidationError):
+        validate_field_value(reg, "geometry", "bad", strict=True)
+    # unknown type or no validator: no-op even in strict mode
+    validate_field_value(reg, "string", "anything", strict=True)
+    validate_field_value(reg, "not-registered", "anything", strict=True)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_field_types.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'sunstone.field_types'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/sunstone/field_types.py`:
+
+```python
+"""Registry of field (column) value-types for dataset schemas.
+
+Built-in scalar types mirror the Frictionless Table Schema vocabulary. Plugins
+extend this with structured/domain types (e.g. ``geometry``) via
+``FieldTypeDescriptor`` — see ``PluginRegistry`` classification. This is the
+extensibility seam for non-scalar columns; geometry is the first consumer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+class FieldTypeValidationError(ValueError):
+    """A field value failed its registered type contract in strict mode."""
+
+
+@dataclass(frozen=True)
+class FieldTypeDescriptor:
+    """Describes a field (column) value-type.
+
+    ``validate`` is an optional cell-level contract: it returns True for a
+    valid value. ``None`` means "no contract" (always accepted).
+    """
+
+    name: str
+    validate: Optional[Callable[[Any], bool]] = None
+    description: Optional[str] = None
+
+
+# Frictionless Table Schema scalar types (plus "any").
+_BUILTIN_SCALAR_TYPES: tuple[str, ...] = (
+    "string", "number", "integer", "boolean", "object", "array",
+    "date", "datetime", "time", "year", "yearmonth", "duration", "any",
+)
+
+
+class FieldTypeRegistry:
+    """Holds known field value-types, keyed by name."""
+
+    def __init__(self) -> None:
+        self._types: dict[str, FieldTypeDescriptor] = {
+            name: FieldTypeDescriptor(name=name) for name in _BUILTIN_SCALAR_TYPES
+        }
+
+    def register(self, descriptor: FieldTypeDescriptor) -> None:
+        self._types[descriptor.name] = descriptor
+
+    def get(self, name: str) -> Optional[FieldTypeDescriptor]:
+        return self._types.get(name)
+
+    def known(self) -> tuple[str, ...]:
+        return tuple(self._types)
+
+
+def validate_field_value(
+    registry: FieldTypeRegistry, type_name: str, value: Any, *, strict: bool
+) -> None:
+    """Validate ``value`` against the contract for ``type_name``.
+
+    No-op when the type is unknown or has no contract. In strict mode a failed
+    contract raises ``FieldTypeValidationError``; in lenient mode it is ignored.
+    """
+    descriptor = registry.get(type_name)
+    if descriptor is None or descriptor.validate is None:
+        return
+    if not descriptor.validate(value) and strict:
+        raise FieldTypeValidationError(
+            f"Value {value!r} is not valid for field type {type_name!r}"
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_field_types.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/field_types.py tests/test_field_types.py
+git commit -m "feat: field-type registry for column value-types"
+```
+
+---
+
+### Task 3: Discover `field_types()` from plugins; expose a shared registry
+
+**Files:**
+- Modify: `src/sunstone/plugins.py` (`PluginRegistry.__init__`, `_register`, and `_register_builtins`)
+- Test: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_plugin_field_types_are_registered():
+    from sunstone.field_types import FieldTypeDescriptor
+    from sunstone.plugins import PluginRegistry
+
+    class FakeGeoPlugin:
+        def field_types(self):
+            return (FieldTypeDescriptor(name="geometry", validate=lambda v: True),)
+
+    reg = PluginRegistry()
+    reg._register("fake-geo", FakeGeoPlugin())
+    assert reg.field_types.get("geometry") is not None
+    # built-ins still present
+    assert reg.field_types.get("string") is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_plugins.py::test_plugin_field_types_are_registered -v --no-cov`
+Expected: FAIL — `AttributeError: 'PluginRegistry' object has no attribute 'field_types'`
+
+- [ ] **Step 3: Add the registry instance**
+
+In `src/sunstone/plugins.py`, in `PluginRegistry.__init__` next to `self._format_handlers: list[FormatHandler] = []`:
+
+```python
+        from .field_types import FieldTypeRegistry
+
+        self.field_types = FieldTypeRegistry()
+```
+
+- [ ] **Step 4: Classify `field_types()` during registration**
+
+In `PluginRegistry._register`, after the existing classification branches (before the final `return`/`registered` handling), add:
+
+```python
+        if hasattr(plugin, "field_types") and callable(plugin.field_types):
+            for descriptor in plugin.field_types():
+                self.field_types.register(descriptor)
+            registered = True
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_plugins.py::test_plugin_field_types_are_registered -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 6: Run the full plugins suite (regression)**
+
+Run: `uv run pytest tests/test_plugins.py -v --no-cov`
+Expected: PASS (all existing tests still green)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "feat: discover plugin field types in registry"
+```
+
+---
+
+### Task 4: `read_dataset` honors a pinned `format`
+
+**Files:**
+- Modify: `src/sunstone/dataframe.py` (`read_dataset`, ~lines 424-446)
+- Test: `tests/test_dataframe.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_pinned_format_overrides_extension(tmp_path):
+    """A .json file pinned as format: geojson must NOT be read as tabular JSON.
+
+    With no geojson handler installed (Phase 1), resolution must fail loudly
+    instead of silently mis-parsing via read_json.
+    """
+    import pytest
+    from sunstone.dataframe import DataFrame
+
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n"
+        "  - name: World\n"
+        "    slug: world\n"
+        "    location: world.json\n"
+        "    format: geojson\n"
+    )
+    (tmp_path / "world.json").write_text('{"type":"FeatureCollection","features":[]}')
+
+    with pytest.raises(ValueError, match="geojson"):
+        DataFrame.read_dataset("world", project_path=tmp_path)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dataframe.py::test_pinned_format_overrides_extension -v --no-cov`
+Expected: FAIL — no error raised (the file is silently read by `read_json` as a tabular frame).
+
+- [ ] **Step 3: Thread `dataset.format` into resolution**
+
+In `src/sunstone/dataframe.py` `read_dataset`, after `dataset` is fetched and before resolving the handler (just before `format_handler = registry.find_format_reader(location, format)`), add:
+
+```python
+        # A pinned format in datasets.yaml overrides extension detection.
+        if format is None and dataset.format is not None:
+            format = dataset.format
+```
+
+- [ ] **Step 4: Sharpen the not-found error**
+
+Replace the existing `raise ValueError(...)` for the missing-handler case with a message that names the format and hints at extras:
+
+```python
+        if format_handler is None:
+            extension = absolute_path.suffix.lower()
+            detail = f"format={format!r}" if format else f"extension={extension!r}"
+            raise ValueError(
+                f"No format handler found for '{absolute_path.name}' ({detail}). "
+                "Install the matching extra (e.g. `pip install sunstone-py[geo]` for "
+                "geojson/topojson) or check the file extension."
+            )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_dataframe.py::test_pinned_format_overrides_extension -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 6: Regression — plain reads still work**
+
+Run: `uv run pytest tests/test_dataframe.py tests/test_datasets.py -v --no-cov`
+Expected: PASS (a `.json` dataset with no pinned `format` still reads as tabular JSON.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sunstone/dataframe.py tests/test_dataframe.py
+git commit -m "feat: pinned datasets.yaml format overrides extension detection"
+```
+
+---
+
+### Task 5: Full-suite regression + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest --no-cov`
+Expected: PASS (entire suite green)
+
+- [ ] **Step 2: Add a CHANGELOG entry**
+
+Under the `[Unreleased]` section of `CHANGELOG.md`, add:
+
+```
+- Added: Extensible field value-types (registry) for structured columns.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog for field-type registry"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: D2 (field-type registry + plugin discovery) → Tasks 2–3. D4 (`format` field + format-driven resolution) → Tasks 1, 4. Thin `type` needs no change (it already exists as `resource_type` and is not used for resolution).
+- The `validate_field_value` helper is wired into actual read/write validation in Phase 2 (where the `geometry` field type provides a real contract); Phase 1 ships the seam and its unit tests.
+- No new dependencies; no `AssetKind` change in Phase 1.

--- a/docs/superpowers/plans/2026-06-17-geo-phase2-geo-plugin.md
+++ b/docs/superpowers/plans/2026-06-17-geo-phase2-geo-plugin.md
@@ -1,0 +1,936 @@
+# Geo Phase 2: The `[geo]` Plugin (GeoJSON/TopoJSON) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Read/write GeoJSON and TopoJSON into a `geopandas.GeoDataFrame` with lineage, behind an optional `[geo]` extra, via a new `GEOFEATURES` asset kind and a `sunstone.geopandas` facade.
+
+**Architecture:** A new `AssetKind.GEOFEATURES` (payload = `GeoDataFrame`). `handlers_geo.py` provides `GeoFeaturesFormatHandler` (geojson + topojson, lazy geopandas imports) and registers a `geometry` field type. Metadata embeds as a top-level `"sunstone"` foreign member. A `sunstone.geopandas` facade + `GeoDataFrame` wrapper mirror the `pandas` facade. Core never imports geopandas.
+
+**Tech Stack:** Python 3.11+, geopandas, shapely, pyogrio, topojson (all under the `[geo]` extra), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md` (D1, D3, D5–D8). **Format refs:** `docs/references/geojson.md`, `docs/references/topojson.md`.
+
+**Depends on:** Phase 1 (`field_types` registry, `format`-driven resolution).
+
+---
+
+### Task 1: Add `AssetKind.GEOFEATURES` and the accessor
+
+**Files:**
+- Modify: `src/sunstone/asset.py` (`AssetKind` enum ~line 26; accessors ~line 60-83)
+- Test: `tests/test_dataframe_coverage.py` (or a new `tests/test_asset.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_geofeatures_kind_and_accessor():
+    import pytest
+    from sunstone.asset import Asset, AssetKind
+    from sunstone.errors import IncompatibleAssetKindError
+    from sunstone.lineage import Metadata
+
+    payload = object()  # stand-in for a GeoDataFrame
+    a = Asset(payload=payload, kind=AssetKind.GEOFEATURES, metadata=Metadata())
+    assert a.as_geofeatures() is payload
+
+    t = Asset(payload=[], kind=AssetKind.TABULAR, metadata=Metadata())
+    with pytest.raises(IncompatibleAssetKindError):
+        t.as_geofeatures()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dataframe_coverage.py::test_geofeatures_kind_and_accessor -v --no-cov`
+Expected: FAIL — `AttributeError: GEOFEATURES` / `as_geofeatures`
+
+- [ ] **Step 3: Add the enum member**
+
+In `src/sunstone/asset.py`, in `AssetKind`, after `BLOB = "blob"`:
+
+```python
+    GEOFEATURES = "geofeatures"
+```
+
+- [ ] **Step 4: Add the accessor**
+
+In `src/sunstone/asset.py`, alongside the other `as_*` accessors:
+
+```python
+    def as_geofeatures(self) -> Any:
+        """Return the geopandas GeoDataFrame payload (typed Any: core has no geopandas dep)."""
+        if self.kind is not AssetKind.GEOFEATURES:
+            raise IncompatibleAssetKindError(expected=AssetKind.GEOFEATURES, actual=self.kind)
+        return self.payload
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_dataframe_coverage.py::test_geofeatures_kind_and_accessor -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sunstone/asset.py tests/test_dataframe_coverage.py
+git commit -m "feat: add GEOFEATURES asset kind and accessor"
+```
+
+---
+
+### Task 2: Declare the `[geo]` optional extra
+
+**Files:**
+- Modify: `pyproject.toml` (`[project.optional-dependencies]`)
+
+- [ ] **Step 1: Add the extra**
+
+In `pyproject.toml` under `[project.optional-dependencies]`, add:
+
+```toml
+geo = ["geopandas>=1.0", "shapely>=2.0", "pyogrio>=0.8", "topojson>=1.9"]
+```
+
+- [ ] **Step 2: Sync and verify import availability**
+
+Run: `uv sync --extra geo`
+Then: `uv run python -c "import geopandas, shapely, topojson; print('geo ok')"`
+Expected: prints `geo ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "build: add optional [geo] extra"
+```
+
+---
+
+### Task 3: Handler skeleton + `geometry` field type (no geopandas at import)
+
+**Files:**
+- Create: `src/sunstone/handlers_geo.py`
+- Test: `tests/test_handlers_geo.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_geo_handler_resolution_is_dependency_free():
+    # This test must pass even without the [geo] extra installed.
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+    from sunstone.asset import AssetKind
+
+    h = GeoFeaturesFormatHandler()
+    assert h.can_read("x.geojson", None)
+    assert h.can_read("x.topojson", None)
+    assert h.can_read("x.json", "geojson")
+    assert not h.can_read("x.json", None)          # plain .json is NOT geo
+    assert not h.can_read("x.csv", None)
+    assert h.supported_kinds() == (AssetKind.GEOFEATURES,)
+
+
+def test_geometry_field_type_descriptor_exposed():
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+    names = {ft.name for ft in GeoFeaturesFormatHandler().field_types()}
+    assert "geometry" in names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_handlers_geo.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'sunstone.handlers_geo'`
+
+- [ ] **Step 3: Write the skeleton**
+
+Create `src/sunstone/handlers_geo.py`:
+
+```python
+"""GeoJSON/TopoJSON format handler for AssetKind.GEOFEATURES.
+
+geopandas/shapely/topojson are imported lazily inside read()/write() so that
+importing this module (and resolving handlers) is dependency-free. Registered
+only when the [geo] extra is importable — see PluginRegistry._register_builtins.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+from typing import Any, BinaryIO
+from urllib.parse import urlparse
+
+from .asset import AssetKind
+from .field_types import FieldTypeDescriptor
+
+_EXTENSION_MAP = {".geojson": "geojson", ".topojson": "topojson"}
+_FORMATS = frozenset({"geojson", "topojson"})
+_SUNSTONE_KEY = "sunstone"
+
+
+def _is_geometry(value: Any) -> bool:
+    """Cell contract for the `geometry` field type: a shapely geometry."""
+    return hasattr(value, "geom_type") or value is None
+
+
+def _require_geo() -> None:
+    try:
+        import geopandas  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised via message test
+        raise ImportError(
+            "Reading/writing GeoJSON/TopoJSON requires the geo extra. "
+            "Install it with: pip install sunstone-py[geo]"
+        ) from exc
+
+
+class GeoFeaturesFormatHandler:
+    __sunstone_handler_protocol__ = 2
+
+    def supports_native_metadata_extraction(self) -> bool:
+        return False
+
+    def supports_sunstone_metadata_embedding(self) -> bool:
+        return True
+
+    def supports_metadata(self) -> bool:
+        return True
+
+    def supported_kinds(self) -> tuple:
+        return (AssetKind.GEOFEATURES,)
+
+    def field_types(self) -> tuple[FieldTypeDescriptor, ...]:
+        return (FieldTypeDescriptor(
+            name="geometry",
+            validate=_is_geometry,
+            description="A geographic geometry (shapely) with a CRS.",
+        ),)
+
+    def _resolve_format(self, path: str, format: str | None) -> str | None:
+        if format is not None:
+            return format if format in _FORMATS else None
+        parsed = urlparse(path)
+        file_path = parsed.path if parsed.scheme else path
+        return _EXTENSION_MAP.get(PurePosixPath(file_path).suffix.lower())
+
+    def can_read(self, path: str, format: str | None) -> bool:
+        return self._resolve_format(path, format) is not None
+
+    def can_write(self, path: str, format: str | None) -> bool:
+        return self._resolve_format(path, format) is not None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_handlers_geo.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers_geo.py tests/test_handlers_geo.py
+git commit -m "feat: geo handler skeleton + geometry field type"
+```
+
+---
+
+### Task 4: GeoJSON read (with `"sunstone"` extraction + default CRS)
+
+**Files:**
+- Modify: `src/sunstone/handlers_geo.py`
+- Test: `tests/test_handlers_geo.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+geopandas = pytest.importorskip("geopandas")
+
+
+def _fc():
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [10.0, 20.0]},
+             "properties": {"name": "A"}},
+        ],
+    }
+
+
+def test_geojson_read_builds_geodataframe(tmp_path):
+    import io
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+    from sunstone.asset import AssetKind
+
+    stream = io.BytesIO(json.dumps(_fc()).encode("utf-8"))
+    asset = GeoFeaturesFormatHandler().read(stream, format="geojson", path="x.geojson")
+
+    assert asset.kind == AssetKind.GEOFEATURES
+    gdf = asset.payload
+    assert list(gdf["name"]) == ["A"]
+    assert gdf.geometry.iloc[0].x == 10.0
+    assert gdf.crs.to_epsg() == 4326          # default per RFC 7946
+    assert asset.extras.get("crs") is not None
+```
+
+(add `import json` at the top of the test module if not present)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_geojson_read_builds_geodataframe -v --no-cov`
+Expected: FAIL — `GeoFeaturesFormatHandler` has no attribute `read`
+
+- [ ] **Step 3: Implement `read` (GeoJSON branch)**
+
+Add to `GeoFeaturesFormatHandler` in `src/sunstone/handlers_geo.py`:
+
+```python
+    def read(self, stream: BinaryIO, **kwargs: object) -> "Any":
+        _require_geo()
+        import geopandas as gpd
+
+        from .asset import Asset
+        from .lineage import Metadata
+
+        fmt = self._resolve_format(str(kwargs.get("path") or ""), kwargs.get("format"))  # type: ignore[arg-type]
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+        kwargs.pop("dialect", None)
+
+        raw = stream.read()
+        doc = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
+
+        meta = Metadata()
+        sunstone_blob = doc.pop(_SUNSTONE_KEY, None) if isinstance(doc, dict) else None
+        if sunstone_blob is not None:
+            try:
+                meta = Metadata.from_jsonld(sunstone_blob)
+            except Exception:
+                meta = Metadata()
+
+        if fmt == "topojson":
+            doc = self._topojson_to_featurecollection(doc)
+
+        features = doc.get("features", []) if isinstance(doc, dict) else []
+        if features:
+            gdf = gpd.GeoDataFrame.from_features(features, crs="EPSG:4326")
+        else:
+            gdf = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+
+        return Asset(
+            payload=gdf,
+            kind=AssetKind.GEOFEATURES,
+            metadata=meta,
+            extras={"crs": gdf.crs},
+        )
+```
+
+(`_topojson_to_featurecollection` is implemented in Task 6; for now add a stub that raises `NotImplementedError` so the GeoJSON path compiles:)
+
+```python
+    def _topojson_to_featurecollection(self, doc: dict) -> dict:
+        raise NotImplementedError  # implemented in Task 6
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_geojson_read_builds_geodataframe -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers_geo.py tests/test_handlers_geo.py
+git commit -m "feat: GeoJSON read into GEOFEATURES asset"
+```
+
+---
+
+### Task 5: GeoJSON write (no `crs` member, ring winding, `id`, `"sunstone"` embed)
+
+**Files:**
+- Modify: `src/sunstone/handlers_geo.py`
+- Test: `tests/test_handlers_geo.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_geojson_write_roundtrip_and_conformance(tmp_path):
+    import io, json
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+    from sunstone.asset import Asset, AssetKind
+    from sunstone.lineage import Metadata
+
+    h = GeoFeaturesFormatHandler()
+    src = io.BytesIO(json.dumps(_fc()).encode("utf-8"))
+    asset = h.read(src, format="geojson", path="x.geojson")
+    asset.metadata.slug = "pts"
+    asset.metadata.name = "Points"
+
+    out = io.BytesIO()
+    h.write(asset, out, format="geojson", path="x.geojson")
+    doc = json.loads(out.getvalue().decode("utf-8"))
+
+    assert doc["type"] == "FeatureCollection"
+    assert "crs" not in doc                      # RFC 7946: never emit crs
+    assert doc["sunstone"]["slug"] == "pts" or doc["sunstone"].get("@graph")  # metadata embedded
+    # round-trips back to a GeoDataFrame
+    asset2 = h.read(io.BytesIO(out.getvalue()), format="geojson", path="x.geojson")
+    assert asset2.metadata.slug == "pts"
+    assert list(asset2.payload["name"]) == ["A"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_geojson_write_roundtrip_and_conformance -v --no-cov`
+Expected: FAIL — no `write` method.
+
+- [ ] **Step 3: Implement `write` (GeoJSON branch) + helpers**
+
+Add to `GeoFeaturesFormatHandler`:
+
+```python
+    def write(self, asset: object, stream: BinaryIO, **kwargs: object) -> None:
+        _require_geo()
+        fmt = self._resolve_format(str(kwargs.get("path") or ""), kwargs.get("format"))  # type: ignore[arg-type]
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+        kwargs.pop("dialect", None)
+
+        gdf = asset.as_geofeatures() if hasattr(asset, "as_geofeatures") else asset
+        metadata_obj = getattr(asset, "metadata", None)
+
+        gdf = self._orient_rings(gdf)
+        if gdf.crs is not None and getattr(gdf.crs, "to_epsg", lambda: None)() != 4326:
+            import warnings
+            warnings.warn(
+                "Writing non-WGS84 geometry as GeoJSON is non-conformant with RFC 7946; "
+                "CRS is recorded in metadata but coordinates are not reprojected.",
+                stacklevel=2,
+            )
+
+        if fmt == "topojson":
+            doc = self._geodataframe_to_topojson(gdf)
+        else:
+            doc = json.loads(gdf.to_json())  # FeatureCollection; geopandas does not emit crs in v1
+            doc.pop("crs", None)             # belt-and-suspenders for older geopandas
+
+        if metadata_obj is not None:
+            doc[_SUNSTONE_KEY] = metadata_obj.to_jsonld()
+
+        stream.write(json.dumps(doc).encode("utf-8"))
+
+    @staticmethod
+    def _orient_rings(gdf: "Any") -> "Any":
+        """Right-hand rule per RFC 7946: exterior CCW, holes CW."""
+        from shapely.geometry.polygon import orient
+        from shapely.geometry.base import BaseGeometry
+
+        def _fix(geom: "BaseGeometry"):
+            if geom is None:
+                return geom
+            if geom.geom_type == "Polygon":
+                return orient(geom, sign=1.0)
+            if geom.geom_type == "MultiPolygon":
+                from shapely.geometry import MultiPolygon
+                return MultiPolygon([orient(g, sign=1.0) for g in geom.geoms])
+            return geom
+
+        out = gdf.copy()
+        out[out.geometry.name] = out.geometry.apply(_fix)
+        return out
+```
+
+(`_geodataframe_to_topojson` is implemented in Task 7; add a stub raising `NotImplementedError`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_geojson_write_roundtrip_and_conformance -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers_geo.py tests/test_handlers_geo.py
+git commit -m "feat: GeoJSON write with RFC 7946 conformance + metadata embed"
+```
+
+---
+
+### Task 6: TopoJSON read (decode topology → features)
+
+**Files:**
+- Modify: `src/sunstone/handlers_geo.py` (`_topojson_to_featurecollection`)
+- Test: `tests/test_handlers_geo.py`
+
+Implements the decode algorithm from `docs/references/topojson.md` (delta-decode + scale/translate, arc stitch, negative-index reversal).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_topojson_read_decodes_line(tmp_path):
+    import io, json
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    topo = {
+        "type": "Topology",
+        "transform": {"scale": [1.0, 1.0], "translate": [0.0, 0.0]},
+        "objects": {"ex": {"type": "GeometryCollection", "geometries": [
+            {"type": "LineString", "properties": {"k": "v"}, "arcs": [0]},
+        ]}},
+        "arcs": [[[0, 0], [2, 0], [0, 2]]],   # delta-encoded: (0,0)->(2,0)->(2,2)
+    }
+    asset = GeoFeaturesFormatHandler().read(
+        io.BytesIO(json.dumps(topo).encode("utf-8")), format="topojson", path="x.topojson")
+    line = asset.payload.geometry.iloc[0]
+    assert list(line.coords) == [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]
+    assert list(asset.payload["k"]) == ["v"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_topojson_read_decodes_line -v --no-cov`
+Expected: FAIL — `NotImplementedError`
+
+- [ ] **Step 3: Implement the decoder**
+
+Replace the `_topojson_to_featurecollection` stub in `src/sunstone/handlers_geo.py`:
+
+```python
+    def _topojson_to_featurecollection(self, topo: dict) -> dict:
+        transform = topo.get("transform")
+        raw_arcs = topo.get("arcs", [])
+
+        def decode_arc(arc: list) -> list:
+            if transform is None:
+                return [list(p) for p in arc]
+            sx, sy = transform["scale"]
+            tx, ty = transform["translate"]
+            x = y = 0
+            out = []
+            for p in arc:
+                x += p[0]; y += p[1]
+                out.append([x * sx + tx, y * sy + ty])
+            return out
+
+        arcs = [decode_arc(a) for a in raw_arcs]
+
+        def deref(idx: int) -> list:
+            return list(arcs[idx]) if idx >= 0 else list(reversed(arcs[~idx]))
+
+        def stitch(indexes: list) -> list:
+            line: list = []
+            for k, idx in enumerate(indexes):
+                pts = deref(idx)
+                line.extend(pts[1:] if k > 0 else pts)
+            return line
+
+        def decode_point(p: list) -> list:
+            if transform is None:
+                return list(p)
+            sx, sy = transform["scale"]
+            tx, ty = transform["translate"]
+            return [p[0] * sx + tx, p[1] * sy + ty]
+
+        def to_geometry(g: dict) -> dict | None:
+            t = g.get("type")
+            if t is None:
+                return None
+            if t == "Point":
+                return {"type": "Point", "coordinates": decode_point(g["coordinates"])}
+            if t == "MultiPoint":
+                return {"type": "MultiPoint", "coordinates": [decode_point(p) for p in g["coordinates"]]}
+            if t == "LineString":
+                return {"type": "LineString", "coordinates": stitch(g["arcs"])}
+            if t == "MultiLineString":
+                return {"type": "MultiLineString", "coordinates": [stitch(a) for a in g["arcs"]]}
+            if t == "Polygon":
+                return {"type": "Polygon", "coordinates": [stitch(r) for r in g["arcs"]]}
+            if t == "MultiPolygon":
+                return {"type": "MultiPolygon",
+                        "coordinates": [[stitch(r) for r in poly] for poly in g["arcs"]]}
+            return None
+
+        features = []
+        for obj in topo.get("objects", {}).values():
+            geometries = obj.get("geometries", [obj]) if obj.get("type") == "GeometryCollection" else [obj]
+            for g in geometries:
+                features.append({
+                    "type": "Feature",
+                    "geometry": to_geometry(g),
+                    "properties": g.get("properties", {}) or {},
+                    **({"id": g["id"]} if "id" in g else {}),
+                })
+        return {"type": "FeatureCollection", "features": features}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_topojson_read_decodes_line -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers_geo.py tests/test_handlers_geo.py
+git commit -m "feat: TopoJSON decode (topology -> features)"
+```
+
+---
+
+### Task 7: TopoJSON write (encode via `topojson`)
+
+**Files:**
+- Modify: `src/sunstone/handlers_geo.py` (`_geodataframe_to_topojson`)
+- Test: `tests/test_handlers_geo.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_topojson_write_roundtrip(tmp_path):
+    import io, json
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    h = GeoFeaturesFormatHandler()
+    src = io.BytesIO(json.dumps(_fc()).encode("utf-8"))
+    asset = h.read(src, format="geojson", path="x.geojson")
+    asset.metadata.slug = "pts"; asset.metadata.name = "Points"
+
+    out = io.BytesIO()
+    h.write(asset, out, format="topojson", path="x.topojson")
+    doc = json.loads(out.getvalue().decode("utf-8"))
+    assert doc["type"] == "Topology"
+    assert "sunstone" in doc
+
+    back = h.read(io.BytesIO(out.getvalue()), format="topojson", path="x.topojson")
+    assert back.payload.geometry.iloc[0].x == 10.0
+    assert back.metadata.slug == "pts"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_topojson_write_roundtrip -v --no-cov`
+Expected: FAIL — `NotImplementedError`
+
+- [ ] **Step 3: Implement the encoder**
+
+Replace the `_geodataframe_to_topojson` stub:
+
+```python
+    def _geodataframe_to_topojson(self, gdf: "Any") -> dict:
+        import topojson
+
+        topo = topojson.Topology(gdf, prequantize=False)
+        # topojson returns a JSON string; parse to a dict so we can attach metadata.
+        return json.loads(topo.to_json())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_topojson_write_roundtrip -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/handlers_geo.py tests/test_handlers_geo.py
+git commit -m "feat: TopoJSON encode (features -> topology)"
+```
+
+---
+
+### Task 8: Register the handler conditionally + missing-extra error
+
+**Files:**
+- Modify: `src/sunstone/plugins.py` (`_register_builtins`, ~lines 326-337)
+- Test: `tests/test_plugins.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_geo_handler_registered_when_geopandas_present():
+    import pytest
+    pytest.importorskip("geopandas")
+    from sunstone.plugins import PluginRegistry
+
+    reg = PluginRegistry()
+    h = reg.find_format_reader("x.geojson", None)
+    assert h is not None and type(h).__name__ == "GeoFeaturesFormatHandler"
+    # geometry field type came along with the handler registration
+    assert reg.field_types.get("geometry") is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_plugins.py::test_geo_handler_registered_when_geopandas_present -v --no-cov`
+Expected: FAIL — no handler claims `.geojson`.
+
+- [ ] **Step 3: Register conditionally**
+
+In `src/sunstone/plugins.py` `_register_builtins`, next to the `NpzFormatHandler` block (before `BuiltinFormatHandler` is appended), add:
+
+```python
+        try:
+            import geopandas  # noqa: F401
+            from .handlers_geo import GeoFeaturesFormatHandler
+
+            geo_handler = GeoFeaturesFormatHandler()
+            self._format_handlers.append(geo_handler)  # type: ignore[arg-type]
+            for descriptor in geo_handler.field_types():
+                self.field_types.register(descriptor)
+        except ImportError:
+            pass  # [geo] extra not installed
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_plugins.py::test_geo_handler_registered_when_geopandas_present -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/plugins.py tests/test_plugins.py
+git commit -m "feat: register geo handler + geometry field type when [geo] present"
+```
+
+---
+
+### Task 9: `sunstone.geopandas` facade + `GeoDataFrame` wrapper
+
+**Files:**
+- Create: `src/sunstone/geopandas.py`
+- Test: `tests/test_geopandas.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+pytest.importorskip("geopandas")
+
+
+def test_facade_read_geojson_and_lineage(tmp_path):
+    import json
+    from sunstone import geopandas as gpd
+    import sunstone
+
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n  - name: Pts\n    slug: pts\n    location: pts.geojson\n    format: geojson\n"
+    )
+    (tmp_path / "pts.geojson").write_text(json.dumps({
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature",
+                      "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+                      "properties": {"name": "A"}}],
+    }))
+
+    sunstone.set_project_path(tmp_path)
+    gdf = gpd.read_geojson("pts")
+    assert gdf.data.geometry.iloc[0].x == 1.0
+    assert gdf.metadata.slug == "pts"
+
+
+def test_to_geojson_requires_slug_and_name(tmp_path):
+    import json
+    from sunstone import geopandas as gpd
+    import sunstone
+
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n  - name: Pts\n    slug: pts\n    location: pts.geojson\n    format: geojson\n"
+    )
+    (tmp_path / "pts.geojson").write_text(json.dumps({
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature",
+                      "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+                      "properties": {}}],
+    }))
+    sunstone.set_project_path(tmp_path)
+    gdf = gpd.read_geojson("pts")
+    with pytest.raises(ValueError):
+        gdf.to_geojson(str(tmp_path / "out.geojson"))   # no slug/name for a new output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_geopandas.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'sunstone.geopandas'`
+
+- [ ] **Step 3: Implement the wrapper + facade**
+
+Create `src/sunstone/geopandas.py`:
+
+```python
+"""Lineage-tracking geopandas facade. Requires the [geo] extra.
+
+Mirrors `sunstone.pandas`: read functions resolve a slug/path against the
+project's datasets.yaml and return a `GeoDataFrame` wrapper backed by an
+Asset(kind=GEOFEATURES).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .asset import Asset, AssetKind
+from .context import get_project_path
+from .datasets import DatasetsManager
+from .errors import DatasetNotFoundError
+from .lineage import Metadata
+from .plugins import PluginRegistry
+
+
+class GeoDataFrame:
+    """Wraps a geopandas.GeoDataFrame with sunstone metadata + lineage."""
+
+    def __init__(self, asset: Asset) -> None:
+        if asset.kind is not AssetKind.GEOFEATURES:
+            raise ValueError("GeoDataFrame must wrap a GEOFEATURES asset")
+        self._asset = asset
+
+    @property
+    def asset(self) -> Asset:
+        return self._asset
+
+    @property
+    def data(self) -> Any:
+        return self._asset.payload
+
+    @property
+    def metadata(self) -> Metadata:
+        return self._asset.metadata
+
+    def to_geojson(self, path: str | Path, *, slug: str | None = None, name: str | None = None) -> None:
+        self._write(path, "geojson", slug, name)
+
+    def to_topojson(self, path: str | Path, *, slug: str | None = None, name: str | None = None) -> None:
+        self._write(path, "topojson", slug, name)
+
+    def _write(self, path: str | Path, fmt: str, slug: str | None, name: str | None) -> None:
+        if slug is not None:
+            self._asset.metadata.slug = slug
+        if name is not None:
+            self._asset.metadata.name = name
+        if not self._asset.metadata.slug or not self._asset.metadata.name:
+            raise ValueError("Writing a new geo output requires both slug and name.")
+        registry = PluginRegistry.get(get_project_path())
+        handler = registry.find_format_writer(str(path), fmt)
+        if handler is None:
+            raise ValueError(f"No format handler for {fmt!r} (install sunstone-py[geo]).")
+        url_handler = registry.find_url_handler(str(path))
+        with url_handler.open(str(path), "wb") as stream:
+            handler.write(self._asset, stream, format=fmt, path=str(path))
+
+
+def _read(slug_or_path: str, fmt: str, project_path: str | Path | None) -> GeoDataFrame:
+    project = Path(project_path) if project_path is not None else get_project_path()
+    manager = DatasetsManager(project)
+    dataset = manager.find_dataset_by_slug(slug_or_path)
+    if dataset is None:
+        raise DatasetNotFoundError(
+            f"Dataset '{slug_or_path}' not found in datasets.yaml."
+        )
+    location = str(manager.get_absolute_path(dataset.location))
+    registry = PluginRegistry.get(manager.project_path)
+    handler = registry.find_format_reader(location, fmt)
+    if handler is None:
+        raise ValueError(f"No format handler for {fmt!r} (install sunstone-py[geo]).")
+    url_handler = registry.find_url_handler(location)
+    with url_handler.open(location, "rb") as stream:
+        asset = handler.read(stream, format=fmt, path=location)
+    if not asset.metadata.slug:
+        asset.metadata.slug = dataset.slug
+        asset.metadata.name = dataset.name
+    return GeoDataFrame(asset)
+
+
+def read_geojson(slug_or_path: str, project_path: str | Path | None = None) -> GeoDataFrame:
+    return _read(slug_or_path, "geojson", project_path)
+
+
+def read_topojson(slug_or_path: str, project_path: str | Path | None = None) -> GeoDataFrame:
+    return _read(slug_or_path, "topojson", project_path)
+
+
+def read_file(slug_or_path: str, project_path: str | Path | None = None) -> GeoDataFrame:
+    """Auto-detect geojson vs topojson from the dataset's format/extension."""
+    project = Path(project_path) if project_path is not None else get_project_path()
+    manager = DatasetsManager(project)
+    dataset = manager.find_dataset_by_slug(slug_or_path)
+    fmt = (dataset.format if dataset and dataset.format else None)
+    if fmt is None and dataset is not None and dataset.location.endswith(".topojson"):
+        fmt = "topojson"
+    return _read(slug_or_path, fmt or "geojson", project_path)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_geopandas.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sunstone/geopandas.py tests/test_geopandas.py
+git commit -m "feat: sunstone.geopandas facade + GeoDataFrame wrapper"
+```
+
+---
+
+### Task 10: End-to-end round-trip + missing-extra message + CHANGELOG
+
+**Files:**
+- Test: `tests/test_handlers_geo.py`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Write the missing-extra message test (runs without the extra)**
+
+```python
+def test_missing_geo_extra_message(monkeypatch):
+    import io, builtins, pytest
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "geopandas":
+            raise ImportError("no geopandas")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match=r"sunstone-py\[geo\]"):
+        GeoFeaturesFormatHandler().read(io.BytesIO(b"{}"), format="geojson", path="x.geojson")
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run pytest tests/test_handlers_geo.py::test_missing_geo_extra_message -v --no-cov`
+Expected: PASS (the `_require_geo()` guard fires)
+
+- [ ] **Step 3: Run the full geo + plugin + dataframe suites with the extra**
+
+Run: `uv run pytest tests/test_handlers_geo.py tests/test_geopandas.py tests/test_plugins.py tests/test_dataframe.py --no-cov`
+Expected: PASS
+
+- [ ] **Step 4: Add CHANGELOG entry**
+
+Under `[Unreleased]` in `CHANGELOG.md`:
+
+```
+- Added: GeoJSON and TopoJSON read/write via the optional [geo] extra.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_handlers_geo.py CHANGELOG.md
+git commit -m "test: geo end-to-end + missing-extra; changelog"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: D1 (GEOFEATURES + accessor) → Task 1; D8 extra → Task 2; D5 handler/conformance → Tasks 3–7; D6 metadata embed → Tasks 5,7; D3 geometry field type → Tasks 3,8; D7 facade/wrapper → Task 9; resolution + missing-extra → Tasks 8,10.
+- Open question O1 resolved in this plan as **hand-rolled decode** (Task 6, per `docs/references/topojson.md`) — no decode-only dependency. If `pyogrio`'s GDAL build exposes a TopoJSON driver, an implementer may substitute it in `_topojson_to_featurecollection` without changing the public surface.
+- Names are consistent: `GeoFeaturesFormatHandler`, `as_geofeatures()`, `AssetKind.GEOFEATURES`, `field_types()`, `read_geojson/read_topojson/read_file`, `to_geojson/to_topojson`.
+- Deferred to a follow-up (noted, not silently dropped): primary-geometry-column selection for *multiple* geometry columns (spec D3) — the handler currently relies on geopandas' single active geometry column; multi-geometry support can layer on without changing the kind or facade.
+- The derive policy for GEOFEATURES (CRS invalidation on geometry-dropping derivations) is not required for read/write round-trips and is omitted here; add it when GeoDataFrame derivations are exercised, registering into `KIND_DERIVE_POLICIES` from the geo module to keep geopandas out of core.

--- a/docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md
+++ b/docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md
@@ -1,0 +1,161 @@
+# GeoJSON and TopoJSON Vector Support
+
+**Date:** 2026-06-16
+**Status:** Proposed
+**Related:** `2026-05-12-generic-format-handler-asset-envelope-design.md` (Asset envelope), `2026-05-27-asset-kind-blob-and-content-type-discovery-design.md` (adding a new `AssetKind`, optional-dep handler pattern), `2026-04-07-dataframe-metadata-design.md` (Metadata model), `2026-04-23-parquet-metadata-design.md` (embedded-metadata precedent).
+
+## Problem
+
+sunstone-py has no geospatial vector support. The `.json` extension currently maps to pandas `read_json` in `BuiltinFormatHandler`, so a GeoJSON file — which *is* `.json` — gets silently slurped and mangled into a nonsense tabular frame. That is worse than not supporting it: it *pretends* to. There is no `geopandas`/`shapely` anywhere, no `AssetKind` for vector geometry, and no user-facing API for geometry data.
+
+We need first-class read/write of **GeoJSON** and **TopoJSON**, returning a real `geopandas.GeoDataFrame` with geometry, CRS, and lineage tracking, so data scientists can consume basemaps and feature collections through the same metadata/lineage story as tabular data.
+
+## Goals
+
+- Add a `VECTOR` `AssetKind` whose payload is a `geopandas.GeoDataFrame`.
+- Built-in handler reading and writing **GeoJSON** (full round-trip) and **TopoJSON** (full round-trip, including topology computation on write).
+- A `sunstone.geopandas` facade plus a lineage-tracking `GeoDataFrame` wrapper, parallel to the existing `sunstone.pandas` / `DataFrame`.
+- Round-trip the sunstone `Metadata` as a top-level `"sunstone"` foreign member in the JSON, giving lineage parity with the Parquet handler.
+- All geo dependencies behind an optional `[geo]` extra; core install and existence checks stay free of `geopandas`.
+
+## Non-Goals
+
+- Raster/coverage formats (GeoTIFF, COG) — those are `AssetKind.RASTER`, a separate concern.
+- Shapefile, GeoPackage, FlatGeobuf, KML, or other OGR vector formats. GeoJSON/TopoJSON only for now; the handler is structured so adding OGR-driver formats later is incremental.
+- Reprojection / CRS transformation helpers. We preserve the file's CRS (defaulting to WGS84 per RFC 7946) and expose it; transformation is the user's call via geopandas.
+- Content-sniffing. Detection stays extension-based plus explicit `format=`, as everywhere else.
+
+## Design Decisions
+
+### D1. Add `AssetKind.VECTOR`
+
+Extend the closed enum in `sunstone.asset.AssetKind`:
+
+```python
+class AssetKind(Enum):
+    TABULAR = "tabular"
+    RASTER  = "raster"
+    ARRAY   = "array"
+    TILES   = "tiles"
+    BLOB    = "blob"
+    VECTOR  = "vector"   # NEW — geopandas.GeoDataFrame payload
+```
+
+Semantics:
+
+- `Asset(kind=VECTOR).payload` is a `geopandas.GeoDataFrame`.
+- CRS lives in `extras["crs"]`; the existing `Asset.crs` property already reads it. (The GeoDataFrame also carries `.crs` natively; `extras["crs"]` is the envelope-level mirror, consistent with how RASTER keeps its `profile`.)
+- New typed accessor mirroring the others:
+
+```python
+def as_vector(self) -> "geopandas.GeoDataFrame":
+    if self.kind is not AssetKind.VECTOR:
+        raise IncompatibleAssetKindError(expected=AssetKind.VECTOR, actual=self.kind)
+    return cast("geopandas.GeoDataFrame", self.payload)
+```
+
+- `derive()`: add a VECTOR entry to `derive_policies.apply_kind_derive_policy`. A derivation that keeps the geometry column keeps `extras["crs"]`; a derivation whose result is non-geometry (geopandas op that drops geometry) clears it — same shape as the RASTER profile-invalidation policy. The `as_vector()` import of `geopandas` is lazy (inside the method / `TYPE_CHECKING`), so importing `sunstone.asset` never drags geopandas in.
+
+### D2. `VectorFormatHandler` in a new `handlers_geo.py`
+
+A new module keeps the `geopandas`/`shapely`/`topojson` imports out of the always-loaded `handlers.py`, exactly as `handlers_gcs.py`, `handlers_s3.py`, `handlers_npz.py`, and `handlers_hdf5.py` isolate their optional deps.
+
+```python
+class VectorFormatHandler:
+    __sunstone_handler_protocol__ = 2  # produces/consumes Asset
+
+    # extension -> format string
+    _EXTENSION_MAP = {".geojson": "geojson", ".topojson": "topojson"}
+    _FORMATS = frozenset({"geojson", "topojson"})
+```
+
+- `supported_kinds() -> (AssetKind.VECTOR,)`.
+- `can_read` / `can_write` resolve by extension or explicit `format=` **only** — no `geopandas` import (mirrors the module-level `_READER_FORMATS` trick in `BuiltinFormatHandler` so existence checks stay cheap and dependency-free).
+- `supports_sunstone_metadata_embedding() -> True` (see D5); `supports_native_metadata_extraction() -> False`.
+- All `geopandas` / `shapely` / `topojson` imports are **lazy, inside `read`/`write`**, with an `ImportError` re-raised as a clear message pointing at `pip install sunstone-py[geo]` — exactly how `ParquetFormatHandler` defers `pyarrow`.
+
+**Read path** (both formats, stream in):
+
+1. Read the full stream, `json.loads` it.
+2. Pop the top-level `"sunstone"` foreign member, if present (D5), into a `Metadata` via `Metadata.from_jsonld`.
+3. For `geojson`: build the `GeoDataFrame` from the remaining FeatureCollection (`geopandas.GeoDataFrame.from_features`, attaching CRS — default `EPSG:4326` per RFC 7946 when the file omits one).
+4. For `topojson`: decode topology → GeoJSON FeatureCollection (arc-stitching) for each named object, then as step 3. **Decode library TBD — see Open Question O1.**
+5. Return `Asset(payload=gdf, kind=VECTOR, metadata=meta, extras={"crs": gdf.crs})`.
+
+**Write path** (Asset/GeoDataFrame in, stream out):
+
+1. `geojson`: `gdf.to_json()` → JSON string → `json.loads` to a dict. (Use `to_json()` rather than `to_file()` — it is stream-friendly and avoids a temp path.)
+2. `topojson`: `topojson.Topology(gdf).to_json()` → dict. Topology is computed here (shared-arc deduplication) — the whole point of TopoJSON.
+3. Inject the sunstone `Metadata` as the top-level `"sunstone"` member (D5).
+4. `json.dumps` to the stream.
+
+### D3. Registration in `PluginRegistry`
+
+Register inside the existing `_register_builtins` flow, **before** `BuiltinFormatHandler`, using the optional-dep try/except pattern already used for `NpzFormatHandler`:
+
+```python
+try:
+    from .handlers_geo import VectorFormatHandler
+    self._format_handlers.append(VectorFormatHandler())  # type: ignore[arg-type]
+except ImportError:
+    pass  # [geo] extra not installed
+```
+
+`.geojson`/`.topojson` are distinct extensions that no other built-in claims, and plain `.json` stays with `BuiltinFormatHandler`, so ordering never conflicts on extension. When the `[geo]` extra is absent, `.geojson`/`.topojson` fall through to `BlobFormatHandler`'s residual handling rather than the tabular mis-parse — an acceptable degraded mode (raw bytes + lineage, no geometry).
+
+### D4. Plain `.json` is NOT auto-detected as geo
+
+`.geojson` → `geojson`, `.topojson` → `topojson` by extension. A plain `.json` file stays tabular (`BuiltinFormatHandler`'s `read_json`). To read a `.json` file as vector data, the caller passes `format="geojson"`. This follows the established `.txt`/`.xls` precedent (extensions deliberately not auto-claimed to avoid ambiguity). Documented in the facade docstrings.
+
+### D5. Embed `Metadata` as a top-level `"sunstone"` foreign member
+
+On write, the sunstone `Metadata` is serialized via `Metadata.to_jsonld()` and attached as a single top-level member named `"sunstone"`; on read it is popped and parsed back. This gives GeoJSON/TopoJSON the same embedded-lineage round-trip the Parquet handler provides.
+
+This is safe and was verified against primary sources:
+
+- **RFC 7946 §6.1** explicitly permits foreign members: *"Members not described in this specification ('foreign members') MAY be used in a GeoJSON document."*
+- **GDAL/OGR** (QGIS, geopandas via pyogrio/fiona) *preserves* foreign members by default (NATIVE_DATA round-trip).
+- **Leaflet** and **OpenLayers** ignore unknown top-level members (verified against Leaflet source — no whitelist, no throw, no warn).
+- The member name avoids the two reserved names RFC 7946 forbids at the `FeatureCollection` level (`geometry`, `properties`). `"sunstone"` is safe.
+
+`datasets.yaml` remains the authoritative metadata store. Embedding is belt-and-suspenders: the asymmetric round-trip (JS tools drop the member on re-export; GDAL keeps it) costs us nothing because `datasets.yaml` is the source of truth.
+
+### D6. `sunstone.geopandas` facade and `GeoDataFrame` wrapper
+
+A new module `sunstone/geopandas.py` plus a lineage-tracking `GeoDataFrame` wrapper (new `sunstone/dataframe_geo.py`), parallel to `sunstone.pandas` / `sunstone.dataframe.DataFrame`.
+
+- Usage: `from sunstone import geopandas as gpd`, then `gpd.read_file('x.geojson')` (auto-detect by extension), plus explicit `gpd.read_geojson(...)` / `gpd.read_topojson(...)`. Same project-path resolution (`set_project_path` / `use_project_path` / `project_path=`) and `datasets.yaml` registration as the `pandas` facade.
+- `sunstone.geopandas.GeoDataFrame` wraps an `Asset(kind=VECTOR, payload=geopandas.GeoDataFrame)`. `.data` → the `GeoDataFrame`, `.metadata` → the unified `Metadata`, `.asset` → the envelope; lineage flows through operations, mirroring the tabular wrapper.
+- Writers `gdf.to_geojson(...)` / `gdf.to_topojson(...)` require `slug` + `name` for new outputs (settable via `metadata.slug`/`metadata.name` or passed as params), identical to `to_csv`.
+- The TABULAR-only guard in `DataFrame.read_dataset` (`dataframe.py:454`) is left untouched; the geo wrapper has its own VECTOR-accepting read path. The two wrappers share the `Metadata`/lineage machinery but enforce their own kinds. This keeps the tabular facade's invariant (`as_table()` always valid) intact.
+
+### D7. `[geo]` optional extra
+
+In `pyproject.toml`:
+
+```toml
+[project.optional-dependencies]
+geo = ["geopandas", "shapely", "pyogrio", "topojson"]
+```
+
+Strictly optional, never a base dependency (per the project's dependency-hygiene preference). `pyogrio` is geopandas's fast IO engine; `topojson` provides TopoJSON encoding. The exact TopoJSON *decode* dependency is Open Question O1.
+
+## Open Questions
+
+- **O1. TopoJSON decode library.** `topojson` (mattijn/topojson) cleanly covers *encoding* (GeoDataFrame → TopoJSON). The decode direction (TopoJSON → features/GeoDataFrame) needs a verified library or a small hand-rolled arc-stitcher. To be resolved at plan time before committing to the `[geo]` extra's exact contents — do not guess. Candidates to evaluate: a dedicated decoder package vs. ~100 lines of arc-stitching against the TopoJSON 1.0 spec.
+
+## Testing
+
+TDD throughout. Geo-dependent tests skip when the `[geo]` extra is not installed (`pytest.importorskip("geopandas")`).
+
+- `tests/test_handlers_geo.py`: GeoJSON round-trip (geometry + CRS preserved); TopoJSON round-trip (topology computed on write, geometry recovered on read); `"sunstone"` foreign-member metadata round-trip; `.json` is NOT claimed by the vector handler; explicit `format="geojson"` on a `.json` path works; missing-`[geo]` `ImportError` message names the extra.
+- `tests/test_geopandas.py`: `read_file` / `read_geojson` / `read_topojson` via the facade; project-path resolution; `datasets.yaml` registration; lineage flow through an operation; `to_geojson`/`to_topojson` require `slug`+`name`.
+- `tests/test_asset` (existing): `as_vector()` accessor and `IncompatibleAssetKindError` on mismatch; VECTOR `derive` policy (CRS kept vs. cleared).
+
+## CHANGELOG
+
+One line under `[Unreleased]`:
+
+```
+- Added: GeoJSON and TopoJSON read/write via the optional [geo] extra.
+```

--- a/docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md
+++ b/docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md
@@ -1,161 +1,189 @@
-# GeoJSON and TopoJSON Vector Support
+# GeoJSON/TopoJSON Vector Support + Plugin-Extensible Kinds
 
 **Date:** 2026-06-16
 **Status:** Proposed
-**Related:** `2026-05-12-generic-format-handler-asset-envelope-design.md` (Asset envelope), `2026-05-27-asset-kind-blob-and-content-type-discovery-design.md` (adding a new `AssetKind`, optional-dep handler pattern), `2026-04-07-dataframe-metadata-design.md` (Metadata model), `2026-04-23-parquet-metadata-design.md` (embedded-metadata precedent).
+**Related:** `2026-05-12-generic-format-handler-asset-envelope-design.md` (Asset envelope, closed-enum decision this spec revises), `2026-05-27-asset-kind-blob-and-content-type-discovery-design.md` (adding a kind, optional-dep handler pattern, content-type discovery), `2026-04-07-dataframe-metadata-design.md` (Metadata model), `2026-04-23-parquet-metadata-design.md` (embedded-metadata precedent).
 
 ## Problem
 
-sunstone-py has no geospatial vector support. The `.json` extension currently maps to pandas `read_json` in `BuiltinFormatHandler`, so a GeoJSON file — which *is* `.json` — gets silently slurped and mangled into a nonsense tabular frame. That is worse than not supporting it: it *pretends* to. There is no `geopandas`/`shapely` anywhere, no `AssetKind` for vector geometry, and no user-facing API for geometry data.
+sunstone-py has no geospatial vector support. The `.json` extension maps to pandas `read_json` in `BuiltinFormatHandler`, so a GeoJSON file — which *is* `.json` — gets silently slurped and mangled into a nonsense tabular frame. There is no `geopandas`/`shapely` anywhere, no kind for vector geometry, and no user-facing API for geometry data.
 
-We need first-class read/write of **GeoJSON** and **TopoJSON**, returning a real `geopandas.GeoDataFrame` with geometry, CRS, and lineage tracking, so data scientists can consume basemaps and feature collections through the same metadata/lineage story as tabular data.
+Three deeper issues surfaced while scoping this:
+
+1. **No way to pin a dataset's shape or format.** `read_dataset` resolves a handler purely as explicit `format=` argument → else file-extension detection (`dataframe.py:426`). `datasets.yaml` has a `type` field (`DatasetMetadata.resource_type`), but it is only a CLI validation hint (`type: table` ⇒ fields required) and is **never consulted for handler resolution**. So a registered `.geojson` with the `[geo]` extra absent silently falls back to `BlobFormatHandler`. That silent wrong-shape handling is the bug to kill.
+
+2. **Shape and serialization are independent axes, and neither determines the other.** Many formats share one shape (CSV/JSON/Excel/TSV/Parquet all → tabular; GeoJSON/TopoJSON/Geobuf all → vector). And one format spans many shapes (JSON is table *or* tree *or* GeoJSON). This is exactly the Frictionless model the repo already follows — `type` (resource kind), `format` (serialization), `mediatype` (IANA MIME) as separate fields. We should mirror it.
+
+3. **Kinds are a closed enum, requiring core changes to extend.** `AssetKind` is a closed `Enum` whose docstring says new kinds "require extending upstream." But an audit shows **nothing relies on enum exhaustiveness**: there is no `match`/`case` on `AssetKind` anywhere. Every consumer is an identity check (`if kind is not X: raise`), a dict-dispatch-with-default (`KIND_DERIVE_POLICIES.get(kind, no_op_policy)` — already a registry), or a per-handler `supported_kinds()` tuple. The only things forcing a core edit are the closed `Enum` itself and the typed accessors. Opening this up is therefore cheap, and lets an optional extra like `[geo]` contribute *both* a kind and its handlers without touching core.
 
 ## Goals
 
-- Add a `VECTOR` `AssetKind` whose payload is a `geopandas.GeoDataFrame`.
-- Built-in handler reading and writing **GeoJSON** (full round-trip) and **TopoJSON** (full round-trip, including topology computation on write).
-- A `sunstone.geopandas` facade plus a lineage-tracking `GeoDataFrame` wrapper, parallel to the existing `sunstone.pandas` / `DataFrame`.
-- Round-trip the sunstone `Metadata` as a top-level `"sunstone"` foreign member in the JSON, giving lineage parity with the Parquet handler.
-- All geo dependencies behind an optional `[geo]` extra; core install and existence checks stay free of `geopandas`.
+- **Plugin-extensible kinds.** A `KindRegistry` lets internal optional modules (and future external plugins) register a new kind (shape) — name, payload contract, derive policy — without modifying core. Built-in kinds are pre-registered; behavior is unchanged for existing kinds.
+- **Geo as a self-contained plugin.** The `[geo]` extra contributes the `vector` kind, GeoJSON/TopoJSON handlers (full round-trip both ways, incl. topology computation on TopoJSON write), and a lineage-tracking `GeoDataFrame` wrapper + `sunstone.geopandas` facade — all gated by the extra. No core file references geopandas, even under `TYPE_CHECKING`.
+- **Pinnable, load-bearing `type` + `format` in `datasets.yaml`**, Frictionless-aligned, so handler resolution can refuse a wrong-shape handler instead of silently falling back to blob.
+- **Embedded lineage** via a top-level `"sunstone"` foreign member, giving GeoJSON/TopoJSON metadata round-trip parity with Parquet.
 
 ## Non-Goals
 
-- Raster/coverage formats (GeoTIFF, COG) — those are `AssetKind.RASTER`, a separate concern.
-- Shapefile, GeoPackage, FlatGeobuf, KML, or other OGR vector formats. GeoJSON/TopoJSON only for now; the handler is structured so adding OGR-driver formats later is incremental.
-- Reprojection / CRS transformation helpers. We preserve the file's CRS (defaulting to WGS84 per RFC 7946) and expose it; transformation is the user's call via geopandas.
-- Content-sniffing. Detection stays extension-based plus explicit `format=`, as everywhere else.
+- Raster/coverage formats (GeoTIFF, COG) — `AssetKind.RASTER`, separate.
+- Vector formats beyond GeoJSON/TopoJSON (Shapefile, GeoPackage, FlatGeobuf, Geobuf, KML). The plugin is structured so adding them later is incremental — they register against the same `vector` kind.
+- Reprojection/CRS transformation helpers. We preserve the file's CRS (default WGS84 per RFC 7946) and expose it; transformation is the user's call via geopandas.
+- A general-purpose external-plugin *packaging* guide. We expose the registration mechanism and use it internally for geo; documenting third-party plugin distribution is a follow-up.
+- Content-sniffing. Detection stays extension + explicit `format=` + pinned `datasets.yaml`, as everywhere else.
 
 ## Design Decisions
 
-### D1. Add `AssetKind.VECTOR`
+### Phase 1 — Open the kind system (core, behavior-preserving)
 
-Extend the closed enum in `sunstone.asset.AssetKind`:
+#### D1. `AssetKind` becomes a `StrEnum`; `Asset.kind` becomes `str`
 
-```python
-class AssetKind(Enum):
-    TABULAR = "tabular"
-    RASTER  = "raster"
-    ARRAY   = "array"
-    TILES   = "tiles"
-    BLOB    = "blob"
-    VECTOR  = "vector"   # NEW — geopandas.GeoDataFrame payload
-```
+`AssetKind` is changed from `Enum` to `StrEnum`, so members are named string constants (`AssetKind.VECTOR == "vector"`) and arbitrary registered kind names are representable as plain strings. `Asset.kind` is typed `str`.
 
-Semantics:
+The ~10 identity checks (`if self.kind is not AssetKind.TABULAR`) migrate from `is`/`is not` to `==`/`!=` (StrEnum members are not identical objects to bare string literals). This is mechanical and fully covered by existing tests. Built-in kind names are unchanged on the wire: `tabular`, `raster`, `array`, `tiles`, `blob`.
 
-- `Asset(kind=VECTOR).payload` is a `geopandas.GeoDataFrame`.
-- CRS lives in `extras["crs"]`; the existing `Asset.crs` property already reads it. (The GeoDataFrame also carries `.crs` natively; `extras["crs"]` is the envelope-level mirror, consistent with how RASTER keeps its `profile`.)
-- New typed accessor mirroring the others:
+#### D2. `KindRegistry` and `KindDescriptor`
+
+A registry parallel to the format-handler registry. A `KindDescriptor` carries:
 
 ```python
-def as_vector(self) -> "geopandas.GeoDataFrame":
-    if self.kind is not AssetKind.VECTOR:
-        raise IncompatibleAssetKindError(expected=AssetKind.VECTOR, actual=self.kind)
-    return cast("geopandas.GeoDataFrame", self.payload)
+@dataclass(frozen=True)
+class KindDescriptor:
+    name: str                                   # e.g. "vector"
+    payload_contract: Callable[[Any], bool] | None = None   # validate payload (duck-typed; no hard dep)
+    derive_policy: KindDerivePolicy | None = None
+    description: str | None = None
 ```
 
-- `derive()`: add a VECTOR entry to `derive_policies.apply_kind_derive_policy`. A derivation that keeps the geometry column keeps `extras["crs"]`; a derivation whose result is non-geometry (geopandas op that drops geometry) clears it — same shape as the RASTER profile-invalidation policy. The `as_vector()` import of `geopandas` is lazy (inside the method / `TYPE_CHECKING`), so importing `sunstone.asset` never drags geopandas in.
+- Built-in kinds (`tabular`, `raster`, `array`, `tiles`, `blob`) are pre-registered in core with their existing semantics.
+- The registry is **plugin-facing**: a registered plugin MAY expose `kind_descriptors() -> tuple[KindDescriptor, ...]`, classified during `PluginRegistry._register` alongside `AuthProvider`/`FormatHandler`/`StoreFormatHandler`. This is how a future *external* plugin adds a kind.
+- Internal optional modules register via the existing conditional-import path (the `NpzFormatHandler` pattern): when the extra is importable, register its `KindDescriptor` and handlers; otherwise skip.
 
-### D2. `VectorFormatHandler` in a new `handlers_geo.py`
+#### D3. Derive policies keyed by kind name
 
-A new module keeps the `geopandas`/`shapely`/`topojson` imports out of the always-loaded `handlers.py`, exactly as `handlers_gcs.py`, `handlers_s3.py`, `handlers_npz.py`, and `handlers_hdf5.py` isolate their optional deps.
+`KIND_DERIVE_POLICIES` is re-keyed from `AssetKind` to `str` (no semantic change — it is already a dict with a `no_op_policy` default). A `KindDescriptor.derive_policy` is registered into this dict at kind-registration time. The RASTER policy is unchanged.
+
+#### D4. Accessors: typed built-ins + generic extension accessor
+
+The built-in typed accessors (`as_table`, `as_raster`, `as_array`, `as_tiles`, `as_blob`) stay in core for the common, statically-typed path. Extension kinds use a generic accessor:
+
+```python
+def require_kind(self, name: str) -> Any:
+    if self.kind != name:
+        raise IncompatibleAssetKindError(expected=name, actual=self.kind)
+    return self.payload
+```
+
+`IncompatibleAssetKindError` is generalized to accept string kind names (it already stores `expected`/`actual`). A plugin that wants a typed accessor for its kind (geo does) provides it on its own wrapper, not on core `Asset`. **Core never imports geopandas**, so there is no core `as_vector()` returning a `GeoDataFrame`; the typed surface lives on the plugin's `GeoDataFrame` wrapper.
+
+### Phase 2 — Geo as a self-contained `[geo]` plugin
+
+#### D5. The `vector` kind is registered by `[geo]`, not core
+
+`vector` is a `KindDescriptor` registered only when the `[geo]` extra is present. Semantics: payload is a `geopandas.GeoDataFrame`; CRS mirrored in `extras["crs"]` (existing `Asset.crs` reads it); derive policy clears `extras["crs"]` when a derivation drops the geometry column, keeps it otherwise (same shape as the RASTER profile policy). When `[geo]` is absent, the `vector` kind is simply unregistered — and resolution (D11) turns that into a loud error rather than a blob.
+
+> Shape rigor note: `vector` is a distinct shape from `table` — a geometry-typed column plus a CRS contract that `table` does not admit — but it is table-*compatible* (rectangular, row-per-feature; `GeoDataFrame` IS-A `DataFrame`). `as_table()` on a vector is therefore an explicit, lossy downcast (geometry dropped/serialized), never an identity. A "vector" is conceptually the single geometry column + its contracts; adding non-geometry columns is the feature-collection refinement geopandas already models, not a different kind.
+
+#### D6. `VectorFormatHandler` in `handlers_geo.py`
+
+A new module (keeps geopandas/shapely/topojson out of the always-loaded `handlers.py`, exactly like `handlers_gcs.py`/`handlers_s3.py`/`handlers_npz.py`/`handlers_hdf5.py`).
 
 ```python
 class VectorFormatHandler:
-    __sunstone_handler_protocol__ = 2  # produces/consumes Asset
-
-    # extension -> format string
+    __sunstone_handler_protocol__ = 2
     _EXTENSION_MAP = {".geojson": "geojson", ".topojson": "topojson"}
     _FORMATS = frozenset({"geojson", "topojson"})
+    def supported_kinds(self): return ("vector",)
 ```
 
-- `supported_kinds() -> (AssetKind.VECTOR,)`.
-- `can_read` / `can_write` resolve by extension or explicit `format=` **only** — no `geopandas` import (mirrors the module-level `_READER_FORMATS` trick in `BuiltinFormatHandler` so existence checks stay cheap and dependency-free).
-- `supports_sunstone_metadata_embedding() -> True` (see D5); `supports_native_metadata_extraction() -> False`.
-- All `geopandas` / `shapely` / `topojson` imports are **lazy, inside `read`/`write`**, with an `ImportError` re-raised as a clear message pointing at `pip install sunstone-py[geo]` — exactly how `ParquetFormatHandler` defers `pyarrow`.
+- `can_read`/`can_write` resolve by extension or explicit `format=` **only** — no geopandas import (mirrors the module-level `_READER_FORMATS` trick), so existence checks stay dependency-free.
+- `supports_sunstone_metadata_embedding() -> True`; `supports_native_metadata_extraction() -> False`.
+- geopandas/shapely/topojson imports are **lazy inside `read`/`write`**, re-raising `ImportError` as a clear "install `sunstone-py[geo]`" message (the `ParquetFormatHandler`/pyarrow pattern).
+- **Read**: read stream → `json.loads` → pop top-level `"sunstone"` member into `Metadata` (D8) → build `GeoDataFrame` (`from_features`, default CRS `EPSG:4326` per RFC 7946 when absent). TopoJSON first decodes topology→FeatureCollection (arc-stitching) per named object. **Decode library: Open Question O1.**
+- **Write**: GeoJSON via `gdf.to_json()` → dict; TopoJSON via `topojson.Topology(gdf).to_json()` → dict (topology computed here). Inject `"sunstone"` member (D8) → `json.dumps` to stream.
 
-**Read path** (both formats, stream in):
+#### D7. Plain `.json` is NOT auto-detected as geo
 
-1. Read the full stream, `json.loads` it.
-2. Pop the top-level `"sunstone"` foreign member, if present (D5), into a `Metadata` via `Metadata.from_jsonld`.
-3. For `geojson`: build the `GeoDataFrame` from the remaining FeatureCollection (`geopandas.GeoDataFrame.from_features`, attaching CRS — default `EPSG:4326` per RFC 7946 when the file omits one).
-4. For `topojson`: decode topology → GeoJSON FeatureCollection (arc-stitching) for each named object, then as step 3. **Decode library TBD — see Open Question O1.**
-5. Return `Asset(payload=gdf, kind=VECTOR, metadata=meta, extras={"crs": gdf.crs})`.
+`.geojson` → `geojson`, `.topojson` → `topojson` by extension; plain `.json` stays tabular. To read a `.json` file as vector, pass `format="geojson"` or pin it in `datasets.yaml`. Follows the established `.txt`/`.xls` precedent. (This is the "one format, many shapes" ambiguity made concrete — JSON alone cannot imply a shape.)
 
-**Write path** (Asset/GeoDataFrame in, stream out):
+#### D8. Embed `Metadata` as a top-level `"sunstone"` foreign member
 
-1. `geojson`: `gdf.to_json()` → JSON string → `json.loads` to a dict. (Use `to_json()` rather than `to_file()` — it is stream-friendly and avoids a temp path.)
-2. `topojson`: `topojson.Topology(gdf).to_json()` → dict. Topology is computed here (shared-arc deduplication) — the whole point of TopoJSON.
-3. Inject the sunstone `Metadata` as the top-level `"sunstone"` member (D5).
-4. `json.dumps` to the stream.
+On write, serialize `Metadata.to_jsonld()` as a single top-level member named `"sunstone"`; on read, pop and parse it. Gives lineage round-trip parity with Parquet. Verified safe against primary sources:
 
-### D3. Registration in `PluginRegistry`
-
-Register inside the existing `_register_builtins` flow, **before** `BuiltinFormatHandler`, using the optional-dep try/except pattern already used for `NpzFormatHandler`:
-
-```python
-try:
-    from .handlers_geo import VectorFormatHandler
-    self._format_handlers.append(VectorFormatHandler())  # type: ignore[arg-type]
-except ImportError:
-    pass  # [geo] extra not installed
-```
-
-`.geojson`/`.topojson` are distinct extensions that no other built-in claims, and plain `.json` stays with `BuiltinFormatHandler`, so ordering never conflicts on extension. When the `[geo]` extra is absent, `.geojson`/`.topojson` fall through to `BlobFormatHandler`'s residual handling rather than the tabular mis-parse — an acceptable degraded mode (raw bytes + lineage, no geometry).
-
-### D4. Plain `.json` is NOT auto-detected as geo
-
-`.geojson` → `geojson`, `.topojson` → `topojson` by extension. A plain `.json` file stays tabular (`BuiltinFormatHandler`'s `read_json`). To read a `.json` file as vector data, the caller passes `format="geojson"`. This follows the established `.txt`/`.xls` precedent (extensions deliberately not auto-claimed to avoid ambiguity). Documented in the facade docstrings.
-
-### D5. Embed `Metadata` as a top-level `"sunstone"` foreign member
-
-On write, the sunstone `Metadata` is serialized via `Metadata.to_jsonld()` and attached as a single top-level member named `"sunstone"`; on read it is popped and parsed back. This gives GeoJSON/TopoJSON the same embedded-lineage round-trip the Parquet handler provides.
-
-This is safe and was verified against primary sources:
-
-- **RFC 7946 §6.1** explicitly permits foreign members: *"Members not described in this specification ('foreign members') MAY be used in a GeoJSON document."*
+- **RFC 7946 §6.1**: *"Members not described in this specification ('foreign members') MAY be used in a GeoJSON document."*
 - **GDAL/OGR** (QGIS, geopandas via pyogrio/fiona) *preserves* foreign members by default (NATIVE_DATA round-trip).
 - **Leaflet** and **OpenLayers** ignore unknown top-level members (verified against Leaflet source — no whitelist, no throw, no warn).
-- The member name avoids the two reserved names RFC 7946 forbids at the `FeatureCollection` level (`geometry`, `properties`). `"sunstone"` is safe.
+- Avoids the two names RFC 7946 forbids at `FeatureCollection` level (`geometry`, `properties`). `"sunstone"` is safe.
 
-`datasets.yaml` remains the authoritative metadata store. Embedding is belt-and-suspenders: the asymmetric round-trip (JS tools drop the member on re-export; GDAL keeps it) costs us nothing because `datasets.yaml` is the source of truth.
+`datasets.yaml` remains authoritative; embedding is belt-and-suspenders. The asymmetric round-trip (JS tools drop the member on re-export, GDAL keeps it) costs nothing.
 
-### D6. `sunstone.geopandas` facade and `GeoDataFrame` wrapper
+#### D9. `sunstone.geopandas` facade + `GeoDataFrame` wrapper (in the geo plugin)
 
-A new module `sunstone/geopandas.py` plus a lineage-tracking `GeoDataFrame` wrapper (new `sunstone/dataframe_geo.py`), parallel to `sunstone.pandas` / `sunstone.dataframe.DataFrame`.
+- `from sunstone import geopandas as gpd`, then `gpd.read_file('x.geojson')` (auto-detect by extension), plus explicit `gpd.read_geojson(...)` / `gpd.read_topojson(...)`. Same project-path resolution and `datasets.yaml` registration as the `pandas` facade.
+- `GeoDataFrame` wrapper wraps `Asset(kind="vector", payload=geopandas.GeoDataFrame)`. `.data` → the GeoDataFrame, `.metadata` → unified `Metadata`, `.asset` → envelope; lineage flows through ops, parallel to the tabular `DataFrame`. This wrapper is the typed `as_vector`-equivalent surface (D4).
+- Writers `gdf.to_geojson(...)`/`gdf.to_topojson(...)` require `slug`+`name` for new outputs, like `to_csv`.
+- The TABULAR-only guard in `DataFrame.read_dataset` (`dataframe.py:454`) stays; the geo wrapper has its own vector-accepting read path. Both share `Metadata`/lineage machinery but enforce their own kinds.
 
-- Usage: `from sunstone import geopandas as gpd`, then `gpd.read_file('x.geojson')` (auto-detect by extension), plus explicit `gpd.read_geojson(...)` / `gpd.read_topojson(...)`. Same project-path resolution (`set_project_path` / `use_project_path` / `project_path=`) and `datasets.yaml` registration as the `pandas` facade.
-- `sunstone.geopandas.GeoDataFrame` wraps an `Asset(kind=VECTOR, payload=geopandas.GeoDataFrame)`. `.data` → the `GeoDataFrame`, `.metadata` → the unified `Metadata`, `.asset` → the envelope; lineage flows through operations, mirroring the tabular wrapper.
-- Writers `gdf.to_geojson(...)` / `gdf.to_topojson(...)` require `slug` + `name` for new outputs (settable via `metadata.slug`/`metadata.name` or passed as params), identical to `to_csv`.
-- The TABULAR-only guard in `DataFrame.read_dataset` (`dataframe.py:454`) is left untouched; the geo wrapper has its own VECTOR-accepting read path. The two wrappers share the `Metadata`/lineage machinery but enforce their own kinds. This keeps the tabular facade's invariant (`as_table()` always valid) intact.
+### Cross-cutting — `datasets.yaml` pinning and resolution
 
-### D7. `[geo]` optional extra
+#### D10. `type` + `format` pins in `datasets.yaml` (Frictionless-aligned)
 
-In `pyproject.toml`:
+Add a `format` field to `datasets.yaml` → `DatasetMetadata.format`. Keep `type` as the orthogonal *shape* axis and extend its vocabulary to the registered kind names (`table`, `vector`, `raster`, `array`, `tiles`, `blob`).
+
+```yaml
+inputs:
+  - slug: world-borders
+    type: vector        # shape  → kind "vector" (load-bearing; see D11)
+    format: geojson     # serialization → handler selection within the shape
+    location: inputs/world.geojson
+```
+
+CLI validation extends its existing `type`-driven rules (`type: table` ⇒ fields required) with vector expectations (geometry/CRS).
+
+#### D11. Resolution filters handlers by `supported_kinds()` — `type` is load-bearing
+
+`read_dataset` (and the geo facade read path) thread the dataset's pinned `format` into resolution as the explicit format **before** extension detection, and filter candidate handlers to those whose `supported_kinds()` includes the pinned `type` (when set). Consequences:
+
+- `type: vector` **alone** refuses `BlobFormatHandler` (`supported_kinds() == ("blob",)`) and `BuiltinFormatHandler` (`("tabular",)`) on a shape mismatch — the silent blob fallback dies even with no `format` pinned.
+- Missing `[geo]` extra ⇒ `vector` kind unregistered ⇒ no vector-capable handler ⇒ the existing loud `"No format handler found ... Install a plugin"` error, naming the `[geo]` extra. Never a blob.
+- `format: geojson` disambiguates within the vector shape (geojson vs topojson vs future geobuf).
+- Both pinned ⇒ chosen handler must satisfy both. The blob fallback is reachable **only** for a fully-unpinned dataset whose extension no specific handler claims — the intended residual behavior.
+
+#### D12. `[geo]` optional extra
 
 ```toml
 [project.optional-dependencies]
 geo = ["geopandas", "shapely", "pyogrio", "topojson"]
 ```
 
-Strictly optional, never a base dependency (per the project's dependency-hygiene preference). `pyogrio` is geopandas's fast IO engine; `topojson` provides TopoJSON encoding. The exact TopoJSON *decode* dependency is Open Question O1.
+Strictly optional, never base (dependency-hygiene preference). `pyogrio` is geopandas's fast IO engine; `topojson` provides TopoJSON encoding. TopoJSON *decode* dependency is O1.
 
 ## Open Questions
 
-- **O1. TopoJSON decode library.** `topojson` (mattijn/topojson) cleanly covers *encoding* (GeoDataFrame → TopoJSON). The decode direction (TopoJSON → features/GeoDataFrame) needs a verified library or a small hand-rolled arc-stitcher. To be resolved at plan time before committing to the `[geo]` extra's exact contents — do not guess. Candidates to evaluate: a dedicated decoder package vs. ~100 lines of arc-stitching against the TopoJSON 1.0 spec.
+- **O1. TopoJSON decode library.** `topojson` (mattijn/topojson) cleanly covers *encoding*; the decode direction (TopoJSON → GeoDataFrame) needs a verified library or a small hand-rolled arc-stitcher (~100 lines against the TopoJSON 1.0 spec). Resolve at plan time before finalizing the `[geo]` extra contents — do not guess.
+- **O2. External-plugin kind registration surface.** D2 proposes `kind_descriptors()` on plugin objects classified during `_register`. Confirm this shape vs. a dedicated entry-point group at plan time. Geo uses the internal conditional-import path regardless, so this does not block Phase 2.
+
+## Phasing
+
+Phase 1 and Phase 2 are separate implementation plans / PRs:
+
+1. **Phase 1** (core seam): D1–D4 + D10–D11's resolution mechanism, with built-in kinds registered exactly as today and the tabular/parquet/blob/array handlers declaring `supported_kinds()` (most already do). Behavior-preserving; lands on existing tests plus new registry tests. No geo dependency.
+2. **Phase 2** (geo plugin): D5–D9 + D12, gated by `[geo]`. Depends on Phase 1.
+
+This keeps the risky-looking refactor isolated and verifiable before any geopandas code lands.
 
 ## Testing
 
-TDD throughout. Geo-dependent tests skip when the `[geo]` extra is not installed (`pytest.importorskip("geopandas")`).
+TDD throughout. Geo tests skip without the extra (`pytest.importorskip("geopandas")`).
 
-- `tests/test_handlers_geo.py`: GeoJSON round-trip (geometry + CRS preserved); TopoJSON round-trip (topology computed on write, geometry recovered on read); `"sunstone"` foreign-member metadata round-trip; `.json` is NOT claimed by the vector handler; explicit `format="geojson"` on a `.json` path works; missing-`[geo]` `ImportError` message names the extra.
-- `tests/test_geopandas.py`: `read_file` / `read_geojson` / `read_topojson` via the facade; project-path resolution; `datasets.yaml` registration; lineage flow through an operation; `to_geojson`/`to_topojson` require `slug`+`name`.
-- `tests/test_asset` (existing): `as_vector()` accessor and `IncompatibleAssetKindError` on mismatch; VECTOR `derive` policy (CRS kept vs. cleared).
+- **Phase 1**: `tests/test_kind_registry.py` — register/lookup a custom kind; derive policy dispatched by name; `require_kind` + `IncompatibleAssetKindError` for string kinds; built-ins still resolve; `StrEnum` equality (`AssetKind.TABULAR == "tabular"`). Existing asset/handler/dataframe tests must stay green after the `is`→`==` migration.
+- **Resolution (D10/D11)**: `type: vector` refuses blob/tabular handlers; pinned `format` wins over extension; both-pinned requires both; unpinned `.geojson` with `[geo]` absent errors loudly (not blob); fully-unpinned unknown extension still reaches blob.
+- **Phase 2**: `tests/test_handlers_geo.py` — GeoJSON round-trip (geometry + CRS); TopoJSON round-trip (topology on write, geometry on read); `"sunstone"` foreign-member metadata round-trip; `.json` not claimed by the vector handler; explicit `format="geojson"` on a `.json` path works; missing-`[geo]` `ImportError` names the extra. `tests/test_geopandas.py` — facade reads, project-path resolution, `datasets.yaml` registration, lineage flow, `to_*` requires slug+name.
 
 ## CHANGELOG
 
-One line under `[Unreleased]`:
+Two lines under `[Unreleased]` (one per phase as they land):
 
 ```
+- Added: Plugin-extensible asset kinds via a kind registry.
 - Added: GeoJSON and TopoJSON read/write via the optional [geo] extra.
 ```

--- a/docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md
+++ b/docs/superpowers/specs/2026-06-16-geojson-topojson-vector-support-design.md
@@ -1,189 +1,50 @@
-# GeoJSON/TopoJSON Vector Support + Plugin-Extensible Kinds
+# GeoJSON/TopoJSON Support + Extensible Field Types
 
-**Date:** 2026-06-16
-**Status:** Proposed
-**Related:** `2026-05-12-generic-format-handler-asset-envelope-design.md` (Asset envelope, closed-enum decision this spec revises), `2026-05-27-asset-kind-blob-and-content-type-discovery-design.md` (adding a kind, optional-dep handler pattern, content-type discovery), `2026-04-07-dataframe-metadata-design.md` (Metadata model), `2026-04-23-parquet-metadata-design.md` (embedded-metadata precedent).
+**Date:** 2026-06-16 · **Status:** Proposed
+**Related:** `2026-06-14-field-observed-property-design.md` (field metadata — the extension point), `2026-04-23-parquet-metadata-design.md` (embedded-metadata precedent), `2026-05-27-asset-kind-blob...md` (optional-dep handler pattern).
+**Format refs:** `docs/references/geojson.md`, `docs/references/topojson.md` (normative rules).
+**Prior art:** Frictionless (`geojson`/`geopoint` *field* types), GeoParquet/GeoArrow (geometry = column metadata over an unchanged format), pandas `ExtensionDtype` / geopandas `"geometry"` dtype (CRS per column). All agree: **geometry is a field type, not a resource type.**
 
 ## Problem
 
-sunstone-py has no geospatial vector support. The `.json` extension maps to pandas `read_json` in `BuiltinFormatHandler`, so a GeoJSON file — which *is* `.json` — gets silently slurped and mangled into a nonsense tabular frame. There is no `geopandas`/`shapely` anywhere, no kind for vector geometry, and no user-facing API for geometry data.
+GeoJSON shipped as `.json` is silently mis-parsed by `read_json`. There is no geo support, and no way to mark a column as geometry. We want GeoJSON/TopoJSON read+write into a `geopandas.GeoDataFrame` with lineage, gated behind an optional `[geo]` extra.
 
-Three deeper issues surfaced while scoping this:
+## Design
 
-1. **No way to pin a dataset's shape or format.** `read_dataset` resolves a handler purely as explicit `format=` argument → else file-extension detection (`dataframe.py:426`). `datasets.yaml` has a `type` field (`DatasetMetadata.resource_type`), but it is only a CLI validation hint (`type: table` ⇒ fields required) and is **never consulted for handler resolution**. So a registered `.geojson` with the `[geo]` extra absent silently falls back to `BlobFormatHandler`. That silent wrong-shape handling is the bug to kill.
+**D1 — Geo is its own `AssetKind`: `GEOFEATURES`** (payload = `geopandas.GeoDataFrame`; accessor `as_geofeatures()`; CRS-aware derive policy). Not `TABULAR` (a GeoDataFrame isn't a plain table — `as_table()` would be gymnastics) and not `VECTOR` (overloaded by embeddings). Adding one enum member is cheap — nothing matches `AssetKind` exhaustively. Core declares the member (a bare string, no geopandas dep); `[geo]` supplies the handlers, typed wrapper, and accessor. This is the runtime payload label — **distinct from** the catalog `type` axis (D4), not a resource-catalog discriminator.
 
-2. **Shape and serialization are independent axes, and neither determines the other.** Many formats share one shape (CSV/JSON/Excel/TSV/Parquet all → tabular; GeoJSON/TopoJSON/Geobuf all → vector). And one format spans many shapes (JSON is table *or* tree *or* GeoJSON). This is exactly the Frictionless model the repo already follows — `type` (resource kind), `format` (serialization), `mediatype` (IANA MIME) as separate fields. We should mirror it.
+**D2 — Field-type registry (the extensibility seam).** Extend the field-metadata `type` axis with a registry: a plugin exposes `field_types() -> tuple[FieldTypeDescriptor, ...]` (`name`, optional `validate` hook, optional (de)serialization), classified in `PluginRegistry._register`. Built-in scalar types pre-registered. This is the pandas-`ExtensionDtype` / GeoArrow-extension-type / Frictionless-field-type pattern — `geometry` now, an embedding `vector` later. No top-level kind registry.
 
-3. **Kinds are a closed enum, requiring core changes to extend.** `AssetKind` is a closed `Enum` whose docstring says new kinds "require extending upstream." But an audit shows **nothing relies on enum exhaustiveness**: there is no `match`/`case` on `AssetKind` anywhere. Every consumer is an identity check (`if kind is not X: raise`), a dict-dispatch-with-default (`KIND_DERIVE_POLICIES.get(kind, no_op_policy)` — already a registry), or a per-handler `supported_kinds()` tuple. The only things forcing a core edit are the closed `Enum` itself and the typed accessors. Opening this up is therefore cheap, and lets an optional extra like `[geo]` contribute *both* a kind and its handlers without touching core.
+**D3 — `geometry` field type** (registered by `[geo]`): per-**column** CRS, with one designated **primary** geometry column (GeoParquet's `primary_column`); multiple geometry columns allowed. shapely (via geopandas) owns geometry validity; sunstone records the field type + CRS and validates at the boundary (mode-gated). The kind (`GEOFEATURES`, D1) says "this payload has geometry"; the field type says *which* column and its CRS. Catalog `type` stays a thin `table` (D4) — geometry is never a catalog resource-type.
 
-## Goals
+**D4 — `format` drives resolution; `type` stays thin.** Handler resolution = pinned `datasets.yaml` `format` → else file extension. `type` is optional, inferred, Frictionless-shaped (`table`), descriptive only — **not** load-bearing. Consequences: `format: geojson` on a `.json` file reads correctly (the real silent-failure fix); `.geojson`/`.topojson` auto-detect by extension; a missing `[geo]` extra → loud "install `sunstone-py[geo]`" error (no built-in claims those extensions, so never a blob fallback). Add a `format` field to `DatasetMetadata`.
 
-- **Plugin-extensible kinds.** A `KindRegistry` lets internal optional modules (and future external plugins) register a new kind (shape) — name, payload contract, derive policy — without modifying core. Built-in kinds are pre-registered; behavior is unchanged for existing kinds.
-- **Geo as a self-contained plugin.** The `[geo]` extra contributes the `vector` kind, GeoJSON/TopoJSON handlers (full round-trip both ways, incl. topology computation on TopoJSON write), and a lineage-tracking `GeoDataFrame` wrapper + `sunstone.geopandas` facade — all gated by the extra. No core file references geopandas, even under `TYPE_CHECKING`.
-- **Pinnable, load-bearing `type` + `format` in `datasets.yaml`**, Frictionless-aligned, so handler resolution can refuse a wrong-shape handler instead of silently falling back to blob.
-- **Embedded lineage** via a top-level `"sunstone"` foreign member, giving GeoJSON/TopoJSON metadata round-trip parity with Parquet.
+**D5 — `GeoFeaturesFormatHandler`** in `handlers_geo.py` (keeps geopandas out of always-loaded code, per the npz/hdf5 pattern). `can_read`/`can_write` by extension/format only (no geopandas import); geopandas/shapely/topojson imported lazily with a clear `[geo]` error. Read: `json.loads` → pop `"sunstone"` member (D6) → `GeoDataFrame` (default CRS EPSG:4326). Write: `gdf.to_json()` (GeoJSON) / `topojson.Topology(gdf).to_json()` (TopoJSON). Both formats decode to a `GEOFEATURES` payload (one kind, two serializations); TopoJSON's shared-arc **topology is recomputed on write, not preserved** through the GeoDataFrame (geopandas has no topology concept — geometrically equivalent, not arc-identical). **RFC 7946 conformance** (per `geojson.md`): never emit a `crs` member (warn if CRS≠WGS84; reprojection is out of scope); orient rings right-hand on write; preserve Feature `id` (geopandas drops it by default); accept null geometry/properties; lon-lat order (assert in tests).
 
-## Non-Goals
+**D6 — Embed metadata as a top-level `"sunstone"` foreign member** (JSON-LD), like Parquet. Safe per RFC 7946 §6.1 (foreign members allowed; ignored by Leaflet/OpenLayers, preserved by GDAL; `"sunstone"` isn't a reserved name). `datasets.yaml` stays authoritative; embedding is belt-and-suspenders.
 
-- Raster/coverage formats (GeoTIFF, COG) — `AssetKind.RASTER`, separate.
-- Vector formats beyond GeoJSON/TopoJSON (Shapefile, GeoPackage, FlatGeobuf, Geobuf, KML). The plugin is structured so adding them later is incremental — they register against the same `vector` kind.
-- Reprojection/CRS transformation helpers. We preserve the file's CRS (default WGS84 per RFC 7946) and expose it; transformation is the user's call via geopandas.
-- A general-purpose external-plugin *packaging* guide. We expose the registration mechanism and use it internally for geo; documenting third-party plugin distribution is a follow-up.
-- Content-sniffing. Detection stays extension + explicit `format=` + pinned `datasets.yaml`, as everywhere else.
+**D7 — `sunstone.geopandas` facade + `GeoDataFrame` wrapper** (in `[geo]`): `gpd.read_file()/read_geojson()/read_topojson()`, project-path resolution and `datasets.yaml` registration like the `pandas` facade. Wrapper wraps `Asset(kind=GEOFEATURES, payload=GeoDataFrame)`, knows the geometry column, flows lineage. `to_geojson()/to_topojson()` require `slug`+`name`. Core never imports geopandas.
 
-## Design Decisions
+**D8 — `[geo]` extra:** `geopandas, shapely, pyogrio, topojson`. Optional, never base.
 
-### Phase 1 — Open the kind system (core, behavior-preserving)
+## Open question
 
-#### D1. `AssetKind` becomes a `StrEnum`; `Asset.kind` becomes `str`
-
-`AssetKind` is changed from `Enum` to `StrEnum`, so members are named string constants (`AssetKind.VECTOR == "vector"`) and arbitrary registered kind names are representable as plain strings. `Asset.kind` is typed `str`.
-
-The ~10 identity checks (`if self.kind is not AssetKind.TABULAR`) migrate from `is`/`is not` to `==`/`!=` (StrEnum members are not identical objects to bare string literals). This is mechanical and fully covered by existing tests. Built-in kind names are unchanged on the wire: `tabular`, `raster`, `array`, `tiles`, `blob`.
-
-#### D2. `KindRegistry` and `KindDescriptor`
-
-A registry parallel to the format-handler registry. A `KindDescriptor` carries:
-
-```python
-@dataclass(frozen=True)
-class KindDescriptor:
-    name: str                                   # e.g. "vector"
-    payload_contract: Callable[[Any], bool] | None = None   # validate payload (duck-typed; no hard dep)
-    derive_policy: KindDerivePolicy | None = None
-    description: str | None = None
-```
-
-- Built-in kinds (`tabular`, `raster`, `array`, `tiles`, `blob`) are pre-registered in core with their existing semantics.
-- The registry is **plugin-facing**: a registered plugin MAY expose `kind_descriptors() -> tuple[KindDescriptor, ...]`, classified during `PluginRegistry._register` alongside `AuthProvider`/`FormatHandler`/`StoreFormatHandler`. This is how a future *external* plugin adds a kind.
-- Internal optional modules register via the existing conditional-import path (the `NpzFormatHandler` pattern): when the extra is importable, register its `KindDescriptor` and handlers; otherwise skip.
-
-#### D3. Derive policies keyed by kind name
-
-`KIND_DERIVE_POLICIES` is re-keyed from `AssetKind` to `str` (no semantic change — it is already a dict with a `no_op_policy` default). A `KindDescriptor.derive_policy` is registered into this dict at kind-registration time. The RASTER policy is unchanged.
-
-#### D4. Accessors: typed built-ins + generic extension accessor
-
-The built-in typed accessors (`as_table`, `as_raster`, `as_array`, `as_tiles`, `as_blob`) stay in core for the common, statically-typed path. Extension kinds use a generic accessor:
-
-```python
-def require_kind(self, name: str) -> Any:
-    if self.kind != name:
-        raise IncompatibleAssetKindError(expected=name, actual=self.kind)
-    return self.payload
-```
-
-`IncompatibleAssetKindError` is generalized to accept string kind names (it already stores `expected`/`actual`). A plugin that wants a typed accessor for its kind (geo does) provides it on its own wrapper, not on core `Asset`. **Core never imports geopandas**, so there is no core `as_vector()` returning a `GeoDataFrame`; the typed surface lives on the plugin's `GeoDataFrame` wrapper.
-
-### Phase 2 — Geo as a self-contained `[geo]` plugin
-
-#### D5. The `vector` kind is registered by `[geo]`, not core
-
-`vector` is a `KindDescriptor` registered only when the `[geo]` extra is present. Semantics: payload is a `geopandas.GeoDataFrame`; CRS mirrored in `extras["crs"]` (existing `Asset.crs` reads it); derive policy clears `extras["crs"]` when a derivation drops the geometry column, keeps it otherwise (same shape as the RASTER profile policy). When `[geo]` is absent, the `vector` kind is simply unregistered — and resolution (D11) turns that into a loud error rather than a blob.
-
-> Shape rigor note: `vector` is a distinct shape from `table` — a geometry-typed column plus a CRS contract that `table` does not admit — but it is table-*compatible* (rectangular, row-per-feature; `GeoDataFrame` IS-A `DataFrame`). `as_table()` on a vector is therefore an explicit, lossy downcast (geometry dropped/serialized), never an identity. A "vector" is conceptually the single geometry column + its contracts; adding non-geometry columns is the feature-collection refinement geopandas already models, not a different kind.
-
-#### D6. `VectorFormatHandler` in `handlers_geo.py`
-
-A new module (keeps geopandas/shapely/topojson out of the always-loaded `handlers.py`, exactly like `handlers_gcs.py`/`handlers_s3.py`/`handlers_npz.py`/`handlers_hdf5.py`).
-
-```python
-class VectorFormatHandler:
-    __sunstone_handler_protocol__ = 2
-    _EXTENSION_MAP = {".geojson": "geojson", ".topojson": "topojson"}
-    _FORMATS = frozenset({"geojson", "topojson"})
-    def supported_kinds(self): return ("vector",)
-```
-
-- `can_read`/`can_write` resolve by extension or explicit `format=` **only** — no geopandas import (mirrors the module-level `_READER_FORMATS` trick), so existence checks stay dependency-free.
-- `supports_sunstone_metadata_embedding() -> True`; `supports_native_metadata_extraction() -> False`.
-- geopandas/shapely/topojson imports are **lazy inside `read`/`write`**, re-raising `ImportError` as a clear "install `sunstone-py[geo]`" message (the `ParquetFormatHandler`/pyarrow pattern).
-- **Read**: read stream → `json.loads` → pop top-level `"sunstone"` member into `Metadata` (D8) → build `GeoDataFrame` (`from_features`, default CRS `EPSG:4326` per RFC 7946 when absent). TopoJSON first decodes topology→FeatureCollection (arc-stitching) per named object. **Decode library: Open Question O1.**
-- **Write**: GeoJSON via `gdf.to_json()` → dict; TopoJSON via `topojson.Topology(gdf).to_json()` → dict (topology computed here). Inject `"sunstone"` member (D8) → `json.dumps` to stream.
-
-#### D7. Plain `.json` is NOT auto-detected as geo
-
-`.geojson` → `geojson`, `.topojson` → `topojson` by extension; plain `.json` stays tabular. To read a `.json` file as vector, pass `format="geojson"` or pin it in `datasets.yaml`. Follows the established `.txt`/`.xls` precedent. (This is the "one format, many shapes" ambiguity made concrete — JSON alone cannot imply a shape.)
-
-#### D8. Embed `Metadata` as a top-level `"sunstone"` foreign member
-
-On write, serialize `Metadata.to_jsonld()` as a single top-level member named `"sunstone"`; on read, pop and parse it. Gives lineage round-trip parity with Parquet. Verified safe against primary sources:
-
-- **RFC 7946 §6.1**: *"Members not described in this specification ('foreign members') MAY be used in a GeoJSON document."*
-- **GDAL/OGR** (QGIS, geopandas via pyogrio/fiona) *preserves* foreign members by default (NATIVE_DATA round-trip).
-- **Leaflet** and **OpenLayers** ignore unknown top-level members (verified against Leaflet source — no whitelist, no throw, no warn).
-- Avoids the two names RFC 7946 forbids at `FeatureCollection` level (`geometry`, `properties`). `"sunstone"` is safe.
-
-`datasets.yaml` remains authoritative; embedding is belt-and-suspenders. The asymmetric round-trip (JS tools drop the member on re-export, GDAL keeps it) costs nothing.
-
-#### D9. `sunstone.geopandas` facade + `GeoDataFrame` wrapper (in the geo plugin)
-
-- `from sunstone import geopandas as gpd`, then `gpd.read_file('x.geojson')` (auto-detect by extension), plus explicit `gpd.read_geojson(...)` / `gpd.read_topojson(...)`. Same project-path resolution and `datasets.yaml` registration as the `pandas` facade.
-- `GeoDataFrame` wrapper wraps `Asset(kind="vector", payload=geopandas.GeoDataFrame)`. `.data` → the GeoDataFrame, `.metadata` → unified `Metadata`, `.asset` → envelope; lineage flows through ops, parallel to the tabular `DataFrame`. This wrapper is the typed `as_vector`-equivalent surface (D4).
-- Writers `gdf.to_geojson(...)`/`gdf.to_topojson(...)` require `slug`+`name` for new outputs, like `to_csv`.
-- The TABULAR-only guard in `DataFrame.read_dataset` (`dataframe.py:454`) stays; the geo wrapper has its own vector-accepting read path. Both share `Metadata`/lineage machinery but enforce their own kinds.
-
-### Cross-cutting — `datasets.yaml` pinning and resolution
-
-#### D10. `type` + `format` pins in `datasets.yaml` (Frictionless-aligned)
-
-Add a `format` field to `datasets.yaml` → `DatasetMetadata.format`. Keep `type` as the orthogonal *shape* axis and extend its vocabulary to the registered kind names (`table`, `vector`, `raster`, `array`, `tiles`, `blob`).
-
-```yaml
-inputs:
-  - slug: world-borders
-    type: vector        # shape  → kind "vector" (load-bearing; see D11)
-    format: geojson     # serialization → handler selection within the shape
-    location: inputs/world.geojson
-```
-
-CLI validation extends its existing `type`-driven rules (`type: table` ⇒ fields required) with vector expectations (geometry/CRS).
-
-#### D11. Resolution filters handlers by `supported_kinds()` — `type` is load-bearing
-
-`read_dataset` (and the geo facade read path) thread the dataset's pinned `format` into resolution as the explicit format **before** extension detection, and filter candidate handlers to those whose `supported_kinds()` includes the pinned `type` (when set). Consequences:
-
-- `type: vector` **alone** refuses `BlobFormatHandler` (`supported_kinds() == ("blob",)`) and `BuiltinFormatHandler` (`("tabular",)`) on a shape mismatch — the silent blob fallback dies even with no `format` pinned.
-- Missing `[geo]` extra ⇒ `vector` kind unregistered ⇒ no vector-capable handler ⇒ the existing loud `"No format handler found ... Install a plugin"` error, naming the `[geo]` extra. Never a blob.
-- `format: geojson` disambiguates within the vector shape (geojson vs topojson vs future geobuf).
-- Both pinned ⇒ chosen handler must satisfy both. The blob fallback is reachable **only** for a fully-unpinned dataset whose extension no specific handler claims — the intended residual behavior.
-
-#### D12. `[geo]` optional extra
-
-```toml
-[project.optional-dependencies]
-geo = ["geopandas", "shapely", "pyogrio", "topojson"]
-```
-
-Strictly optional, never base (dependency-hygiene preference). `pyogrio` is geopandas's fast IO engine; `topojson` provides TopoJSON encoding. TopoJSON *decode* dependency is O1.
-
-## Open Questions
-
-- **O1. TopoJSON decode library.** `topojson` (mattijn/topojson) cleanly covers *encoding*; the decode direction (TopoJSON → GeoDataFrame) needs a verified library or a small hand-rolled arc-stitcher (~100 lines against the TopoJSON 1.0 spec). Resolve at plan time before finalizing the `[geo]` extra contents — do not guess.
-- **O2. External-plugin kind registration surface.** D2 proposes `kind_descriptors()` on plugin objects classified during `_register`. Confirm this shape vs. a dedicated entry-point group at plan time. Geo uses the internal conditional-import path regardless, so this does not block Phase 2.
+**O1 — TopoJSON decode.** Fully specified in `topojson.md` (delta-decode + transform + arc-stitch + negative-index reversal). At plan time pick: (a) GDAL's read-only TopoJSON driver via pyogrio (no new dep), else (b) hand-roll ~40 lines. Encode uses `topojson`. Either way no decode-only dependency.
 
 ## Phasing
 
-Phase 1 and Phase 2 are separate implementation plans / PRs:
+1. **Core, no geo dep:** D2 field-type registry, D4 `format` pin + format-driven resolution.
+2. **`[geo]` plugin:** D1, D3, D5–D8. Depends on (1).
 
-1. **Phase 1** (core seam): D1–D4 + D10–D11's resolution mechanism, with built-in kinds registered exactly as today and the tabular/parquet/blob/array handlers declaring `supported_kinds()` (most already do). Behavior-preserving; lands on existing tests plus new registry tests. No geo dependency.
-2. **Phase 2** (geo plugin): D5–D9 + D12, gated by `[geo]`. Depends on Phase 1.
+## Testing (TDD; geo tests `importorskip("geopandas")`)
 
-This keeps the risky-looking refactor isolated and verifiable before any geopandas code lands.
+- Registry: register/look up a field type; mode-gated validation; built-ins unaffected.
+- Resolution: `format: geojson` on `.json` selects geo handler (not `read_json`); pinned format beats extension; `.geojson` without `[geo]` errors loudly naming the extra.
+- Geo round-trip: GeoJSON + TopoJSON geometry/CRS; primary geometry column; `"sunstone"` metadata round-trip; Feature `id` preserved; no `crs` member emitted; facade reads + lineage; `to_*` require slug+name.
 
-## Testing
-
-TDD throughout. Geo tests skip without the extra (`pytest.importorskip("geopandas")`).
-
-- **Phase 1**: `tests/test_kind_registry.py` — register/lookup a custom kind; derive policy dispatched by name; `require_kind` + `IncompatibleAssetKindError` for string kinds; built-ins still resolve; `StrEnum` equality (`AssetKind.TABULAR == "tabular"`). Existing asset/handler/dataframe tests must stay green after the `is`→`==` migration.
-- **Resolution (D10/D11)**: `type: vector` refuses blob/tabular handlers; pinned `format` wins over extension; both-pinned requires both; unpinned `.geojson` with `[geo]` absent errors loudly (not blob); fully-unpinned unknown extension still reaches blob.
-- **Phase 2**: `tests/test_handlers_geo.py` — GeoJSON round-trip (geometry + CRS); TopoJSON round-trip (topology on write, geometry on read); `"sunstone"` foreign-member metadata round-trip; `.json` not claimed by the vector handler; explicit `format="geojson"` on a `.json` path works; missing-`[geo]` `ImportError` names the extra. `tests/test_geopandas.py` — facade reads, project-path resolution, `datasets.yaml` registration, lineage flow, `to_*` requires slug+name.
-
-## CHANGELOG
-
-Two lines under `[Unreleased]` (one per phase as they land):
+## CHANGELOG (one line per phase as it lands)
 
 ```
-- Added: Plugin-extensible asset kinds via a kind registry.
+- Added: Extensible field value-types (registry) for structured columns.
 - Added: GeoJSON and TopoJSON read/write via the optional [geo] extra.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ overrides = [
     { module = "ontopint", ignore_missing_imports = true },
     { module = "zarr", ignore_missing_imports = true },
     { module = "h5py", ignore_missing_imports = true },
+    { module = "geopandas.*", ignore_missing_imports = true },
+    { module = "shapely.*", ignore_missing_imports = true },
+    { module = "topojson.*", ignore_missing_imports = true },
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,12 @@ zarr = [
 hdf5 = [
     "h5py>=3.10",
 ]
+geo = [
+    "geopandas>=1.0",
+    "shapely>=2.0",
+    "pyogrio>=0.8",
+    "topojson>=1.9",
+]
 
 [project.license]
 text = "MIT"

--- a/src/sunstone/asset.py
+++ b/src/sunstone/asset.py
@@ -28,6 +28,7 @@ class AssetKind(Enum):
     ARRAY = "array"
     TILES = "tiles"
     BLOB = "blob"
+    GEOFEATURES = "geofeatures"
 
 
 @dataclass
@@ -81,6 +82,12 @@ class Asset:
         if self.kind is not AssetKind.BLOB:
             raise IncompatibleAssetKindError(expected=AssetKind.BLOB, actual=self.kind)
         return cast(bytes, self.payload)
+
+    def as_geofeatures(self) -> Any:
+        """Return the geopandas GeoDataFrame payload (typed Any: core has no geopandas dep)."""
+        if self.kind is not AssetKind.GEOFEATURES:
+            raise IncompatibleAssetKindError(expected=AssetKind.GEOFEATURES, actual=self.kind)
+        return self.payload
 
     def derive(
         self,

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -421,16 +421,21 @@ class DataFrame:
 
         registry = PluginRegistry.get(manager.project_path)
 
+        # A pinned format in datasets.yaml overrides extension detection.
+        if format is None and dataset.format is not None:
+            format = dataset.format
+
         # Try explicit format string first, then extension-based detection
         location = str(absolute_path)
         format_handler = registry.find_format_reader(location, format)
 
         if format_handler is None:
             extension = absolute_path.suffix.lower()
+            detail = f"format={format!r}" if format else f"extension={extension!r}"
             raise ValueError(
-                f"No format handler found for '{absolute_path.name}'"
-                + (f" (format='{format}')" if format else f" (extension='{extension}')")
-                + ". Install a plugin or check the file extension."
+                f"No format handler found for '{absolute_path.name}' ({detail}). "
+                "Install the matching extra (e.g. `pip install sunstone-py[geo]` for "
+                "geojson/topojson) or check the file extension."
             )
 
         url_handler = registry.find_url_handler(location)

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -691,6 +691,7 @@ class DatasetsManager:
             location=dataset_data["location"],
             description=dataset_data.get("description"),
             resource_type=dataset_data.get("type"),
+            format=dataset_data.get("format"),
             fields=fields,
             source=source,
             license=dataset_data.get("license"),

--- a/src/sunstone/field_types.py
+++ b/src/sunstone/field_types.py
@@ -1,0 +1,78 @@
+"""Registry of field (column) value-types for dataset schemas.
+
+Built-in scalar types mirror the Frictionless Table Schema vocabulary. Plugins
+extend this with structured/domain types (e.g. ``geometry``) via
+``FieldTypeDescriptor`` — see ``PluginRegistry`` classification. This is the
+extensibility seam for non-scalar columns; geometry is the first consumer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+class FieldTypeValidationError(ValueError):
+    """A field value failed its registered type contract in strict mode."""
+
+
+@dataclass(frozen=True)
+class FieldTypeDescriptor:
+    """Describes a field (column) value-type.
+
+    ``validate`` is an optional cell-level contract: it returns True for a
+    valid value. ``None`` means "no contract" (always accepted).
+    """
+
+    name: str
+    validate: Optional[Callable[[Any], bool]] = None
+    description: Optional[str] = None
+
+
+# Frictionless Table Schema scalar types (plus "any").
+_BUILTIN_SCALAR_TYPES: tuple[str, ...] = (
+    "string",
+    "number",
+    "integer",
+    "boolean",
+    "object",
+    "array",
+    "date",
+    "datetime",
+    "time",
+    "year",
+    "yearmonth",
+    "duration",
+    "any",
+)
+
+
+class FieldTypeRegistry:
+    """Holds known field value-types, keyed by name."""
+
+    def __init__(self) -> None:
+        self._types: dict[str, FieldTypeDescriptor] = {
+            name: FieldTypeDescriptor(name=name) for name in _BUILTIN_SCALAR_TYPES
+        }
+
+    def register(self, descriptor: FieldTypeDescriptor) -> None:
+        self._types[descriptor.name] = descriptor
+
+    def get(self, name: str) -> Optional[FieldTypeDescriptor]:
+        return self._types.get(name)
+
+    def known(self) -> tuple[str, ...]:
+        return tuple(self._types)
+
+
+def validate_field_value(registry: FieldTypeRegistry, type_name: str, value: Any, *, strict: bool) -> None:
+    """Validate ``value`` against the contract for ``type_name``.
+
+    No-op when the type is unknown or has no contract. In strict mode a failed
+    contract raises ``FieldTypeValidationError``; in lenient mode it is ignored.
+    """
+    descriptor = registry.get(type_name)
+    if descriptor is None or descriptor.validate is None:
+        return
+    if not descriptor.validate(value) and strict:
+        raise FieldTypeValidationError(f"Value {value!r} is not valid for field type {type_name!r}")

--- a/src/sunstone/geopandas.py
+++ b/src/sunstone/geopandas.py
@@ -1,0 +1,103 @@
+"""Lineage-tracking geopandas facade. Requires the [geo] extra.
+
+Mirrors ``sunstone.pandas``: read functions resolve a slug/path against the
+project's datasets.yaml and return a ``GeoDataFrame`` wrapper backed by an
+``Asset(kind=GEOFEATURES)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from .asset import Asset, AssetKind
+from .config import get_project_path
+from .datasets import DatasetsManager
+from .exceptions import DatasetNotFoundError
+from .lineage import Metadata
+from .plugins import PluginRegistry
+
+
+class GeoDataFrame:
+    """Wraps a geopandas.GeoDataFrame with sunstone metadata + lineage."""
+
+    def __init__(self, asset: Asset) -> None:
+        if asset.kind is not AssetKind.GEOFEATURES:
+            raise ValueError("GeoDataFrame must wrap a GEOFEATURES asset")
+        self._asset = asset
+
+    @property
+    def asset(self) -> Asset:
+        return self._asset
+
+    @property
+    def data(self) -> Any:
+        return self._asset.payload
+
+    @property
+    def metadata(self) -> Metadata:
+        return self._asset.metadata
+
+    def to_geojson(self, path: str | Path, *, slug: str | None = None, name: str | None = None) -> None:
+        self._write(path, "geojson", slug, name)
+
+    def to_topojson(self, path: str | Path, *, slug: str | None = None, name: str | None = None) -> None:
+        self._write(path, "topojson", slug, name)
+
+    def _write(self, path: str | Path, fmt: str, slug: str | None, name: str | None) -> None:
+        if slug is not None:
+            self._asset.metadata.slug = slug
+        if name is not None:
+            self._asset.metadata.name = name
+        if not self._asset.metadata.slug or not self._asset.metadata.name:
+            raise ValueError("Writing a new geo output requires both slug and name.")
+        registry = PluginRegistry.get(get_project_path())
+        handler = registry.find_format_writer(str(path), fmt)
+        if handler is None:
+            raise ValueError(f"No format handler for {fmt!r} (install sunstone-py[geo]).")
+        url_handler = registry.find_url_handler(str(path))
+        if url_handler is None:
+            raise ValueError(f"No URL handler for {path!r}.")
+        with url_handler.open(str(path), "wb") as stream:
+            handler.write(self._asset, stream, format=fmt, path=str(path))
+
+
+def _read(slug_or_path: str, fmt: str, project_path: str | Path | None) -> GeoDataFrame:
+    project = Path(project_path) if project_path is not None else get_project_path()
+    manager = DatasetsManager(project)
+    dataset = manager.find_dataset_by_slug(slug_or_path)
+    if dataset is None:
+        raise DatasetNotFoundError(f"Dataset '{slug_or_path}' not found in datasets.yaml.")
+    location = str(manager.get_absolute_path(dataset.location))
+    registry = PluginRegistry.get(manager.project_path)
+    handler = registry.find_format_reader(location, fmt)
+    if handler is None:
+        raise ValueError(f"No format handler for {fmt!r} (install sunstone-py[geo]).")
+    url_handler = registry.find_url_handler(location)
+    if url_handler is None:
+        raise ValueError(f"No URL handler for {location!r}.")
+    with url_handler.open(location, "rb") as stream:
+        asset = cast(Asset, handler.read(stream, format=fmt, path=location))
+    if not asset.metadata.slug:
+        asset.metadata.slug = dataset.slug
+        asset.metadata.name = dataset.name
+    return GeoDataFrame(asset)
+
+
+def read_geojson(slug_or_path: str, project_path: str | Path | None = None) -> GeoDataFrame:
+    return _read(slug_or_path, "geojson", project_path)
+
+
+def read_topojson(slug_or_path: str, project_path: str | Path | None = None) -> GeoDataFrame:
+    return _read(slug_or_path, "topojson", project_path)
+
+
+def read_file(slug_or_path: str, project_path: str | Path | None = None) -> GeoDataFrame:
+    """Auto-detect geojson vs topojson from the dataset's format/extension."""
+    project = Path(project_path) if project_path is not None else get_project_path()
+    manager = DatasetsManager(project)
+    dataset = manager.find_dataset_by_slug(slug_or_path)
+    fmt = dataset.format if dataset and dataset.format else None
+    if fmt is None and dataset is not None and dataset.location.endswith(".topojson"):
+        fmt = "topojson"
+    return _read(slug_or_path, fmt or "geojson", project_path)

--- a/src/sunstone/handlers_geo.py
+++ b/src/sunstone/handlers_geo.py
@@ -1,0 +1,242 @@
+"""GeoJSON/TopoJSON format handler for AssetKind.GEOFEATURES.
+
+geopandas/shapely/topojson are imported lazily inside read()/write() so that
+importing this module (and resolving handlers) is dependency-free. Registered
+only when the [geo] extra is importable — see PluginRegistry._discover.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+from typing import Any, BinaryIO
+from urllib.parse import urlparse
+
+from .asset import AssetKind
+from .field_types import FieldTypeDescriptor
+
+_EXTENSION_MAP = {".geojson": "geojson", ".topojson": "topojson"}
+_FORMATS = frozenset({"geojson", "topojson"})
+_SUNSTONE_KEY = "sunstone"
+
+
+def _is_geometry(value: Any) -> bool:
+    """Cell contract for the `geometry` field type: a shapely geometry."""
+    return hasattr(value, "geom_type") or value is None
+
+
+def _require_geo() -> None:
+    try:
+        import geopandas  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised via message test
+        raise ImportError(
+            "Reading/writing GeoJSON/TopoJSON requires the geo extra. Install it with: pip install sunstone-py[geo]"
+        ) from exc
+
+
+class GeoFeaturesFormatHandler:
+    __sunstone_handler_protocol__ = 2
+
+    def supports_native_metadata_extraction(self) -> bool:
+        return False
+
+    def supports_sunstone_metadata_embedding(self) -> bool:
+        return True
+
+    def supports_metadata(self) -> bool:
+        return True
+
+    def supported_kinds(self) -> tuple:
+        return (AssetKind.GEOFEATURES,)
+
+    def field_types(self) -> tuple[FieldTypeDescriptor, ...]:
+        return (
+            FieldTypeDescriptor(
+                name="geometry",
+                validate=_is_geometry,
+                description="A geographic geometry (shapely) with a CRS.",
+            ),
+        )
+
+    def _resolve_format(self, path: str, format: str | None) -> str | None:
+        if format is not None:
+            return format if format in _FORMATS else None
+        parsed = urlparse(path)
+        file_path = parsed.path if parsed.scheme else path
+        return _EXTENSION_MAP.get(PurePosixPath(file_path).suffix.lower())
+
+    def can_read(self, path: str, format: str | None) -> bool:
+        return self._resolve_format(path, format) is not None
+
+    def can_write(self, path: str, format: str | None) -> bool:
+        return self._resolve_format(path, format) is not None
+
+    def read(self, stream: BinaryIO, **kwargs: object) -> Any:
+        _require_geo()
+        import geopandas as gpd
+
+        from .asset import Asset
+        from .lineage import Metadata
+
+        fmt = self._resolve_format(str(kwargs.get("path") or ""), kwargs.get("format"))  # type: ignore[arg-type]
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+        kwargs.pop("dialect", None)
+
+        raw = stream.read()
+        doc = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
+
+        meta = Metadata()
+        sunstone_blob = doc.pop(_SUNSTONE_KEY, None) if isinstance(doc, dict) else None
+        if sunstone_blob is not None:
+            try:
+                meta = Metadata.from_jsonld(sunstone_blob)
+            except Exception:
+                meta = Metadata()
+
+        if fmt == "topojson":
+            doc = self._topojson_to_featurecollection(doc)
+
+        features = doc.get("features", []) if isinstance(doc, dict) else []
+        if features:
+            gdf = gpd.GeoDataFrame.from_features(features, crs="EPSG:4326")
+        else:
+            gdf = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+
+        return Asset(
+            payload=gdf,
+            kind=AssetKind.GEOFEATURES,
+            metadata=meta,
+            extras={"crs": gdf.crs},
+        )
+
+    def write(self, asset: object, stream: BinaryIO, **kwargs: object) -> None:
+        _require_geo()
+        fmt = self._resolve_format(str(kwargs.get("path") or ""), kwargs.get("format"))  # type: ignore[arg-type]
+        kwargs.pop("format", None)
+        kwargs.pop("path", None)
+        kwargs.pop("dialect", None)
+
+        gdf = asset.as_geofeatures() if hasattr(asset, "as_geofeatures") else asset
+        metadata_obj = getattr(asset, "metadata", None)
+
+        gdf = self._orient_rings(gdf)
+        if gdf.crs is not None and getattr(gdf.crs, "to_epsg", lambda: None)() != 4326:
+            import warnings
+
+            warnings.warn(
+                "Writing non-WGS84 geometry as GeoJSON is non-conformant with RFC 7946; "
+                "CRS is recorded in metadata but coordinates are not reprojected.",
+                stacklevel=2,
+            )
+
+        if fmt == "topojson":
+            doc = self._geodataframe_to_topojson(gdf)
+        else:
+            doc = json.loads(gdf.to_json())  # FeatureCollection; geopandas does not emit crs in v1
+            doc.pop("crs", None)  # belt-and-suspenders for older geopandas
+
+        if metadata_obj is not None:
+            doc[_SUNSTONE_KEY] = metadata_obj.to_jsonld()
+
+        stream.write(json.dumps(doc).encode("utf-8"))
+
+    @staticmethod
+    def _orient_rings(gdf: Any) -> Any:
+        """Right-hand rule per RFC 7946: exterior CCW, holes CW."""
+        from shapely.geometry.base import BaseGeometry
+        from shapely.geometry.polygon import orient
+
+        def _fix(geom: BaseGeometry) -> Any:
+            if geom is None:
+                return geom
+            if geom.geom_type == "Polygon":
+                return orient(geom, sign=1.0)
+            if geom.geom_type == "MultiPolygon":
+                from shapely.geometry import MultiPolygon
+
+                return MultiPolygon([orient(g, sign=1.0) for g in geom.geoms])
+            return geom
+
+        out = gdf.copy()
+        out[out.geometry.name] = out.geometry.apply(_fix)
+        return out
+
+    def _topojson_to_featurecollection(self, topo: dict) -> dict:
+        transform = topo.get("transform")
+        raw_arcs = topo.get("arcs", [])
+
+        def decode_arc(arc: list) -> list:
+            if transform is None:
+                return [list(p) for p in arc]
+            sx, sy = transform["scale"]
+            tx, ty = transform["translate"]
+            x = y = 0
+            out = []
+            for p in arc:
+                x += p[0]
+                y += p[1]
+                out.append([x * sx + tx, y * sy + ty])
+            return out
+
+        arcs = [decode_arc(a) for a in raw_arcs]
+
+        def deref(idx: int) -> list:
+            return list(arcs[idx]) if idx >= 0 else list(reversed(arcs[~idx]))
+
+        def stitch(indexes: list) -> list:
+            line: list = []
+            for k, idx in enumerate(indexes):
+                pts = deref(idx)
+                line.extend(pts[1:] if k > 0 else pts)
+            return line
+
+        def decode_point(p: list) -> list:
+            if transform is None:
+                return list(p)
+            sx, sy = transform["scale"]
+            tx, ty = transform["translate"]
+            return [p[0] * sx + tx, p[1] * sy + ty]
+
+        def to_geometry(g: dict) -> dict | None:
+            t = g.get("type")
+            if t is None:
+                return None
+            if t == "Point":
+                return {"type": "Point", "coordinates": decode_point(g["coordinates"])}
+            if t == "MultiPoint":
+                return {"type": "MultiPoint", "coordinates": [decode_point(p) for p in g["coordinates"]]}
+            if t == "LineString":
+                return {"type": "LineString", "coordinates": stitch(g["arcs"])}
+            if t == "MultiLineString":
+                return {"type": "MultiLineString", "coordinates": [stitch(a) for a in g["arcs"]]}
+            if t == "Polygon":
+                return {"type": "Polygon", "coordinates": [stitch(r) for r in g["arcs"]]}
+            if t == "MultiPolygon":
+                return {
+                    "type": "MultiPolygon",
+                    "coordinates": [[stitch(r) for r in poly] for poly in g["arcs"]],
+                }
+            return None
+
+        features = []
+        for obj in topo.get("objects", {}).values():
+            geometries = obj.get("geometries", [obj]) if obj.get("type") == "GeometryCollection" else [obj]
+            for g in geometries:
+                features.append(
+                    {
+                        "type": "Feature",
+                        "geometry": to_geometry(g),
+                        "properties": g.get("properties", {}) or {},
+                        **({"id": g["id"]} if "id" in g else {}),
+                    }
+                )
+        return {"type": "FeatureCollection", "features": features}
+
+    def _geodataframe_to_topojson(self, gdf: Any) -> dict:
+        import topojson
+
+        topo = topojson.Topology(gdf, prequantize=False)
+        # topojson returns a JSON string; parse to a dict so we can attach metadata.
+        result: dict = json.loads(topo.to_json())
+        return result

--- a/src/sunstone/lineage.py
+++ b/src/sunstone/lineage.py
@@ -371,6 +371,10 @@ class DatasetMetadata:
     resource_type: Optional[str] = None
     """Resource type (e.g., 'table'). Optional."""
 
+    format: Optional[str] = None
+    """Serialization format (e.g. 'geojson', 'topojson', 'csv'). Drives handler
+    resolution when set; otherwise the file extension is used."""
+
     fields: Optional[List[FieldSchema]] = None
     """Schema definitions for dataset fields. Required for table resources."""
 

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -241,6 +241,9 @@ class PluginRegistry:
         self._url_handlers: list[URLHandler] = [LocalFileHandler()]
         self._format_handlers: list[FormatHandler] = []
         self._store_format_handlers: list[object] = []
+        from .field_types import FieldTypeRegistry
+
+        self.field_types = FieldTypeRegistry()
         self._cli_providers: list[CLIProvider] = []
         self._env_section_providers: list[EnvSectionProvider] = []
 
@@ -365,6 +368,10 @@ class PluginRegistry:
             registered = True
         if isinstance(plugin, EnvSectionProvider):
             self._env_section_providers.append(plugin)
+            registered = True
+        if hasattr(plugin, "field_types") and callable(plugin.field_types):
+            for descriptor in plugin.field_types():
+                self.field_types.register(descriptor)
             registered = True
         if not registered:
             logger.warning("Plugin '%s' does not implement any known plugin protocol", name)

--- a/src/sunstone/plugins.py
+++ b/src/sunstone/plugins.py
@@ -333,6 +333,19 @@ class PluginRegistry:
             self._format_handlers.append(NpzFormatHandler())  # type: ignore[arg-type]
         except ImportError:
             pass  # numpy not installed (shouldn't normally happen — pandas pulls it in)
+        # Optional geo handler (GeoJSON/TopoJSON). Registered before the
+        # catch-all BuiltinFormatHandler so .geojson/.topojson resolve here.
+        try:
+            import geopandas  # noqa: F401
+
+            from .handlers_geo import GeoFeaturesFormatHandler
+
+            geo_handler = GeoFeaturesFormatHandler()
+            self._format_handlers.append(geo_handler)  # type: ignore[arg-type]
+            for descriptor in geo_handler.field_types():
+                self.field_types.register(descriptor)
+        except ImportError:
+            pass  # [geo] extra not installed
         self._format_handlers.append(BuiltinFormatHandler())  # type: ignore[arg-type]
         # BlobFormatHandler is the residual fallback — registered LAST so more
         # specific handlers (Parquet, BuiltinFormatHandler for CSV/XLSX/etc.)

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -8,7 +8,7 @@ from sunstone.lineage import Metadata
 
 
 def test_asset_kind_is_closed_enum():
-    assert {k.value for k in AssetKind} == {"tabular", "raster", "array", "tiles", "blob"}
+    assert {k.value for k in AssetKind} == {"tabular", "raster", "array", "tiles", "blob", "geofeatures"}
 
 
 def test_asset_kind_blob_exists_with_expected_value():

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1086,8 +1086,12 @@ outputs: []
 def test_pinned_format_overrides_extension(tmp_path):
     """A .json file pinned as format: geojson must NOT be read as tabular JSON.
 
-    With no geojson handler installed (Phase 1), resolution must fail loudly
-    instead of silently mis-parsing via read_json.
+    Resolution must fail loudly instead of silently mis-parsing via read_json.
+    When the [geo] extra is absent, no handler claims ``geojson`` and lookup
+    raises a "geojson" ValueError. When it is present, the geo handler resolves
+    but returns a non-tabular GEOFEATURES asset, which the tabular path rejects
+    via IncompatibleAssetKindError (also a ValueError) — geo data must be read
+    through ``sunstone.geopandas``, not the tabular facade.
     """
     import pytest
     from sunstone.dataframe import DataFrame
@@ -1097,5 +1101,5 @@ def test_pinned_format_overrides_extension(tmp_path):
     )
     (tmp_path / "world.json").write_text('{"type":"FeatureCollection","features":[]}')
 
-    with pytest.raises(ValueError, match="geojson"):
+    with pytest.raises(ValueError, match="geojson|geofeatures"):
         DataFrame.read_dataset("world", project_path=tmp_path)

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1081,3 +1081,21 @@ outputs: []
         # Read raw bytes to verify the delimiter was honored on write
         written = (project / "outputs" / "semi_out.csv").read_text()
         assert written == "a;b\n1;2\n3;4\n"
+
+
+def test_pinned_format_overrides_extension(tmp_path):
+    """A .json file pinned as format: geojson must NOT be read as tabular JSON.
+
+    With no geojson handler installed (Phase 1), resolution must fail loudly
+    instead of silently mis-parsing via read_json.
+    """
+    import pytest
+    from sunstone.dataframe import DataFrame
+
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n  - name: World\n    slug: world\n    location: world.json\n    format: geojson\n"
+    )
+    (tmp_path / "world.json").write_text('{"type":"FeatureCollection","features":[]}')
+
+    with pytest.raises(ValueError, match="geojson"):
+        DataFrame.read_dataset("world", project_path=tmp_path)

--- a/tests/test_dataframe_coverage.py
+++ b/tests/test_dataframe_coverage.py
@@ -474,3 +474,18 @@ class TestInferFieldSchema:
         assert type_map["active"] == "boolean"
         assert type_map["created"] == "datetime"
         assert type_map["label"] == "string"
+
+
+def test_geofeatures_kind_and_accessor():
+    import pytest
+    from sunstone.asset import Asset, AssetKind
+    from sunstone.errors import IncompatibleAssetKindError
+    from sunstone.lineage import Metadata
+
+    payload = object()  # stand-in for a GeoDataFrame
+    a = Asset(payload=payload, kind=AssetKind.GEOFEATURES, metadata=Metadata())
+    assert a.as_geofeatures() is payload
+
+    t = Asset(payload=[], kind=AssetKind.TABULAR, metadata=Metadata())
+    with pytest.raises(IncompatibleAssetKindError):
+        t.as_geofeatures()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1216,3 +1216,19 @@ class TestPerDatasetPublishDeprecation:
             assert len(deprecation_warnings) == 1
             assert "publish" in str(deprecation_warnings[0].message).lower()
             assert "packages:" in str(deprecation_warnings[0].message)
+
+
+def test_dataset_format_field_parsed(tmp_path):
+    from sunstone.datasets import DatasetsManager
+
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n"
+        "  - name: World Borders\n"
+        "    slug: world-borders\n"
+        "    location: inputs/world.json\n"
+        "    format: geojson\n"
+    )
+    mgr = DatasetsManager(tmp_path)
+    ds = mgr.find_dataset_by_slug("world-borders")
+    assert ds is not None
+    assert ds.format == "geojson"

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -1,0 +1,31 @@
+import pytest
+from sunstone.field_types import (
+    FieldTypeDescriptor,
+    FieldTypeRegistry,
+    validate_field_value,
+    FieldTypeValidationError,
+)
+
+
+def test_builtin_scalar_types_present():
+    reg = FieldTypeRegistry()
+    for name in ("string", "integer", "number", "boolean", "date", "datetime", "any"):
+        assert reg.get(name) is not None
+
+
+def test_register_and_get_custom_type():
+    reg = FieldTypeRegistry()
+    desc = FieldTypeDescriptor(name="geometry", validate=lambda v: hasattr(v, "geom_type"))
+    reg.register(desc)
+    assert reg.get("geometry") is desc
+    assert "geometry" in reg.known()
+
+
+def test_validate_is_mode_gated():
+    reg = FieldTypeRegistry()
+    reg.register(FieldTypeDescriptor(name="geometry", validate=lambda v: v == "ok"))
+    validate_field_value(reg, "geometry", "bad", strict=False)
+    with pytest.raises(FieldTypeValidationError):
+        validate_field_value(reg, "geometry", "bad", strict=True)
+    validate_field_value(reg, "string", "anything", strict=True)
+    validate_field_value(reg, "not-registered", "anything", strict=True)

--- a/tests/test_geopandas.py
+++ b/tests/test_geopandas.py
@@ -1,0 +1,63 @@
+import json
+
+import pytest
+
+pytest.importorskip("geopandas")
+
+
+def test_facade_read_geojson_and_lineage(tmp_path):
+    from sunstone import geopandas as gpd
+    import sunstone
+
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n  - name: Pts\n    slug: pts\n    location: pts.geojson\n    format: geojson\n"
+    )
+    (tmp_path / "pts.geojson").write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+                        "properties": {"name": "A"},
+                    }
+                ],
+            }
+        )
+    )
+
+    sunstone.set_project_path(tmp_path)
+    gdf = gpd.read_geojson("pts")
+    assert gdf.data.geometry.iloc[0].x == 1.0
+    assert gdf.metadata.slug == "pts"
+
+
+def test_to_geojson_requires_slug_and_name(tmp_path):
+    from sunstone import geopandas as gpd
+    import sunstone
+
+    (tmp_path / "datasets.yaml").write_text(
+        "inputs:\n  - name: Pts\n    slug: pts\n    location: pts.geojson\n    format: geojson\n"
+    )
+    (tmp_path / "pts.geojson").write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+                        "properties": {},
+                    }
+                ],
+            }
+        )
+    )
+    sunstone.set_project_path(tmp_path)
+    gdf = gpd.read_geojson("pts")
+    # Clear inherited slug/name so a brand-new output requires them explicitly.
+    gdf.metadata.slug = None
+    gdf.metadata.name = None
+    with pytest.raises(ValueError):
+        gdf.to_geojson(str(tmp_path / "out.geojson"))  # no slug/name for a new output

--- a/tests/test_handlers_geo.py
+++ b/tests/test_handlers_geo.py
@@ -122,3 +122,20 @@ def test_topojson_write_roundtrip(tmp_path):
     back = h.read(io.BytesIO(out.getvalue()), format="topojson", path="x.topojson")
     assert back.payload.geometry.iloc[0].x == 10.0
     assert back.metadata.slug == "pts"
+
+
+def test_missing_geo_extra_message(monkeypatch):
+    import io
+    import builtins
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "geopandas":
+            raise ImportError("no geopandas")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match=r"sunstone-py\[geo\]"):
+        GeoFeaturesFormatHandler().read(io.BytesIO(b"{}"), format="geojson", path="x.geojson")

--- a/tests/test_handlers_geo.py
+++ b/tests/test_handlers_geo.py
@@ -1,3 +1,8 @@
+import json
+
+import pytest
+
+
 def test_geo_handler_resolution_is_dependency_free():
     # This test must pass even without the [geo] extra installed.
     from sunstone.handlers_geo import GeoFeaturesFormatHandler
@@ -17,3 +22,35 @@ def test_geometry_field_type_descriptor_exposed():
 
     names = {ft.name for ft in GeoFeaturesFormatHandler().field_types()}
     assert "geometry" in names
+
+
+geopandas = pytest.importorskip("geopandas")
+
+
+def _fc():
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [10.0, 20.0]},
+                "properties": {"name": "A"},
+            },
+        ],
+    }
+
+
+def test_geojson_read_builds_geodataframe(tmp_path):
+    import io
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+    from sunstone.asset import AssetKind
+
+    stream = io.BytesIO(json.dumps(_fc()).encode("utf-8"))
+    asset = GeoFeaturesFormatHandler().read(stream, format="geojson", path="x.geojson")
+
+    assert asset.kind == AssetKind.GEOFEATURES
+    gdf = asset.payload
+    assert list(gdf["name"]) == ["A"]
+    assert gdf.geometry.iloc[0].x == 10.0
+    assert gdf.crs.to_epsg() == 4326  # default per RFC 7946
+    assert asset.extras.get("crs") is not None

--- a/tests/test_handlers_geo.py
+++ b/tests/test_handlers_geo.py
@@ -1,0 +1,19 @@
+def test_geo_handler_resolution_is_dependency_free():
+    # This test must pass even without the [geo] extra installed.
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+    from sunstone.asset import AssetKind
+
+    h = GeoFeaturesFormatHandler()
+    assert h.can_read("x.geojson", None)
+    assert h.can_read("x.topojson", None)
+    assert h.can_read("x.json", "geojson")
+    assert not h.can_read("x.json", None)  # plain .json is NOT geo
+    assert not h.can_read("x.csv", None)
+    assert h.supported_kinds() == (AssetKind.GEOFEATURES,)
+
+
+def test_geometry_field_type_descriptor_exposed():
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    names = {ft.name for ft in GeoFeaturesFormatHandler().field_types()}
+    assert "geometry" in names

--- a/tests/test_handlers_geo.py
+++ b/tests/test_handlers_geo.py
@@ -76,3 +76,28 @@ def test_geojson_write_roundtrip_and_conformance(tmp_path):
     asset2 = h.read(io.BytesIO(out.getvalue()), format="geojson", path="x.geojson")
     assert asset2.metadata.slug == "pts"
     assert list(asset2.payload["name"]) == ["A"]
+
+
+def test_topojson_read_decodes_line(tmp_path):
+    import io
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    topo = {
+        "type": "Topology",
+        "transform": {"scale": [1.0, 1.0], "translate": [0.0, 0.0]},
+        "objects": {
+            "ex": {
+                "type": "GeometryCollection",
+                "geometries": [
+                    {"type": "LineString", "properties": {"k": "v"}, "arcs": [0]},
+                ],
+            }
+        },
+        "arcs": [[[0, 0], [2, 0], [0, 2]]],  # delta-encoded: (0,0)->(2,0)->(2,2)
+    }
+    asset = GeoFeaturesFormatHandler().read(
+        io.BytesIO(json.dumps(topo).encode("utf-8")), format="topojson", path="x.topojson"
+    )
+    line = asset.payload.geometry.iloc[0]
+    assert list(line.coords) == [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]
+    assert list(asset.payload["k"]) == ["v"]

--- a/tests/test_handlers_geo.py
+++ b/tests/test_handlers_geo.py
@@ -101,3 +101,24 @@ def test_topojson_read_decodes_line(tmp_path):
     line = asset.payload.geometry.iloc[0]
     assert list(line.coords) == [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]
     assert list(asset.payload["k"]) == ["v"]
+
+
+def test_topojson_write_roundtrip(tmp_path):
+    import io
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    h = GeoFeaturesFormatHandler()
+    src = io.BytesIO(json.dumps(_fc()).encode("utf-8"))
+    asset = h.read(src, format="geojson", path="x.geojson")
+    asset.metadata.slug = "pts"
+    asset.metadata.name = "Points"
+
+    out = io.BytesIO()
+    h.write(asset, out, format="topojson", path="x.topojson")
+    doc = json.loads(out.getvalue().decode("utf-8"))
+    assert doc["type"] == "Topology"
+    assert "sunstone" in doc
+
+    back = h.read(io.BytesIO(out.getvalue()), format="topojson", path="x.topojson")
+    assert back.payload.geometry.iloc[0].x == 10.0
+    assert back.metadata.slug == "pts"

--- a/tests/test_handlers_geo.py
+++ b/tests/test_handlers_geo.py
@@ -54,3 +54,25 @@ def test_geojson_read_builds_geodataframe(tmp_path):
     assert gdf.geometry.iloc[0].x == 10.0
     assert gdf.crs.to_epsg() == 4326  # default per RFC 7946
     assert asset.extras.get("crs") is not None
+
+
+def test_geojson_write_roundtrip_and_conformance(tmp_path):
+    import io
+    from sunstone.handlers_geo import GeoFeaturesFormatHandler
+
+    h = GeoFeaturesFormatHandler()
+    src = io.BytesIO(json.dumps(_fc()).encode("utf-8"))
+    asset = h.read(src, format="geojson", path="x.geojson")
+    asset.metadata.slug = "pts"
+    asset.metadata.name = "Points"
+
+    out = io.BytesIO()
+    h.write(asset, out, format="geojson", path="x.geojson")
+    doc = json.loads(out.getvalue().decode("utf-8"))
+
+    assert doc["type"] == "FeatureCollection"
+    assert "crs" not in doc  # RFC 7946: never emit crs
+    assert doc["sunstone"]["dct:identifier"] == "pts" or doc["sunstone"].get("@graph")
+    asset2 = h.read(io.BytesIO(out.getvalue()), format="geojson", path="x.geojson")
+    assert asset2.metadata.slug == "pts"
+    assert list(asset2.payload["name"]) == ["A"]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1170,3 +1170,17 @@ def test_registry_multi_protocol_with_env_section():
             registry = PluginRegistry.get()
             assert len(registry.get_auth_providers()) == 1
             assert len(registry.get_env_section_providers()) == 1
+
+
+def test_plugin_field_types_are_registered():
+    from sunstone.field_types import FieldTypeDescriptor
+    from sunstone.plugins import PluginRegistry
+
+    class FakeGeoPlugin:
+        def field_types(self):
+            return (FieldTypeDescriptor(name="geometry", validate=lambda v: True),)
+
+    reg = PluginRegistry()
+    reg._register("fake-geo", FakeGeoPlugin())
+    assert reg.field_types.get("geometry") is not None
+    assert reg.field_types.get("string") is not None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1184,3 +1184,16 @@ def test_plugin_field_types_are_registered():
     reg._register("fake-geo", FakeGeoPlugin())
     assert reg.field_types.get("geometry") is not None
     assert reg.field_types.get("string") is not None
+
+
+def test_geo_handler_registered_when_geopandas_present():
+    import pytest
+
+    pytest.importorskip("geopandas")
+    from sunstone.plugins import PluginRegistry
+
+    reg = PluginRegistry()
+    reg._discover()
+    h = reg.find_format_reader("x.geojson", None)
+    assert h is not None and type(h).__name__ == "GeoFeaturesFormatHandler"
+    assert reg.field_types.get("geometry") is not None

--- a/uv.lock
+++ b/uv.lock
@@ -509,6 +509,23 @@ wheels = [
 ]
 
 [[package]]
+name = "geopandas"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyogrio" },
+    { name = "pyproj" },
+    { name = "shapely" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/ba/8e6b2091878e99e86a36a814dcaeff652ed48bdb03d53e78e15aaa63a914/geopandas-1.1.3.tar.gz", hash = "sha256:91a31989b6f566012838d21d5f8033f37dce882079ccb7cfdc40d5ccce7f284f", size = 336718, upload-time = "2026-03-09T21:49:09.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/78/6a04792ace63a93e162f1305392d500ae8ddcb620e7eb88a22fd622b35bb/geopandas-1.1.3-py3-none-any.whl", hash = "sha256:90d62a64f95eaa3be2ccc115c5f3d6e24208bb11983b390fdc0621a3eccd0230", size = 342514, upload-time = "2026-03-09T21:49:07.973Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1613,12 +1630,111 @@ wheels = [
 ]
 
 [[package]]
+name = "pyogrio"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/d4/12f86b1ed09721363da4c09622464b604c851a9223fc0c6b393fb2012208/pyogrio-0.12.1.tar.gz", hash = "sha256:e548ab705bb3e5383693717de1e6c76da97f3762ab92522cb310f93128a75ff1", size = 303289, upload-time = "2025-11-28T19:04:53.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/e0/656b6536549d41b5aec57e0deca1f269b4f17532f0636836f587e581603a/pyogrio-0.12.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:7a0d5ca39184030aec4cde30f4258f75b227a854530d2659babc8189d76e657d", size = 23661857, upload-time = "2025-11-28T19:03:27.744Z" },
+    { url = "https://files.pythonhosted.org/packages/14/78/313259e40da728bdb60106ffdc7ea8224d164498cb838ecb79b634aab967/pyogrio-0.12.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:feaff42bbe8087ca0b30e33b09d1ce049ca55fe83ad83db1139ef37d1d04f30c", size = 25237106, upload-time = "2025-11-28T19:03:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ca/5368571a8b00b941ccfbe6ea29a5566aaffd45d4eb1553b956f7755af43e/pyogrio-0.12.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:81096a5139532de5a8003ef02b41d5d2444cb382a9aecd1165b447eb549180d3", size = 31417048, upload-time = "2025-11-28T19:03:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/85/6eeb875f27bf498d657eb5dab9f58e4c48b36c9037122787abee9a1ba4ba/pyogrio-0.12.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:41b78863f782f7a113ed0d36a5dc74d59735bd3a82af53510899bb02a18b06bb", size = 30952115, upload-time = "2025-11-28T19:03:35.332Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/cf8bec9024625947e1a71441906f60a5fa6f9e4c441c4428037e73b1fcc8/pyogrio-0.12.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8b65be8c4258b27cc8f919b21929cecdadda4c353e3637fa30850339ef4d15c5", size = 32537246, upload-time = "2025-11-28T19:03:37.969Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/7c9f5e428273574e69f217eba3a6c0c42936188ad4dcd9e2c41ebb711188/pyogrio-0.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:1291b866c2c81d991bda15021b08b3621709b40ee3a85689229929e9465788bf", size = 22933980, upload-time = "2025-11-28T19:03:41.047Z" },
+    { url = "https://files.pythonhosted.org/packages/be/56/f56e79f71b84aa9bea25fdde39fab3846841bd7926be96f623eb7253b7e1/pyogrio-0.12.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:ec0e47a5a704e575092b2fd5c83fa0472a1d421e590f94093eb837bb0a11125d", size = 23658483, upload-time = "2025-11-28T19:03:43.567Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ac/5559f8a35d58a16cbb2dd7602dd11936ff8796d8c9bf789f14da88764ec3/pyogrio-0.12.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:b4c888fc08f388be4dd99dfca5e84a5cdc5994deeec0230cc45144d3460e2b21", size = 25232737, upload-time = "2025-11-28T19:03:45.92Z" },
+    { url = "https://files.pythonhosted.org/packages/59/58/925f1c129ddd7cbba8dea4e7609797cea7a76dbc863ac9afd318a679c4b9/pyogrio-0.12.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73a88436f9962750d782853727897ac2722cac5900d920e39fab3e56d7a6a7f1", size = 31377986, upload-time = "2025-11-28T19:03:48.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/5f/c87034e92847b1844d0e8492a6a8e3301147d32c5e57909397ce64dbedf5/pyogrio-0.12.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b5d248a0d59fe9bbf9a35690b70004c67830ee0ebe7d4f7bb8ffd8659f684b3a", size = 30915791, upload-time = "2025-11-28T19:03:51.267Z" },
+    { url = "https://files.pythonhosted.org/packages/46/35/b874f79d03e9f900012cf609f7fff97b77164f2e14ee5aac282f8a999c1b/pyogrio-0.12.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0622bc1a186421547660271083079b38d42e6f868802936d8538c0b379f1ab6b", size = 32499754, upload-time = "2025-11-28T19:03:58.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c4/705678c9c4200130290b3a104b45c0cc10aaa48fcef3b2585b34e34ab3e1/pyogrio-0.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:207bd60c7ffbcea84584596e3637653aa7095e9ee20fa408f90c7f9460392613", size = 22933945, upload-time = "2025-11-28T19:04:01.551Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e0/d92d4944001330bc87742d43f112d63d12fc89378b6187e62ff3fc1e8e85/pyogrio-0.12.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1511b39a283fa27cda906cd187a791578942a87a40b6a06697d9b43bb8ac80b0", size = 23692697, upload-time = "2025-11-28T19:04:04.208Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d7/40acbe06d1b1140e3bb27b79e9163776469c1dc785f1be7d9a7fc7b95c87/pyogrio-0.12.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:e486cd6aa9ea8a15394a5f84e019d61ec18f257eeeb642348bd68c3d1e57280b", size = 25258083, upload-time = "2025-11-28T19:04:07.121Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a1/39fefd9cddd95986700524f43d3093b4350f6e4fc200623c3838424a5080/pyogrio-0.12.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d3f1a19f63bfd1d3042e45f37ad1d6598123a5a604b6c4ba3f38b419273486cd", size = 31368995, upload-time = "2025-11-28T19:04:09.88Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d7/da88c566e67d741a03851eb8d01358949d52e0b0fc2cd953582dc6d89ff8/pyogrio-0.12.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f3dcc59b3316b8a0f59346bcc638a4d69997864a4d21da839192f50c4c92369a", size = 31035589, upload-time = "2025-11-28T19:04:12.993Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ac/8f0199f0d31b8ddbc4b4ea1918df8070fdf3e0a63100b898633ec9396224/pyogrio-0.12.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a0643e041dee3e8e038fce69f52a915ecb486e6d7b674c0f9919f3c9e9629689", size = 32487973, upload-time = "2025-11-28T19:04:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/64/8541a27e9635a335835d234dfaeb19d6c26097fd88224eda7791f83ca98d/pyogrio-0.12.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5881017f29e110d3613819667657844d8e961b747f2d35cf92f273c27af6d068", size = 22987374, upload-time = "2025-11-28T19:04:18.91Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6f/b4d5e285e08c0c60bcc23b50d73038ddc7335d8de79cc25678cd486a3db0/pyogrio-0.12.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5a1b0453d1c9e7b03715dd57296c8f3790acb8b50d7e3b5844b3074a18f50709", size = 23660673, upload-time = "2025-11-28T19:04:21.662Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/75/4b29e71489c5551aa1a1c5ca8c5160a60203c94f2f68c87c0e3614d58965/pyogrio-0.12.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e7ee560422239dd09ca7f8284cc8483a8919c30d25f3049bb0249bff4c38dec4", size = 25232194, upload-time = "2025-11-28T19:04:23.975Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/e9929d2261a07c36301983de2767bcde90d441ab5bf1d767ce56dd07f8b4/pyogrio-0.12.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:648c6f7f5f214d30e6cf493b4af1d59782907ac068af9119ca35f18153d6865a", size = 31336936, upload-time = "2025-11-28T19:04:26.594Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9e/c59941d734ed936d4e5c89b4b99cb5541307cc42b3fd466ee78a1850c177/pyogrio-0.12.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:58042584f3fd4cabb0f55d26c1405053f656be8a5c266c38140316a1e981aca0", size = 30902210, upload-time = "2025-11-28T19:04:29.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/68/cc07320a63f9c2586e60bf11d148b00e12d0e707673bffe609bbdcb7e754/pyogrio-0.12.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b438e38e4ccbaedaa5cb5824ff5de5539315d9b2fde6547c1e816576924ee8ca", size = 32461674, upload-time = "2025-11-28T19:04:31.792Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bc/e4522f429c45a3b6ad28185849dd76e5c8718b780883c4795e7ee41841ae/pyogrio-0.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:f1d8d8a2fea3781dc2a05982c050259261ebc0f6c5e03732d6d79d582adf9363", size = 23550575, upload-time = "2025-11-28T19:04:34.556Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ac/34f0664d0e391994a7b68529ae07a96432b2b4926dbac173ddc4ec94d310/pyogrio-0.12.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:9fe7286946f35a73e6370dc5855bc7a5e8e7babf9e4a8bad7a3279a1d94c7ea9", size = 23694285, upload-time = "2025-11-28T19:04:37.833Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/93/873255529faff1da09d0b27287e85ec805a318c60c0c74fd7df77f94e557/pyogrio-0.12.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2c50345b382f1be801d654ec22c70ee974d6057d4ba7afe984b55f2192bc94ee", size = 25259825, upload-time = "2025-11-28T19:04:40.125Z" },
+    { url = "https://files.pythonhosted.org/packages/27/95/4d4c3644695d99c6fa0b0b42f0d6266ae9dfaf64478a3371eaac950bdd02/pyogrio-0.12.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0db95765ac0ca935c7fe579e29451294e3ab19c317b0c59c31fbe92a69155e0", size = 31371995, upload-time = "2025-11-28T19:04:42.736Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/6f/71f6bcca8754c8bf55a4b7153c61c91f8ac5ba992568e9fa3e54a0ee76fd/pyogrio-0.12.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fc882779075982b93064b3bf3d8642514a6df00d9dd752493b104817072cfb01", size = 31035498, upload-time = "2025-11-28T19:04:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/47/75c1aa165a988347317afab9b938a01ad25dbca559b582ea34473703dc38/pyogrio-0.12.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:806f620e0c54b54dbdd65e9b6368d24f344cda84c9343364b40a57eb3e1c4dca", size = 32496390, upload-time = "2025-11-28T19:04:48.786Z" },
+    { url = "https://files.pythonhosted.org/packages/31/93/4641dc5d952f6bdb71dabad2c50e3f8a5d58396cdea6ff8f8a08bfd4f4a6/pyogrio-0.12.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5399f66730978d8852ef5f44dbafa0f738e7f28f4f784349f36830b69a9d2134", size = 23620996, upload-time = "2025-11-28T19:04:51.132Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyproj"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/90/67bd7260b4ea9b8b20b4f58afef6c223ecb3abf368eb4ec5bc2cdef81b49/pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c", size = 226279, upload-time = "2025-08-14T12:05:42.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/ab/9893ea9fb066be70ed9074ae543914a618c131ed8dff2da1e08b3a4df4db/pyproj-3.7.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:0a9bb26a6356fb5b033433a6d1b4542158fb71e3c51de49b4c318a1dff3aeaab", size = 6219832, upload-time = "2025-08-14T12:04:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/53/78/4c64199146eed7184eb0e85bedec60a4aa8853b6ffe1ab1f3a8b962e70a0/pyproj-3.7.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:567caa03021178861fad27fabde87500ec6d2ee173dd32f3e2d9871e40eebd68", size = 4620650, upload-time = "2025-08-14T12:04:11.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ac/14a78d17943898a93ef4f8c6a9d4169911c994e3161e54a7cedeba9d8dde/pyproj-3.7.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c203101d1dc3c038a56cff0447acc515dd29d6e14811406ac539c21eed422b2a", size = 9667087, upload-time = "2025-08-14T12:04:13.964Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/be/212882c450bba74fc8d7d35cbd57e4af84792f0a56194819d98106b075af/pyproj-3.7.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1edc34266c0c23ced85f95a1ee8b47c9035eae6aca5b6b340327250e8e281630", size = 9552797, upload-time = "2025-08-14T12:04:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/c0f25c87b5d2a8686341c53c1792a222a480d6c9caf60311fec12c99ec26/pyproj-3.7.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aa9f26c21bc0e2dc3d224cb1eb4020cf23e76af179a7c66fea49b828611e4260", size = 10837036, upload-time = "2025-08-14T12:04:18.733Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/5cbd6772addde2090c91113332623a86e8c7d583eccb2ad02ea634c4a89f/pyproj-3.7.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f9428b318530625cb389b9ddc9c51251e172808a4af79b82809376daaeabe5e9", size = 10775952, upload-time = "2025-08-14T12:04:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/69/a1/dc250e3cf83eb4b3b9a2cf86fdb5e25288bd40037ae449695550f9e96b2f/pyproj-3.7.2-cp312-cp312-win32.whl", hash = "sha256:b3d99ed57d319da042f175f4554fc7038aa4bcecc4ac89e217e350346b742c9d", size = 5898872, upload-time = "2025-08-14T12:04:22.485Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a6/6fe724b72b70f2b00152d77282e14964d60ab092ec225e67c196c9b463e5/pyproj-3.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:11614a054cd86a2ed968a657d00987a86eeb91fdcbd9ad3310478685dc14a128", size = 6312176, upload-time = "2025-08-14T12:04:24.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/68/915cc32c02a91e76d02c8f55d5a138d6ef9e47a0d96d259df98f4842e558/pyproj-3.7.2-cp312-cp312-win_arm64.whl", hash = "sha256:509a146d1398bafe4f53273398c3bb0b4732535065fa995270e52a9d3676bca3", size = 6233452, upload-time = "2025-08-14T12:04:27.287Z" },
+    { url = "https://files.pythonhosted.org/packages/be/14/faf1b90d267cea68d7e70662e7f88cefdb1bc890bd596c74b959e0517a72/pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:19466e529b1b15eeefdf8ff26b06fa745856c044f2f77bf0edbae94078c1dfa1", size = 6214580, upload-time = "2025-08-14T12:04:28.804Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/da9a45b184d375f62667f62eba0ca68569b0bd980a0bb7ffcc1d50440520/pyproj-3.7.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c79b9b84c4a626c5dc324c0d666be0bfcebd99f7538d66e8898c2444221b3da7", size = 4615388, upload-time = "2025-08-14T12:04:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e7/d2b459a4a64bca328b712c1b544e109df88e5c800f7c143cfbc404d39bfb/pyproj-3.7.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ceecf374cacca317bc09e165db38ac548ee3cad07c3609442bd70311c59c21aa", size = 9628455, upload-time = "2025-08-14T12:04:32.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5141a538ffdbe4bfd157421828bb2e07123a90a7a2d6f30fa1462abcfb5ce681", size = 9514269, upload-time = "2025-08-14T12:04:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/34/38/07a9b89ae7467872f9a476883a5bad9e4f4d1219d31060f0f2b282276cbe/pyproj-3.7.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f000841e98ea99acbb7b8ca168d67773b0191de95187228a16110245c5d954d5", size = 10808437, upload-time = "2025-08-14T12:04:36.485Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/fda1daeabbd39dec5b07f67233d09f31facb762587b498e6fc4572be9837/pyproj-3.7.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8115faf2597f281a42ab608ceac346b4eb1383d3b45ab474fd37341c4bf82a67", size = 10745540, upload-time = "2025-08-14T12:04:38.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/90/c793182cbba65a39a11db2ac6b479fe76c59e6509ae75e5744c344a0da9d/pyproj-3.7.2-cp313-cp313-win32.whl", hash = "sha256:f18c0579dd6be00b970cb1a6719197fceecc407515bab37da0066f0184aafdf3", size = 5896506, upload-time = "2025-08-14T12:04:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:bb41c29d5f60854b1075853fe80c58950b398d4ebb404eb532536ac8d2834ed7", size = 6310195, upload-time = "2025-08-14T12:04:42.974Z" },
+    { url = "https://files.pythonhosted.org/packages/82/64/fc7598a53172c4931ec6edf5228280663063150625d3f6423b4c20f9daff/pyproj-3.7.2-cp313-cp313-win_arm64.whl", hash = "sha256:2b617d573be4118c11cd96b8891a0b7f65778fa7733ed8ecdb297a447d439100", size = 6230748, upload-time = "2025-08-14T12:04:44.491Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f0/611dd5cddb0d277f94b7af12981f56e1441bf8d22695065d4f0df5218498/pyproj-3.7.2-cp313-cp313t-macosx_13_0_x86_64.whl", hash = "sha256:d27b48f0e81beeaa2b4d60c516c3a1cfbb0c7ff6ef71256d8e9c07792f735279", size = 6241729, upload-time = "2025-08-14T12:04:46.274Z" },
+    { url = "https://files.pythonhosted.org/packages/15/93/40bd4a6c523ff9965e480870611aed7eda5aa2c6128c6537345a2b77b542/pyproj-3.7.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:55a3610d75023c7b1c6e583e48ef8f62918e85a2ae81300569d9f104d6684bb6", size = 4652497, upload-time = "2025-08-14T12:04:48.203Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ae/7150ead53c117880b35e0d37960d3138fe640a235feb9605cb9386f50bb0/pyproj-3.7.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:8d7349182fa622696787cc9e195508d2a41a64765da9b8a6bee846702b9e6220", size = 9942610, upload-time = "2025-08-14T12:04:49.652Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/17/7a4a7eafecf2b46ab64e5c08176c20ceb5844b503eaa551bf12ccac77322/pyproj-3.7.2-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:d230b186eb876ed4f29a7c5ee310144c3a0e44e89e55f65fb3607e13f6db337c", size = 9692390, upload-time = "2025-08-14T12:04:51.731Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/55/ae18f040f6410f0ea547a21ada7ef3e26e6c82befa125b303b02759c0e9d/pyproj-3.7.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:237499c7862c578d0369e2b8ac56eec550e391a025ff70e2af8417139dabb41c", size = 11047596, upload-time = "2025-08-14T12:04:53.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2e/d3fff4d2909473f26ae799f9dda04caa322c417a51ff3b25763f7d03b233/pyproj-3.7.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8c225f5978abd506fd9a78eaaf794435e823c9156091cabaab5374efb29d7f69", size = 10896975, upload-time = "2025-08-14T12:04:55.875Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/bc/8fc7d3963d87057b7b51ebe68c1e7c51c23129eee5072ba6b86558544a46/pyproj-3.7.2-cp313-cp313t-win32.whl", hash = "sha256:2da731876d27639ff9d2d81c151f6ab90a1546455fabd93368e753047be344a2", size = 5953057, upload-time = "2025-08-14T12:04:58.466Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/27/ea9809966cc47d2d51e6d5ae631ea895f7c7c7b9b3c29718f900a8f7d197/pyproj-3.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:f54d91ae18dd23b6c0ab48126d446820e725419da10617d86a1b69ada6d881d3", size = 6375414, upload-time = "2025-08-14T12:04:59.861Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/1ef0129fba9a555c658e22af68989f35e7ba7b9136f25758809efec0cd6e/pyproj-3.7.2-cp313-cp313t-win_arm64.whl", hash = "sha256:fc52ba896cfc3214dc9f9ca3c0677a623e8fdd096b257c14a31e719d21ff3fdd", size = 6262501, upload-time = "2025-08-14T12:05:01.39Z" },
+    { url = "https://files.pythonhosted.org/packages/42/17/c2b050d3f5b71b6edd0d96ae16c990fdc42a5f1366464a5c2772146de33a/pyproj-3.7.2-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:2aaa328605ace41db050d06bac1adc11f01b71fe95c18661497763116c3a0f02", size = 6214541, upload-time = "2025-08-14T12:05:03.166Z" },
+    { url = "https://files.pythonhosted.org/packages/03/68/68ada9c8aea96ded09a66cfd9bf87aa6db8c2edebe93f5bf9b66b0143fbc/pyproj-3.7.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:35dccbce8201313c596a970fde90e33605248b66272595c061b511c8100ccc08", size = 4617456, upload-time = "2025-08-14T12:05:04.563Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e4/4c50ceca7d0e937977866b02cb64e6ccf4df979a5871e521f9e255df6073/pyproj-3.7.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:25b0b7cb0042444c29a164b993c45c1b8013d6c48baa61dc1160d834a277e83b", size = 9615590, upload-time = "2025-08-14T12:05:06.094Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1e/ada6fb15a1d75b5bd9b554355a69a798c55a7dcc93b8d41596265c1772e3/pyproj-3.7.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:85def3a6388e9ba51f964619aa002a9d2098e77c6454ff47773bb68871024281", size = 9474960, upload-time = "2025-08-14T12:05:07.973Z" },
+    { url = "https://files.pythonhosted.org/packages/51/07/9d48ad0a8db36e16f842f2c8a694c1d9d7dcf9137264846bef77585a71f3/pyproj-3.7.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b1bccefec3875ab81eabf49059e2b2ea77362c178b66fd3528c3e4df242f1516", size = 10799478, upload-time = "2025-08-14T12:05:14.102Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cf/2f812b529079f72f51ff2d6456b7fef06c01735e5cfd62d54ffb2b548028/pyproj-3.7.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d5371ca114d6990b675247355a801925814eca53e6c4b2f1b5c0a956336ee36e", size = 10710030, upload-time = "2025-08-14T12:05:16.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9b/4626a19e1f03eba4c0e77b91a6cf0f73aa9cb5d51a22ee385c22812bcc2c/pyproj-3.7.2-cp314-cp314-win32.whl", hash = "sha256:77f066626030f41be543274f5ac79f2a511fe89860ecd0914f22131b40a0ec25", size = 5991181, upload-time = "2025-08-14T12:05:19.492Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b2/5a6610554306a83a563080c2cf2c57565563eadd280e15388efa00fb5b33/pyproj-3.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:5a964da1696b8522806f4276ab04ccfff8f9eb95133a92a25900697609d40112", size = 6434721, upload-time = "2025-08-14T12:05:21.022Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ce/6c910ea2e1c74ef673c5d48c482564b8a7824a44c4e35cca2e765b68cfcc/pyproj-3.7.2-cp314-cp314-win_arm64.whl", hash = "sha256:e258ab4dbd3cf627809067c0ba8f9884ea76c8e5999d039fb37a1619c6c3e1f6", size = 6363821, upload-time = "2025-08-14T12:05:22.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e4/5532f6f7491812ba782a2177fe9de73fd8e2912b59f46a1d056b84b9b8f2/pyproj-3.7.2-cp314-cp314t-macosx_13_0_x86_64.whl", hash = "sha256:bbbac2f930c6d266f70ec75df35ef851d96fdb3701c674f42fd23a9314573b37", size = 6241773, upload-time = "2025-08-14T12:05:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/0938c3f2bbbef1789132d1726d9b0e662f10cfc22522743937f421ad664e/pyproj-3.7.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b7544e0a3d6339dc9151e9c8f3ea62a936ab7cc446a806ec448bbe86aebb979b", size = 4652537, upload-time = "2025-08-14T12:05:26.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a8/488b1ed47d25972f33874f91f09ca8f2227902f05f63a2b80dc73e7b1c97/pyproj-3.7.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f7f5133dca4c703e8acadf6f30bc567d39a42c6af321e7f81975c2518f3ed357", size = 9940864, upload-time = "2025-08-14T12:05:27.985Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/cc/7f4c895d0cb98e47b6a85a6d79eaca03eb266129eed2f845125c09cf31ff/pyproj-3.7.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:5aff3343038d7426aa5076f07feb88065f50e0502d1b0d7c22ddfdd2c75a3f81", size = 9688868, upload-time = "2025-08-14T12:05:30.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b7/c7e306b8bb0f071d9825b753ee4920f066c40fbfcce9372c4f3cfb2fc4ed/pyproj-3.7.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b0552178c61f2ac1c820d087e8ba6e62b29442debddbb09d51c4bf8acc84d888", size = 11045910, upload-time = "2025-08-14T12:05:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fb/538a4d2df695980e2dde5c04d965fbdd1fe8c20a3194dc4aaa3952a4d1be/pyproj-3.7.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:47d87db2d2c436c5fd0409b34d70bb6cdb875cca2ebe7a9d1c442367b0ab8d59", size = 10895724, upload-time = "2025-08-14T12:05:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/a3f0618b03957de9db5489a04558a8826f43906628bb0b766033aa3b5548/pyproj-3.7.2-cp314-cp314t-win32.whl", hash = "sha256:c9b6f1d8ad3e80a0ee0903a778b6ece7dca1d1d40f6d114ae01bc8ddbad971aa", size = 6056848, upload-time = "2025-08-14T12:05:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/56/413240dd5149dd3291eda55aa55a659da4431244a2fd1319d0ae89407cfb/pyproj-3.7.2-cp314-cp314t-win_amd64.whl", hash = "sha256:1914e29e27933ba6f9822663ee0600f169014a2859f851c054c88cf5ea8a333c", size = 6517676, upload-time = "2025-08-14T12:05:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/15/73/a7141a1a0559bf1a7aa42a11c879ceb19f02f5c6c371c6d57fd86cefd4d1/pyproj-3.7.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d9d25bae416a24397e0d85739f84d323b55f6511e45a522dd7d7eae70d10c7e4", size = 6391844, upload-time = "2025-08-14T12:05:40.745Z" },
 ]
 
 [[package]]
@@ -1924,6 +2040,57 @@ wheels = [
 ]
 
 [[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/c0/f3b6453cf2dfa99adc0ba6675f9aaff9e526d2224cbd7ff9c1a879238693/shapely-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe2533caae6a91a543dec62e8360fe86ffcdc42a7c55f9dfd0128a977a896b94", size = 1833550, upload-time = "2025-09-24T13:50:30.019Z" },
+    { url = "https://files.pythonhosted.org/packages/86/07/59dee0bc4b913b7ab59ab1086225baca5b8f19865e6101db9ebb7243e132/shapely-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba4d1333cc0bc94381d6d4308d2e4e008e0bd128bdcff5573199742ee3634359", size = 1643556, upload-time = "2025-09-24T13:50:32.291Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/a5397e75b435b9895cd53e165083faed5d12fd9626eadec15a83a2411f0f/shapely-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bd308103340030feef6c111d3eb98d50dc13feea33affc8a6f9fa549e9458a3", size = 2988308, upload-time = "2025-09-24T13:50:33.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e7d4d7ad262a48bb44277ca12c7c78cb1b0f56b32c10734ec9a1d30c0b0c54b", size = 3099844, upload-time = "2025-09-24T13:50:35.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f3/9876b64d4a5a321b9dc482c92bb6f061f2fa42131cba643c699f39317cb9/shapely-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e9eddfe513096a71896441a7c37db72da0687b34752c4e193577a145c71736fc", size = 3988842, upload-time = "2025-09-24T13:50:37.478Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/704c7292f7014c7e74ec84eddb7b109e1fbae74a16deae9c1504b1d15565/shapely-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:980c777c612514c0cf99bc8a9de6d286f5e186dcaf9091252fcd444e5638193d", size = 4152714, upload-time = "2025-09-24T13:50:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/319c9dc788884ad0785242543cdffac0e6530e4d0deb6c4862bc4143dcf3/shapely-2.1.2-cp312-cp312-win32.whl", hash = "sha256:9111274b88e4d7b54a95218e243282709b330ef52b7b86bc6aaf4f805306f454", size = 1542745, upload-time = "2025-09-24T13:50:41.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bf/cb6c1c505cb31e818e900b9312d514f381fbfa5c4363edfce0fcc4f8c1a4/shapely-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:743044b4cfb34f9a67205cee9279feaf60ba7d02e69febc2afc609047cb49179", size = 1722861, upload-time = "2025-09-24T13:50:43.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/90/98ef257c23c46425dc4d1d31005ad7c8d649fe423a38b917db02c30f1f5a/shapely-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b510dda1a3672d6879beb319bc7c5fd302c6c354584690973c838f46ec3e0fa8", size = 1832644, upload-time = "2025-09-24T13:50:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/0bee5a830d209adcd3a01f2d4b70e587cdd9fd7380d5198c064091005af8/shapely-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8cff473e81017594d20ec55d86b54bc635544897e13a7cfc12e36909c5309a2a", size = 1642887, upload-time = "2025-09-24T13:50:46.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5e/7d7f54ba960c13302584c73704d8c4d15404a51024631adb60b126a4ae88/shapely-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe7b77dc63d707c09726b7908f575fc04ff1d1ad0f3fb92aec212396bc6cfe5e", size = 2970931, upload-time = "2025-09-24T13:50:48.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ed1a5bbfb386ee8332713bf7508bc24e32d24b74fc9a7b9f8529a55db9f4ee6", size = 3082855, upload-time = "2025-09-24T13:50:50.037Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2b/578faf235a5b09f16b5f02833c53822294d7f21b242f8e2d0cf03fb64321/shapely-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a84e0582858d841d54355246ddfcbd1fce3179f185da7470f41ce39d001ee1af", size = 3979960, upload-time = "2025-09-24T13:50:51.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/04/167f096386120f692cc4ca02f75a17b961858997a95e67a3cb6a7bbd6b53/shapely-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc3487447a43d42adcdf52d7ac73804f2312cbfa5d433a7d2c506dcab0033dfd", size = 4142851, upload-time = "2025-09-24T13:50:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/48/74/fb402c5a6235d1c65a97348b48cdedb75fb19eca2b1d66d04969fc1c6091/shapely-2.1.2-cp313-cp313-win32.whl", hash = "sha256:9c3a3c648aedc9f99c09263b39f2d8252f199cb3ac154fadc173283d7d111350", size = 1541890, upload-time = "2025-09-24T13:50:55.337Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/3647fe7ad990af60ad98b889657a976042c9988c2807cf322a9d6685f462/shapely-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:ca2591bff6645c216695bdf1614fca9c82ea1144d4a7591a466fef64f28f0715", size = 1722151, upload-time = "2025-09-24T13:50:57.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/49/63953754faa51ffe7d8189bfbe9ca34def29f8c0e34c67cbe2a2795f269d/shapely-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2d93d23bdd2ed9dc157b46bc2f19b7da143ca8714464249bef6771c679d5ff40", size = 1834130, upload-time = "2025-09-24T13:50:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/dce001c1984052970ff60eb4727164892fb2d08052c575042a47f5a9e88f/shapely-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b", size = 1642802, upload-time = "2025-09-24T13:50:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e7/fc4e9a19929522877fa602f705706b96e78376afb7fad09cad5b9af1553c/shapely-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d8382dd120d64b03698b7298b89611a6ea6f55ada9d39942838b79c9bc89801", size = 3018460, upload-time = "2025-09-24T13:51:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/18/7519a25db21847b525696883ddc8e6a0ecaa36159ea88e0fef11466384d0/shapely-2.1.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19efa3611eef966e776183e338b2d7ea43569ae99ab34f8d17c2c054d3205cc0", size = 3095223, upload-time = "2025-09-24T13:51:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/48/de/b59a620b1f3a129c3fecc2737104a0a7e04e79335bd3b0a1f1609744cf17/shapely-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:346ec0c1a0fcd32f57f00e4134d1200e14bf3f5ae12af87ba83ca275c502498c", size = 4030760, upload-time = "2025-09-24T13:51:06.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c4/3ce4c2d9b6aabd27d26ec988f08cb877ba9e6e96086eff81bfea93e688c7/shapely-2.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9a522f460d28e2bf4e12396240a5fc1518788b2fcd73535166d748399ef0c223", size = 1831290, upload-time = "2025-09-24T13:51:13.56Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ff629e00818033b8d71139565527ced7d776c269a49bd78c9df84e8f852190c", size = 1641463, upload-time = "2025-09-24T13:51:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/57/91d59ae525ca641e7ac5551c04c9503aee6f29b92b392f31790fcb1a4358/shapely-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f67b34271dedc3c653eba4e3d7111aa421d5be9b4c4c7d38d30907f796cb30df", size = 2970145, upload-time = "2025-09-24T13:51:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/4948be52ee1da6927831ab59e10d4c29baa2a714f599f1f0d1bc747f5777/shapely-2.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21952dc00df38a2c28375659b07a3979d22641aeb104751e769c3ee825aadecf", size = 3073806, upload-time = "2025-09-24T13:51:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/03/83/f768a54af775eb41ef2e7bec8a0a0dbe7d2431c3e78c0a8bdba7ab17e446/shapely-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f2f33f486777456586948e333a56ae21f35ae273be99255a191f5c1fa302eb4", size = 3980803, upload-time = "2025-09-24T13:51:20.37Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/559c7c195807c91c79d38a1f6901384a2878a76fbdf3f1048893a9b7534d/shapely-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cf831a13e0d5a7eb519e96f58ec26e049b1fad411fc6fc23b162a7ce04d9cffc", size = 4133301, upload-time = "2025-09-24T13:51:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cd/60d5ae203241c53ef3abd2ef27c6800e21afd6c94e39db5315ea0cbafb4a/shapely-2.1.2-cp314-cp314-win32.whl", hash = "sha256:61edcd8d0d17dd99075d320a1dd39c0cb9616f7572f10ef91b4b5b00c4aeb566", size = 1583247, upload-time = "2025-09-24T13:51:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/135684f342e909330e50d31d441ace06bf83c7dc0777e11043f99167b123/shapely-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:a444e7afccdb0999e203b976adb37ea633725333e5b119ad40b1ca291ecf311c", size = 1773019, upload-time = "2025-09-24T13:51:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/05/a44f3f9f695fa3ada22786dc9da33c933da1cbc4bfe876fe3a100bafe263/shapely-2.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5ebe3f84c6112ad3d4632b1fd2290665aa75d4cef5f6c5d77c4c95b324527c6a", size = 1834137, upload-time = "2025-09-24T13:51:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/4d57db45bf314573427b0a70dfca15d912d108e6023f623947fa69f39b72/shapely-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5860eb9f00a1d49ebb14e881f5caf6c2cf472c7fd38bd7f253bbd34f934eb076", size = 1642884, upload-time = "2025-09-24T13:51:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/4e29c0a55d6d14ad7422bf86995d7ff3f54af0eba59617eb95caf84b9680/shapely-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b705c99c76695702656327b819c9660768ec33f5ce01fa32b2af62b56ba400a1", size = 3018320, upload-time = "2025-09-24T13:51:29.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/bb/992e6a3c463f4d29d4cd6ab8963b75b1b1040199edbd72beada4af46bde5/shapely-2.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a1fd0ea855b2cf7c9cddaf25543e914dd75af9de08785f20ca3085f2c9ca60b0", size = 3094931, upload-time = "2025-09-24T13:51:32.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/82e65e21070e473f0ed6451224ed9fa0be85033d17e0c6e7213a12f59d12/shapely-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:df90e2db118c3671a0754f38e36802db75fe0920d211a27481daf50a711fdf26", size = 4030406, upload-time = "2025-09-24T13:51:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511, upload-time = "2025-09-24T13:51:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607, upload-time = "2025-09-24T13:51:37.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682, upload-time = "2025-09-24T13:51:39.233Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1983,6 +2150,12 @@ dependencies = [
 gcs = [
     { name = "google-cloud-storage" },
 ]
+geo = [
+    { name = "geopandas" },
+    { name = "pyogrio" },
+    { name = "shapely" },
+    { name = "topojson" },
+]
 hdf5 = [
     { name = "h5py" },
 ]
@@ -2015,6 +2188,7 @@ docs = [
 requires-dist = [
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28" },
     { name = "frictionless", specifier = ">=5.18.1" },
+    { name = "geopandas", marker = "extra == 'geo'", specifier = ">=1.0" },
     { name = "google-auth", specifier = ">=2.43.0" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.0" },
     { name = "h5py", marker = "extra == 'hdf5'", specifier = ">=3.10" },
@@ -2023,13 +2197,16 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pint", specifier = ">=0.24" },
     { name = "pyarrow", specifier = ">=23.0.1" },
+    { name = "pyogrio", marker = "extra == 'geo'", specifier = ">=0.8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
+    { name = "shapely", marker = "extra == 'geo'", specifier = ">=2.0" },
     { name = "tomlkit", specifier = ">=0.12.0" },
+    { name = "topojson", marker = "extra == 'geo'", specifier = ">=1.9" },
     { name = "typer", specifier = ">=0.15" },
     { name = "zarr", marker = "extra == 'zarr'", specifier = ">=2.18" },
 ]
-provides-extras = ["gcs", "s3", "qudt", "zarr", "hdf5"]
+provides-extras = ["gcs", "s3", "qudt", "zarr", "hdf5", "geo"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2071,6 +2248,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
+name = "topojson"
+version = "1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "shapely" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/f3/74330050d8f7e05e140e6043302f71524e159f9a83bbee9681c86282f8fd/topojson-1.10.tar.gz", hash = "sha256:a7f53406324061a0310bec46740a6609147c24daeb354596c68345b9527b38c1", size = 25444042, upload-time = "2025-07-22T20:27:31.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/7a/2a8ea3b2b6e50cbec74c53082b69617d71f31e1247e35e65bf9a6edc44cf/topojson-1.10-py3-none-any.whl", hash = "sha256:0879d727c7798939e3268e8969fa87c2cd23274189fe3d8038a0fb11ff263925", size = 83318, upload-time = "2025-07-22T20:27:28.374Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds GeoJSON/TopoJSON vector support to sunstone-py, delivered in two phases. Geospatial dependencies live behind an optional `[geo]` extra — **core never imports geopandas** (verified: `import sunstone.*` core loads no geo libraries; they import lazily inside handler method bodies, guarded in `plugins.py`).

### Phase 1 — Field-type registry + format-driven resolution (no geo dependency)
- `format` field on `DatasetMetadata`, parsed from `datasets.yaml`.
- `FieldTypeRegistry` / `FieldTypeDescriptor` with built-in Frictionless scalar types pre-registered; `PluginRegistry` discovers a plugin's `field_types()` at registration.
- `read_dataset` honors a pinned `format`, overriding extension detection — so a `.json` pinned as `geojson` resolves to the geo handler instead of being silently mis-parsed as tabular JSON.

### Phase 2 — the `[geo]` plugin (GeoJSON/TopoJSON)
- New `AssetKind.GEOFEATURES` (payload = `geopandas.GeoDataFrame`) + `as_geofeatures()` accessor.
- `GeoFeaturesFormatHandler` (`handlers_geo.py`): GeoJSON + TopoJSON read/write with lazy geopandas/shapely/topojson imports.
  - GeoJSON read defaults CRS to EPSG:4326 (RFC 7946); extracts a top-level `"sunstone"` JSON-LD member into `Metadata`.
  - GeoJSON write emits RFC 7946-conformant output (no `crs` member, right-hand-rule ring winding) and embeds metadata under `"sunstone"`; warns on non-WGS84 geometry.
  - Hand-rolled TopoJSON decoder (delta-decode + scale/translate, arc stitching, negative-index reversal) — no decode-only dependency. TopoJSON encode via `topojson.Topology`.
- Registers a `geometry` field type; the handler is registered only when the `[geo]` extra is importable.
- `sunstone.geopandas` facade + `GeoDataFrame` wrapper mirroring `sunstone.pandas`: `read_geojson`/`read_topojson`/`read_file`, `to_geojson`/`to_topojson`.

## Testing
- Full suite: **1425 passed, 12 skipped** (with the `[geo]` extra installed).
- Core-import isolation verified: importing core modules pulls in no geopandas.
- New tests cover the field-type registry, plugin discovery, pinned-format resolution, GeoJSON/TopoJSON read+write round-trips, conditional registration, the facade, and the missing-extra error message.

## Follow-ups (deferred per the implementation plans)
- Geo outputs (`to_geojson`/`to_topojson`) write the file but do not yet register into `datasets.yaml` the way `DataFrame.to_csv` does — lineage parity with the pandas facade is a follow-up.
- Multi-geometry-column selection and a `GEOFEATURES` derive/CRS-invalidation policy.

## Docs
Spec (`docs/superpowers/specs/2026-06-16-…`), the two phase implementation plans, and GeoJSON/TopoJSON format references are included.
