### PR TITLE
perf: add opt-in process-level DatasetsManager cache

### DIFF
--- a/src/sunstone/__init__.py
+++ b/src/sunstone/__init__.py
@@ -178,6 +178,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     # DataFrame and datasets manager
     "DataFrame": ("sunstone.dataframe", "DataFrame"),
     "DatasetsManager": ("sunstone.datasets", "DatasetsManager"),
+    "datasets_manager_cache": ("sunstone.datasets", "datasets_manager_cache"),
+    "clear_datasets_manager_cache": ("sunstone.datasets", "clear_datasets_manager_cache"),
+    "get_datasets_manager": ("sunstone.datasets", "get_datasets_manager"),
     # Errors (sunstone-specific)
     "IncompatibleAssetKindError": ("sunstone.errors", "IncompatibleAssetKindError"),
     # Exceptions
@@ -260,7 +263,12 @@ if TYPE_CHECKING:
     )
     from .context import ExecutionContext, detect_execution_context  # noqa: F401
     from .dataframe import DataFrame  # noqa: F401
-    from .datasets import DatasetsManager  # noqa: F401
+    from .datasets import (  # noqa: F401
+        DatasetsManager,
+        clear_datasets_manager_cache,
+        datasets_manager_cache,
+        get_datasets_manager,
+    )
     from .env import (  # noqa: F401
         DataEnvironment,
         Environment,
@@ -344,6 +352,9 @@ __all__ = [
     # Main classes
     "DataFrame",
     "DatasetsManager",
+    "datasets_manager_cache",
+    "clear_datasets_manager_cache",
+    "get_datasets_manager",
     # Top-level I/O
     "read",
     "write",

--- a/src/sunstone/dataframe.py
+++ b/src/sunstone/dataframe.py
@@ -274,7 +274,9 @@ class DataFrame:
         """Get a DatasetsManager for the current project."""
         if self.metadata.lineage.project_path is None:
             raise ValueError("Project path not set")
-        return DatasetsManager(
+        from .datasets import get_datasets_manager
+
+        return get_datasets_manager(
             self.metadata.lineage.project_path,
             datasets_file=self._datasets_file,
         )

--- a/src/sunstone/datasets.py
+++ b/src/sunstone/datasets.py
@@ -2,10 +2,12 @@
 Parser and manager for datasets.yaml files.
 """
 
+import contextlib
+import contextvars
 import logging
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 from ruamel.yaml import YAML
 
@@ -38,6 +40,98 @@ _yaml.preserve_quotes = True
 _yaml.default_flow_style = False
 _yaml.width = 4096
 _yaml.indent(mapping=2, sequence=4, offset=2)
+
+
+def _mtime_ns(path: Path) -> Optional[int]:
+    """Return the ``st_mtime_ns`` of ``path``, or ``None`` if it doesn't exist."""
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def _resolve_datasets_file(
+    project_path: Union[str, Path],
+    datasets_file: Optional[Union[str, Path]] = None,
+) -> Path:
+    """Resolve the absolute datasets file path the same way ``DatasetsManager``
+    does, for use as a cache key. Mirrors ``DatasetsManager.__init__``."""
+    base = Path(project_path).resolve()
+    if datasets_file is not None:
+        df_path = Path(datasets_file)
+        resolved = df_path if df_path.is_absolute() else base / df_path
+    else:
+        resolved = base / "datasets.yaml"
+    return resolved.resolve()
+
+
+# --- Opt-in process-level manager cache -------------------------------------
+# When a cache context is active this holds a dict mapping resolved datasets-file
+# path (str) -> shared DatasetsManager. It is ``None`` when no context is active,
+# in which case acquisition always constructs a fresh manager (legacy behavior).
+_manager_cache: "contextvars.ContextVar[Optional[Dict[str, DatasetsManager]]]" = contextvars.ContextVar(
+    "sunstone_datasets_manager_cache", default=None
+)
+
+
+@contextlib.contextmanager
+def datasets_manager_cache() -> Iterator[None]:
+    """Activate a process-level ``DatasetsManager`` cache for the duration of the
+    ``with`` block.
+
+    While active, :func:`get_datasets_manager` reuses a single manager instance
+    per resolved ``datasets_file`` path instead of reloading from disk on every
+    acquisition. This is an opt-in optimization: outside this context behavior is
+    unchanged (every acquisition constructs a fresh manager).
+
+    Nesting is safe: an inner context shares the outer cache, and the cache is
+    only cleared when the outermost context exits.
+    """
+    previous = _manager_cache.get()
+    cache: Dict[str, DatasetsManager] = previous if previous is not None else {}
+    token = _manager_cache.set(cache)
+    try:
+        yield
+    finally:
+        _manager_cache.reset(token)
+        if previous is None:
+            cache.clear()
+
+
+def clear_datasets_manager_cache() -> None:
+    """Drop all cached managers in the currently active cache (if any).
+
+    Primarily for test isolation; a no-op when no cache context is active.
+    """
+    cache = _manager_cache.get()
+    if cache is not None:
+        cache.clear()
+
+
+def get_datasets_manager(
+    project_path: Union[str, Path],
+    datasets_file: Optional[Union[str, Path]] = None,
+) -> "DatasetsManager":
+    """Acquire a ``DatasetsManager``, reusing a cached instance when a
+    :func:`datasets_manager_cache` context is active and the cached instance is
+    still valid (the on-disk files match the mtimes recorded at its last
+    load/save).
+
+    Without an active cache context this is equivalent to constructing a fresh
+    ``DatasetsManager(project_path, datasets_file)``.
+    """
+    cache = _manager_cache.get()
+    if cache is None:
+        return DatasetsManager(project_path, datasets_file)
+
+    key = str(_resolve_datasets_file(project_path, datasets_file))
+    cached = cache.get(key)
+    if cached is not None and not cached._is_stale():
+        return cached
+
+    manager = DatasetsManager(project_path, datasets_file)
+    cache[key] = manager
+    return manager
 
 
 def _parse_dialect(data: Any) -> Optional[CsvDialect]:
@@ -133,6 +227,9 @@ class DatasetsManager:
         self._data: Dict[str, Any] = {}
         self._defaults: Dict[str, Any] = {}
         self._lock_data: Dict[str, Any] = {}
+        # mtime stamps used by the opt-in manager cache to detect external edits.
+        self._datasets_mtime_ns: Optional[int] = None
+        self._lock_mtime_ns: Optional[int] = None
         self._load(check_version=True)
 
     @staticmethod
@@ -285,15 +382,35 @@ class DatasetsManager:
                     )
                     break
 
+        # Record the mtimes that correspond to the state we just loaded.
+        self._stamp_mtimes()
+
     @property
     def lock_data(self) -> Dict[str, Any]:
         """Return the lock file data."""
         return self._lock_data
 
+    def _stamp_mtimes(self) -> None:
+        """Record the current on-disk mtimes of the datasets and lock files.
+
+        Used by the opt-in manager cache to tell whether a cached instance's
+        files were changed by something other than the instance itself.
+        """
+        self._datasets_mtime_ns = _mtime_ns(self.datasets_file)
+        self._lock_mtime_ns = _mtime_ns(self.lock_file)
+
+    def _is_stale(self) -> bool:
+        """Return True if the datasets or lock file on disk differs from the
+        mtime recorded at the last load/save (i.e. an external writer touched it)."""
+        return (
+            _mtime_ns(self.datasets_file) != self._datasets_mtime_ns or _mtime_ns(self.lock_file) != self._lock_mtime_ns
+        )
+
     def _save(self) -> None:
         """Save the current data back to datasets.yaml."""
         with open(self.datasets_file, "w") as f:
             _yaml.dump(self._data, f)
+        self._stamp_mtimes()
 
     def _save_lock(self) -> None:
         """Save the current lock data to datasets.lock.yaml."""
@@ -305,6 +422,7 @@ class DatasetsManager:
         with open(self.lock_file, "w") as f:
             f.write("# Auto-generated by sunstone. Do not edit manually.\n")
             _yaml.dump(self._lock_data, f)
+        self._stamp_mtimes()
 
     def _parse_source_location(self, loc_data: Dict[str, Any]) -> SourceLocation:
         """Parse source location data from YAML."""

--- a/tests/test_datasets_cache.py
+++ b/tests/test_datasets_cache.py
@@ -1,0 +1,164 @@
+"""Tests for the opt-in process-level DatasetsManager cache.
+
+These cover the cache-aware acquisition path (`get_datasets_manager`) and the
+`datasets_manager_cache()` context manager. The most important guarantee is the
+*default-unchanged* behavior: without an active cache context, every
+acquisition constructs a fresh manager and loads from disk, exactly as before.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+import sunstone
+from sunstone.datasets import (
+    DatasetsManager,
+    clear_datasets_manager_cache,
+    get_datasets_manager,
+)
+from sunstone.lineage import FieldSchema
+
+
+def _write_datasets(path: Path, outputs: list[tuple[str, str, str]]) -> None:
+    """Write a minimal datasets.yaml with the given (name, slug, location) outputs."""
+    lines = ["outputs:\n"]
+    for name, slug, location in outputs:
+        lines.append(f"  - name: {name}\n")
+        lines.append(f"    slug: {slug}\n")
+        lines.append(f"    location: {location}\n")
+        lines.append("    fields:\n")
+        lines.append("      - name: col\n")
+        lines.append("        type: string\n")
+    path.write_text("".join(lines))
+
+
+@pytest.fixture
+def mini_project(tmp_path: Path) -> Path:
+    """A minimal temp project with a single-output datasets.yaml."""
+    (tmp_path / "out.csv").write_text("col\nval\n")
+    _write_datasets(tmp_path / "datasets.yaml", [("Out A", "out-a", "out.csv")])
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache() -> "object":
+    """Ensure no cache state leaks between tests."""
+    clear_datasets_manager_cache()
+    yield
+    clear_datasets_manager_cache()
+
+
+def _spy_load(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch DatasetsManager._load with a counting wrapper. Returns a counter dict."""
+    counter = {"n": 0}
+    original = DatasetsManager._load
+
+    def counting_load(self: DatasetsManager, check_version: bool = False) -> None:
+        counter["n"] += 1
+        original(self, check_version=check_version)
+
+    monkeypatch.setattr(DatasetsManager, "_load", counting_load)
+    return counter
+
+
+def test_default_no_cache_distinct_instances(mini_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without an active context, two acquisitions return distinct instances and each loads from disk."""
+    counter = _spy_load(monkeypatch)
+
+    m1 = get_datasets_manager(mini_project)
+    m2 = get_datasets_manager(mini_project)
+
+    assert m1 is not m2
+    assert counter["n"] == 2  # one _load per construction
+
+
+def test_cache_hit_same_instance(mini_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inside the context, two acquisitions for the same path return the same instance and load once."""
+    counter = _spy_load(monkeypatch)
+
+    with sunstone.datasets_manager_cache():
+        m1 = get_datasets_manager(mini_project)
+        m2 = get_datasets_manager(mini_project)
+
+    assert m1 is m2
+    assert counter["n"] == 1
+
+
+def test_writes_via_cached_manager_visible(mini_project: Path) -> None:
+    """A write through the cached manager is reflected on re-acquisition (no stale reload)."""
+    with sunstone.datasets_manager_cache():
+        m1 = get_datasets_manager(mini_project)
+        m1.add_output_dataset(
+            name="Out B",
+            slug="out-b",
+            location="b.csv",
+            fields=[FieldSchema(name="col", type="string")],
+        )
+        m2 = get_datasets_manager(mini_project)
+
+        assert m2 is m1  # the writer's own save must not invalidate its cache entry
+        assert m2.find_dataset_by_slug("out-b", "output") is not None
+
+
+def test_external_mtime_change_invalidates(mini_project: Path) -> None:
+    """An external modification to datasets.yaml triggers a fresh load on next acquisition."""
+    with sunstone.datasets_manager_cache():
+        m1 = get_datasets_manager(mini_project)
+        assert m1.find_dataset_by_slug("out-b", "output") is None
+
+        # Simulate an external writer: change content AND force a distinct mtime.
+        ds_file = mini_project / "datasets.yaml"
+        _write_datasets(
+            ds_file,
+            [("Out A", "out-a", "out.csv"), ("Out B", "out-b", "b.csv")],
+        )
+        st = ds_file.stat()
+        os.utime(ds_file, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+
+        m2 = get_datasets_manager(mini_project)
+
+        assert m2 is not m1
+        assert m2.find_dataset_by_slug("out-b", "output") is not None
+
+
+def test_context_exit_clears_cache(mini_project: Path) -> None:
+    """After the context exits, a new acquisition constructs a fresh instance."""
+    with sunstone.datasets_manager_cache():
+        m1 = get_datasets_manager(mini_project)
+
+    m2 = get_datasets_manager(mini_project)
+    assert m2 is not m1
+
+
+def test_distinct_paths_independent(mini_project: Path) -> None:
+    """Two different datasets_file paths get separate cached instances."""
+    _write_datasets(mini_project / "other.yaml", [("Other", "other-out", "out.csv")])
+
+    with sunstone.datasets_manager_cache():
+        m_main = get_datasets_manager(mini_project)
+        m_other = get_datasets_manager(mini_project, datasets_file="other.yaml")
+
+        assert m_main is not m_other
+        assert get_datasets_manager(mini_project) is m_main
+        assert get_datasets_manager(mini_project, datasets_file="other.yaml") is m_other
+
+
+def test_nested_context_safe(mini_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nested contexts share a cache; the cache survives until the outermost exit."""
+    counter = _spy_load(monkeypatch)
+
+    with sunstone.datasets_manager_cache():
+        m1 = get_datasets_manager(mini_project)
+        with sunstone.datasets_manager_cache():
+            m2 = get_datasets_manager(mini_project)
+            assert m2 is m1
+        # Still inside the outer context: cache must remain active.
+        m3 = get_datasets_manager(mini_project)
+        assert m3 is m1
+
+    assert counter["n"] == 1
+
+    # Outermost exit cleared the cache: fresh construction now.
+    m4 = get_datasets_manager(mini_project)
+    assert m4 is not m1


### PR DESCRIPTION
## Motivation

When a consumer writes many datasets in a loop (e.g. a normalize pipeline calling `df.to_parquet()` once per output), every write reconstructs a `DatasetsManager`, which re-parses `datasets.yaml` + all `include:` files + `datasets.lock.yaml` through ruamel.yaml round-trip mode. On a real project that is **~734 ms per construction**; across ~114 writes it's ~84 s of pure redundant re-parsing of content that barely changes between calls — the manager that performed the previous write already holds current state in memory.

## What this adds

An **opt-in**, process-level cache so repeated `DatasetsManager` acquisition for the same datasets file reuses one in-memory instance instead of reloading from disk.

Public API (exported from top-level `sunstone` and `sunstone.datasets`):

- `datasets_manager_cache()` — context manager that activates the cache for the duration of the `with` block. Backed by a `contextvars.ContextVar` keyed by resolved absolute datasets-file path. Nesting-safe; cache cleared on outermost exit.
- `get_datasets_manager(project_path, datasets_file=None)` — cache-aware acquisition. No active context -> fresh manager (legacy behavior). Active context -> shared instance for the resolved path when present and not stale.
- `clear_datasets_manager_cache()` — drops cached state (test isolation).

`DataFrame._get_datasets_manager()` now routes through `get_datasets_manager`, so `to_parquet`/`to_csv`/etc. benefit when a cache context is active.

## Safety

- **Default path is byte-for-byte unchanged.** With no active context (all existing code and tests), every acquisition constructs a fresh, disk-loaded manager exactly as before. The cache is purely an opt-in optimization.
- **mtime-based staleness invalidation.** The manager stamps `st_mtime_ns` of the datasets and lock files at load and after each `_save`/`_save_lock`. A cached instance is discarded if the on-disk mtime differs from its stamp — so an external edit forces a fresh load, while the writing manager (which re-stamps its own saves) is never spuriously invalidated.

## Tests

- New `tests/test_datasets_cache.py` (7 tests): default-unchanged (distinct instances, load-per-construction), cache hit (same instance, one load), writes visible without stale read, external-mtime invalidation, context-exit clears, distinct paths independent, nested-context safety.
- Full suite: 1423 passed, 15 skipped (unchanged from baseline). ruff + mypy clean.

## Notes

- Cache key is the resolved datasets-file path; two managers for files sharing a directory share one `datasets.lock.yaml` (pre-existing design tension, surfaced not introduced — relevant only with concurrent external editors, which the single-process use case excludes).
- Saves are still per-call; batching them is possible future work but deliberately out of scope here to keep durability semantics unchanged.